### PR TITLE
Moved test harness to internal

### DIFF
--- a/internal/requesttesting/test_harness.go
+++ b/internal/requesttesting/test_harness.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package requesttesting provides a harness and other test utilities for
+// verifying the behaviour of the net/http package in Go's standard library.
 package requesttesting
 
 import (
@@ -42,7 +44,7 @@ type FakeListener struct {
 	clientEndpoint net.Conn
 }
 
-// NewFakeListener creates an instance of fakeListener. This will pass requests to the HTTP server as part of the testing harness.
+// NewFakeListener creates an instance of fakeListener.
 func NewFakeListener() *FakeListener {
 	s2c, c2s := net.Pipe()
 	c := make(chan net.Conn, 1)
@@ -126,7 +128,6 @@ func MakeRequest(ctx context.Context, req []byte, callback func(*http.Request)) 
 	if n == 4096 {
 		return nil, errors.New("response larger than or equal to 4096 bytes")
 	}
-	
 
 	return resp[:n], server.Shutdown(ctx)
 }

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,2 +1,0 @@
-The `testing` package provides a harness and other test utilities for verifying
-the behaviour of the Go standard library HTTP related packages.

--- a/tests/formparams/form_params_test.go
+++ b/tests/formparams/form_params_test.go
@@ -19,11 +19,12 @@ package formparams
 import (
 	"bytes"
 	"context"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-safeweb/testing/requesttesting"
 	"net/http"
 	"strconv"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/internal/requesttesting"
 )
 
 const status200OK = "HTTP/1.1 200 OK\r\n"

--- a/tests/headers/basicauth_test.go
+++ b/tests/headers/basicauth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package requestparsing
+package headers
 
 import (
 	"context"
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/google/go-safeweb/testing/requesttesting"
+	"github.com/google/go-safeweb/internal/requesttesting"
 )
 
 func TestBasicAuth(t *testing.T) {

--- a/tests/headers/clte_test.go
+++ b/tests/headers/clte_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package requestparsing
+package headers
 
 import (
 	"context"
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-safeweb/testing/requesttesting"
+	"github.com/google/go-safeweb/internal/requesttesting"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/tests/headers/doc.go
+++ b/tests/headers/doc.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package requestparsing contains tests to verify the
-// request parsing behavior of `net/http` in Go's standard library.
+// Package headers contains tests to verify the
+// request parsing behavior of net/http in Go's standard library.
 // Note: All tests use verbatim newline characters in their
 // requests instead of using multiline strings to ensure that
 // \r and \n end up in exactly the right places.
-package requestparsing
+package headers

--- a/tests/headers/header_test.go
+++ b/tests/headers/header_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package requestparsing
+package headers
 
 import (
 	"context"
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/google/go-safeweb/testing/requesttesting"
+	"github.com/google/go-safeweb/internal/requesttesting"
 )
 
 func TestHeaderParsing(t *testing.T) {

--- a/tests/headers/host_test.go
+++ b/tests/headers/host_test.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package requestparsing
+package headers
 
 import (
 	"context"
 	"net/http"
 	"testing"
 
-	"github.com/google/go-safeweb/testing/requesttesting"
+	"github.com/google/go-safeweb/internal/requesttesting"
 )
 
 func TestHostHeader(t *testing.T) {

--- a/tests/headers/referer_test.go
+++ b/tests/headers/referer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package requestparsing
+package headers
 
 import (
 	"context"
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/google/go-safeweb/testing/requesttesting"
+	"github.com/google/go-safeweb/internal/requesttesting"
 )
 
 func TestReferer(t *testing.T) {

--- a/tests/headers/statusmessages.go
+++ b/tests/headers/statusmessages.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package requestparsing
+package headers
 
 import "bytes"
 

--- a/tests/headers/useragent_test.go
+++ b/tests/headers/useragent_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package requestparsing
+package headers
 
 import (
 	"context"
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-safeweb/testing/requesttesting"
+	"github.com/google/go-safeweb/internal/requesttesting"
 )
 
 func TestUserAgent(t *testing.T) {

--- a/tests/queryparams/query_params_test.go
+++ b/tests/queryparams/query_params_test.go
@@ -19,11 +19,12 @@ package queryparams
 import (
 	"bytes"
 	"context"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-safeweb/testing/requesttesting"
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/internal/requesttesting"
 )
 
 const status200OK = "HTTP/1.1 200 OK\r\n"


### PR DESCRIPTION
We talked about moving the test harness to the `internal` folder to avoid having both a `testing` package and a `tests` package. We also didn't want the test harness to be importable when using the `safehttp` package.