### PR TITLE
Added test for ordering of http.Header.Values()

### DIFF
--- a/tests/headers/header_test.go
+++ b/tests/headers/header_test.go
@@ -206,6 +206,9 @@ func TestStatusCode(t *testing.T) {
 	}
 }
 
+// TestValues verifies that the http.Header.Values() function
+// returns the header values in the order that they are sent
+// in the request to the server.
 func TestValues(t *testing.T) {
 	var tests = []struct {
 		name    string


### PR DESCRIPTION
A question came up in #21 whether the `http.Header.Values()` function sorts the resulting string slice somehow. I added a test to verify that the current behavior is to order the slice in the same order as the headers were sent from the client.