### PR TITLE
First draft of the core of safehttp.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/google/go-safeweb
 
 go 1.14
 
-require github.com/google/go-cmp v0.5.0
+require (
+	github.com/google/go-cmp v0.5.0
+	github.com/google/safehtml v0.0.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,8 @@
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/safehtml v0.0.2 h1:ZOt2VXg4x24bW0m2jtzAOkhoXV0iM8vNKc0paByCZqM=
+github.com/google/safehtml v0.0.2/go.mod h1:L4KWwDsUJdECRAEpZoBn3O64bQaywRscowZjJAzjHnU=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/safehttp/handler.go
+++ b/safehttp/handler.go
@@ -1,0 +1,4 @@
+package safehttp
+
+// HandleFunc TODO
+type HandleFunc func(*ResponseWriter, IncomingRequest) Result

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -1,0 +1,4 @@
+package safehttp
+
+// IncomingRequest TODO
+type IncomingRequest interface{}

--- a/safehttp/prototype.go
+++ b/safehttp/prototype.go
@@ -1,0 +1,18 @@
+package safehttp
+
+// Machinery TODO
+type Machinery struct {
+	h HandleFunc
+	d Dispatcher
+}
+
+// NewMachinery TODO
+func NewMachinery(h HandleFunc, d Dispatcher) *Machinery {
+	return &Machinery{h: h, d: d}
+}
+
+// HandleRequest TODO
+func (m *Machinery) HandleRequest(r string) {
+	rw := &ResponseWriter{d: m.d}
+	m.h(rw, nil)
+}

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -1,0 +1,11 @@
+package safehttp
+
+import "io"
+
+// Response TODO
+type Response interface{}
+
+// Template TODO
+type Template interface {
+	Execute(wr io.Writer, data interface{}) error
+}

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -1,0 +1,38 @@
+package safehttp
+
+// ResponseWriter TODO
+type ResponseWriter struct {
+	d Dispatcher
+}
+
+// Result TODO
+type Result struct{}
+
+// Write TODO
+func (w *ResponseWriter) Write(resp Response) Result {
+	err := w.d.Write(resp)
+	if err != nil {
+		panic("error")
+	}
+	return Result{}
+}
+
+// WriteTemplate TODO
+func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
+	err := w.d.ExecuteTemplate(t, data)
+	if err != nil {
+		panic("error")
+	}
+	return Result{}
+}
+
+// ServerError TODO
+func (w *ResponseWriter) ServerError(code StatusCode, resp Response) Result {
+	return Result{}
+}
+
+// Dispatcher TODO
+type Dispatcher interface {
+	Write(resp Response) error
+	ExecuteTemplate(t Template, data interface{}) error
+}

--- a/safehttp/status.go
+++ b/safehttp/status.go
@@ -1,0 +1,11 @@
+package safehttp
+
+// StatusCode TODO
+type StatusCode int
+
+const (
+	// Status200OK TODO
+	Status200OK StatusCode = 200
+	// Status500InternalServerError TODO
+	Status500InternalServerError = 500
+)

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -22,7 +22,6 @@ func (d *dispatcher) Write(resp safehttp.Response) error {
 	default:
 		panic("not a safe response type")
 	}
-	return nil
 }
 
 func (d *dispatcher) ExecuteTemplate(t safehttp.Template, data interface{}) error {
@@ -32,7 +31,6 @@ func (d *dispatcher) ExecuteTemplate(t safehttp.Template, data interface{}) erro
 	default:
 		panic("not a safe response type")
 	}
-	return nil
 }
 
 func TestHandleRequestWrite(t *testing.T) {

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -1,0 +1,72 @@
+package safehtml_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+	"github.com/google/safehtml/template"
+)
+
+type dispatcher struct {
+	wr io.Writer
+}
+
+func (d *dispatcher) Write(resp safehttp.Response) error {
+	switch x := resp.(type) {
+	case safehtml.HTML:
+		_, err := d.wr.Write([]byte(x.String()))
+		return err
+	default:
+		panic("not a safe response type")
+	}
+	return nil
+}
+
+func (d *dispatcher) ExecuteTemplate(t safehttp.Template, data interface{}) error {
+	switch x := t.(type) {
+	case *template.Template:
+		return x.Execute(d.wr, data)
+	default:
+		panic("not a safe response type")
+	}
+	return nil
+}
+
+func TestHandleRequestWrite(t *testing.T) {
+	b := &strings.Builder{}
+	d := &dispatcher{wr: b}
+
+	m := safehttp.NewMachinery(func(w *safehttp.ResponseWriter, _ safehttp.IncomingRequest) safehttp.Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
+	}, d)
+
+	m.HandleRequest("GET / HTTP/1.1\r\n" +
+		"\r\n")
+
+	want := "&lt;h1&gt;Escaped, so not really a heading&lt;/h1&gt;"
+	got := b.String()
+	if got != want {
+		t.Errorf("response got = %q, want %q", got, want)
+	}
+}
+
+func TestHandleRequestWriteTemplate(t *testing.T) {
+	b := &strings.Builder{}
+	d := &dispatcher{wr: b}
+
+	m := safehttp.NewMachinery(func(w *safehttp.ResponseWriter, _ safehttp.IncomingRequest) safehttp.Result {
+		return w.WriteTemplate(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+	}, d)
+
+	m.HandleRequest("GET / HTTP/1.1\r\n" +
+		"\r\n")
+
+	want := "<h1>This is an actual heading, though.</h1>"
+	got := b.String()
+	if got != want {
+		t.Errorf("response got = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
This is a very early prototype. Anything can change.

`Machinery` is introduced to avoid designing the whole package at once. All things related to registering handlers, muxing, registering safe responses etc is right now hidden there.