### PR TITLE
Renamed the package that contains the test harness requesttesting

### DIFF
--- a/testing/requesttesting/test_harness.go
+++ b/testing/requesttesting/test_harness.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package requesttesting
 
 import (
 	"context"


### PR DESCRIPTION
The change was done to simplify importing the package when writing tests as otherwise it would have coincided with the `testing` package in the standard library.