### PR TITLE
Clearly document strange header parsing behavior

### DIFF
--- a/tests/headers/basicauth_test.go
+++ b/tests/headers/basicauth_test.go
@@ -166,7 +166,7 @@ func TestBasicAuth(t *testing.T) {
 
 func TestBasicAuthOrdering(t *testing.T) {
 	// The documentation of http.Request.BasicAuth() doesn't clearly specify
-	// that only the first Authorization header is used and that the other ones
+	// that only the first Authorization header is used and the other ones
 	// are ignored. This could potentially lead to security issues if two
 	// HTTP servers that look at different headers are chained together.
 	//

--- a/tests/headers/basicauth_test.go
+++ b/tests/headers/basicauth_test.go
@@ -165,13 +165,13 @@ func TestBasicAuth(t *testing.T) {
 }
 
 func TestBasicAuthOrdering(t *testing.T) {
-	// It is not clear from the documentation of http.Request.BasicAuth()
-	// that only the first Authorization header is used and any other ones
+	// The documentation of http.Request.BasicAuth() doesn't clearly specify
+	// that only the first Authorization header is used and that the other ones
 	// are ignored. This could potentially lead to security issues if two
-	// HTTP servers are chained that look at different headers.
+	// HTTP servers that look at different headers are chained together.
 	//
-	// The desired behavior would instead be for http.Request.BasicAuth() to
-	// return ok as false when there are more than one Authorization header.
+	// The desired behavior would be for http.Request.BasicAuth() to
+	// return ok as false when there is more than one Authorization header.
 
 	request := []byte("GET / HTTP/1.1\r\n" +
 		"Host: localhost:8080\r\n" +

--- a/tests/headers/clte_test.go
+++ b/tests/headers/clte_test.go
@@ -302,12 +302,12 @@ func TestTransferEncodingChunkSizeLength(t *testing.T) {
 }
 
 func TestMultipleTransferEncodingChunkedFirst(t *testing.T) {
-	// When faced with two Transfer-Encoding headers net/http
+	// When faced with two Transfer-Encoding headers, net/http
 	// currently only looks at the first one and ignores the
 	// rest.
 	//
-	// RFC 7230 doesn’t say anything specifically about
-	// having multiple TE headers. It only says that in general
+	// RFC 7230 doesn’t say anything specific about
+	// having multiple TE headers. It only says that, in general
 	// a recipient may combine the value of multiple headers
 	// with the same name:
 	// “ [...] A recipient MAY combine multiple header fields
@@ -323,8 +323,8 @@ func TestMultipleTransferEncodingChunkedFirst(t *testing.T) {
 	//
 	// net/http should probably reject requests with two TE headers
 	// just as it does with requests having two CL headers.
-	// I (grenfeldt@) see no legitimate reason for having two TE
-	// headers since the TE header already supports having multiple
+	// There is no legitimate reason for having two TE headers
+	// since the TE header already supports having multiple
 	// encodings in the same header delimited by commas.
 	//
 	// The desired behavior would therefore be to respond with
@@ -457,11 +457,9 @@ func TestTransferEncodingIdentity(t *testing.T) {
 }
 
 func TestTransferEncodingListIdentityFirst(t *testing.T) {
-	// In TestTransferEncodingIdentity we see that the
-	// identity transfer coding should not be supported
-	// at all. But in the current implementation, where
-	// identity is supported, there is a bug. Any transfer
-	// coding that you put after identity in the list of
+	// There is a bug in the handling of lists of transfer
+	// codings that contain the identity encoding. Any transfer
+	// coding that is put after identity in the list of
 	// transfer codings is ignored. Even if it doesn't
 	// exists.
 	//

--- a/tests/headers/clte_test.go
+++ b/tests/headers/clte_test.go
@@ -102,61 +102,6 @@ func TestContentLengthTransferEncoding(t *testing.T) {
 			},
 		},
 		{
-			name: "MultipleTransferEncodingChunkedFirst",
-			request: []byte("GET / HTTP/1.1\r\n" +
-				"Host: localhost:8080\r\n" +
-				"Content-Length: 11\r\n" +
-				"Transfer-Encoding: chunked\r\n" +
-				"Transfer-Encoding: asdf\r\n" +
-				"\r\n" +
-				"5\r\n" +
-				"ABCDE\r\n" +
-				"0\r\n" +
-				"\r\n"),
-			want: testWant{
-				headers:          map[string][]string{},
-				contentLength:    -1,
-				transferEncoding: []string{"chunked"},
-				body:             "ABCDE",
-			},
-		},
-		{
-			name: "TransferEncodingIdentity",
-			request: []byte("GET / HTTP/1.1\r\n" +
-				"Host: localhost:8080\r\n" +
-				"Content-Length: 11\r\n" +
-				"Transfer-Encoding: identity\r\n" +
-				"\r\n" +
-				"5\r\n" +
-				"ABCDE\r\n" +
-				"0\r\n" +
-				"\r\n"),
-			want: testWant{
-				headers:          map[string][]string{"Content-Length": []string{"11"}},
-				contentLength:    11,
-				transferEncoding: nil,
-				body:             "5\r\nABCDE\r\n0",
-			},
-		},
-		{
-			name: "TransferEncodingListIdentityFirst",
-			request: []byte("GET / HTTP/1.1\r\n" +
-				"Host: localhost:8080\r\n" +
-				"Content-Length: 11\r\n" +
-				"Transfer-Encoding: identity, xyz, asdf\r\n" +
-				"\r\n" +
-				"5\r\n" +
-				"ABCDE\r\n" +
-				"0\r\n" +
-				"\r\n"),
-			want: testWant{
-				headers:          map[string][]string{"Content-Length": []string{"11"}},
-				contentLength:    11,
-				transferEncoding: nil,
-				body:             "5\r\nABCDE\r\n0",
-			},
-		},
-		{
 			name: "TransferEncodingListChunkedIdentity",
 			request: []byte("GET / HTTP/1.1\r\n" +
 				"Host: localhost:8080\r\n" +
@@ -354,4 +299,230 @@ func TestTransferEncodingChunkSizeLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MakeRequest() got err: %v", err)
 	}
+}
+
+func TestMultipleTransferEncodingChunkedFirst(t *testing.T) {
+	// When faced with two Transfer-Encoding headers net/http
+	// currently only looks at the first one and ignores the
+	// rest.
+	//
+	// RFC 7230 doesn’t say anything specifically about
+	// having multiple TE headers. It only says that in general
+	// a recipient may combine the value of multiple headers
+	// with the same name:
+	// “ [...] A recipient MAY combine multiple header fields
+	//   with the same field name into one "field-name: field-value"
+	//   pair, without changing the semantics of the message, by
+	//   appending each subsequent field value to the combined
+	//   field value in order, separated by a comma.  The order in
+	//   which header fields with the same field name are received
+	//   is therefore significant to the interpretation of the
+	//   combined field value; a proxy MUST NOT change the order
+	//   of these field values when forwarding a message. [...] “
+	// - RFC 7230 Section 3.2.4
+	//
+	// net/http should probably reject requests with two TE headers
+	// just as it does with requests having two CL headers.
+	// I (grenfeldt@) see no legitimate reason for having two TE
+	// headers since the TE header already supports having multiple
+	// encodings in the same header delimited by commas.
+	//
+	// The desired behavior would therefore be to respond with
+	// 400 (Bad Request) when a request with two TE headers
+	// is received.
+
+	request := []byte("GET / HTTP/1.1\r\n" +
+		"Host: localhost:8080\r\n" +
+		"Content-Length: 11\r\n" +
+		"Transfer-Encoding: chunked\r\n" +
+		"Transfer-Encoding: asdf\r\n" +
+		"\r\n" +
+		"5\r\n" +
+		"ABCDE\r\n" +
+		"0\r\n" +
+		"\r\n")
+
+	t.Run("Current behavior", func(t *testing.T) {
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			if diff := cmp.Diff(map[string][]string{}, map[string][]string(r.Header)); diff != "" {
+				t.Errorf("r.Header mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff([]string{"chunked"}, r.TransferEncoding); diff != "" {
+				t.Errorf("r.TransferEncoding mismatch (-want +got):\n%s", diff)
+			}
+
+			if want := int64(-1); r.ContentLength != want {
+				t.Errorf("r.ContentLength got: %v want: %v", r.ContentLength, want)
+			}
+
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ioutil.ReadAll(r.Body) got err: %v", err)
+			}
+
+			if got, want := string(body), "ABCDE"; got != want {
+				t.Errorf("r.Body got: %q want: %q", got, want)
+			}
+		})
+		if err != nil {
+			t.Fatalf("MakeRequest() got err: %v want: nil", err)
+		}
+
+		if got, want := extractStatus(resp), statusOK; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
+		}
+	})
+
+	t.Run("Desired behavior", func(t *testing.T) {
+		t.Skip()
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			t.Error("Expected handler to not be called!")
+		})
+		if err != nil {
+			t.Fatalf("MakeRequest() got err: %v want: nil", err)
+		}
+
+		if got, want := extractStatus(resp), statusBadRequest; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
+		}
+	})
+}
+
+func TestTransferEncodingIdentity(t *testing.T) {
+	// net/http currently accepts the identity transfer encoding and
+	// interprets it as if there was no transfer encoding at all.
+	//
+	// But RFC 7230 has deprecated and removed the identity encoding.
+	// The net/http package should therefore remove support for this
+	// encoding. The Desired behavior is therefore to return a
+	// 501 (Not Implemented).
+
+	request := []byte("GET / HTTP/1.1\r\n" +
+		"Host: localhost:8080\r\n" +
+		"Content-Length: 11\r\n" +
+		"Transfer-Encoding: identity\r\n" +
+		"\r\n" +
+		"5\r\n" +
+		"ABCDE\r\n" +
+		"0\r\n" +
+		"\r\n")
+
+	t.Run("Current behavior", func(t *testing.T) {
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			wantHeaders := map[string][]string{"Content-Length": []string{"11"}}
+			if diff := cmp.Diff(wantHeaders, map[string][]string(r.Header)); diff != "" {
+				t.Errorf("r.Header mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff([]string(nil), r.TransferEncoding); diff != "" {
+				t.Errorf("r.TransferEncoding mismatch (-want +got):\n%s", diff)
+			}
+
+			if want := int64(11); r.ContentLength != want {
+				t.Errorf("r.ContentLength got: %v want: %v", r.ContentLength, want)
+			}
+
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ioutil.ReadAll(r.Body) got err: %v", err)
+			}
+
+			if got, want := string(body), "5\r\nABCDE\r\n0"; got != want {
+				t.Errorf("r.Body got: %q want: %q", got, want)
+			}
+		})
+		if err != nil {
+			t.Fatalf("MakeRequest() got err: %v", err)
+		}
+
+		if got, want := extractStatus(resp), statusOK; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
+		}
+	})
+
+	t.Run("Desired behavior", func(t *testing.T) {
+		t.Skip()
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			t.Error("Expected handler to not be called!")
+		})
+		if err != nil {
+			t.Fatalf("MakeRequest() got err: %v", err)
+		}
+
+		if got, want := extractStatus(resp), statusNotImplemented; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
+		}
+	})
+}
+
+func TestTransferEncodingListIdentityFirst(t *testing.T) {
+	// In TestTransferEncodingIdentity we see that the
+	// identity transfer coding should not be supported
+	// at all. But in the current implementation, where
+	// identity is supported, there is a bug. Any transfer
+	// coding that you put after identity in the list of
+	// transfer codings is ignored. Even if it doesn't
+	// exists.
+	//
+	// The desired behavior would instead be to return
+	// 501 (Not Implemented) when faced with an unrecognized
+	// transfer coding.
+
+	request := []byte("GET / HTTP/1.1\r\n" +
+		"Host: localhost:8080\r\n" +
+		"Content-Length: 11\r\n" +
+		"Transfer-Encoding: identity, xyz, asdf\r\n" +
+		"\r\n" +
+		"5\r\n" +
+		"ABCDE\r\n" +
+		"0\r\n" +
+		"\r\n")
+
+	t.Run("Current behavior", func(t *testing.T) {
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			wantHeaders := map[string][]string{"Content-Length": []string{"11"}}
+			if diff := cmp.Diff(wantHeaders, map[string][]string(r.Header)); diff != "" {
+				t.Errorf("r.Header mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff([]string(nil), r.TransferEncoding); diff != "" {
+				t.Errorf("r.TransferEncoding mismatch (-want +got):\n%s", diff)
+			}
+
+			if want := int64(11); r.ContentLength != want {
+				t.Errorf("r.ContentLength got: %v want: %v", r.ContentLength, want)
+			}
+
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ioutil.ReadAll(r.Body) got err: %v", err)
+			}
+
+			if got, want := string(body), "5\r\nABCDE\r\n0"; got != want {
+				t.Errorf("r.Body got: %q want: %q", got, want)
+			}
+		})
+		if err != nil {
+			t.Fatalf("MakeRequest() got err: %v want: nil", err)
+		}
+
+		if got, want := extractStatus(resp), statusOK; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
+		}
+	})
+
+	t.Run("Desired behavior", func(t *testing.T) {
+		t.Skip()
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			t.Error("Expected handler to not be called!")
+		})
+		if err != nil {
+			t.Fatalf("MakeRequest() got err: %v want: nil", err)
+		}
+
+		if got, want := extractStatus(resp), statusNotImplemented; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
+		}
+	})
 }

--- a/tests/headers/clte_test.go
+++ b/tests/headers/clte_test.go
@@ -307,7 +307,7 @@ func TestMultipleTransferEncodingChunkedFirst(t *testing.T) {
 	// rest.
 	//
 	// RFC 7230 doesn’t say anything specific about
-	// having multiple TE headers. It only says that, in general
+	// having multiple TE headers. It only says that, in general,
 	// a recipient may combine the value of multiple headers
 	// with the same name:
 	// “ [...] A recipient MAY combine multiple header fields
@@ -457,8 +457,8 @@ func TestTransferEncodingIdentity(t *testing.T) {
 }
 
 func TestTransferEncodingListIdentityFirst(t *testing.T) {
-	// There is a bug in the handling of lists of transfer
-	// codings that contain the identity encoding. Any transfer
+	// There is a bug in the handling of Transfer-Encoding lists
+	// that contain the identity encoding. Any transfer
 	// coding that is put after identity in the list of
 	// transfer codings is ignored. Even if it doesn't
 	// exists.

--- a/tests/headers/host_test.go
+++ b/tests/headers/host_test.go
@@ -110,10 +110,10 @@ func TestAbsoluteFormURLInvalidSchema(t *testing.T) {
 	// form as the request target, any schema is currently
 	// accepted.
 	//
-	// The desired behavior would instead be that only
-	// http or https are accepted as schemas and that
-	// the server responds with a 400 (Bad Request) when
-	// it receives anything else.
+	// The desired behavior would instead be to only
+	// accept http or https as schemas and to respond
+	// with a 400 (Bad Request) when the server receives
+	// any other schema.
 
 	request := []byte("GET x://y.com/asdf HTTP/1.1\r\n" +
 		"Host: x.com\r\n" +

--- a/tests/headers/host_test.go
+++ b/tests/headers/host_test.go
@@ -44,13 +44,6 @@ func TestHostHeader(t *testing.T) {
 			want: "y.com",
 		},
 		{
-			name: "AbsoluteFormURLNoValidSchemaNeeded",
-			request: []byte("GET x://y.com/asdf HTTP/1.1\r\n" +
-				"Host: x.com\r\n" +
-				"\r\n"),
-			want: "y.com",
-		},
-		{
 			// https://tools.ietf.org/html/rfc7230#section-5.3.3
 			name: "AuthorityForm",
 			request: []byte("GET y.com:123/asdf HTTP/1.1\r\n" +
@@ -110,4 +103,54 @@ func TestHostHeaderMultiple(t *testing.T) {
 	if got, want := extractStatus(resp), statusTooManyHostHeaders; got != want {
 		t.Errorf("status code got: %q want: %q", got, want)
 	}
+}
+
+func TestAbsoluteFormURLInvalidSchema(t *testing.T) {
+	// (I (grenfeldt@) don't actually know whether this
+	// is intended behavior or not, but it looks wrong
+	// to me.) When sending a request using the absolute
+	// form as the request target, any schema is currently
+	// accepted.
+	//
+	// The desired behavior would instead be that only
+	// http or https are accepted as schemas and that
+	// the server responds with a 400 (Bad Request) when
+	// it receives anything else.
+
+	request := []byte("GET x://y.com/asdf HTTP/1.1\r\n" +
+		"Host: x.com\r\n" +
+		"\r\n")
+
+	t.Run("Current behavior", func(t *testing.T) {
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			if len(r.Header) != 0 {
+				t.Errorf("len(r.Header) got: %v want: 0", len(r.Header))
+			}
+
+			if want := "y.com"; r.Host != want {
+				t.Errorf("r.Host got: %q want: %q", r.Host, want)
+			}
+		})
+		if err != nil {
+			t.Fatalf("MakeRequest() got err: %v want: nil", err)
+		}
+
+		if got, want := extractStatus(resp), statusOK; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
+		}
+	})
+
+	t.Run("Desired behavior", func(t *testing.T) {
+		t.Skip()
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			t.Error("Expected handler to not be called!")
+		})
+		if err != nil {
+			t.Fatalf("MakeRequest() got err: %v want: nil", err)
+		}
+
+		if got, want := extractStatus(resp), statusBadRequest; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
+		}
+	})
 }

--- a/tests/headers/host_test.go
+++ b/tests/headers/host_test.go
@@ -106,9 +106,7 @@ func TestHostHeaderMultiple(t *testing.T) {
 }
 
 func TestAbsoluteFormURLInvalidSchema(t *testing.T) {
-	// (I (grenfeldt@) don't actually know whether this
-	// is intended behavior or not, but it looks wrong
-	// to me.) When sending a request using the absolute
+	// When sending a request using the absolute
 	// form as the request target, any schema is currently
 	// accepted.
 	//

--- a/tests/headers/referer_test.go
+++ b/tests/headers/referer_test.go
@@ -95,13 +95,13 @@ func TestReferer(t *testing.T) {
 }
 
 func TestRefererOrdering(t *testing.T) {
-	// It is not clear from the documentation of http.Request.Referer()
-	// that only the first Referer header is used and any other ones
+	// The documentation of http.Request.Referer() doesn't clearly specify
+	// that only the first Referer header is used and that the other ones
 	// are ignored. This could potentially lead to security issues if two
-	// HTTP servers are chained that look at different headers.
+	// HTTP servers that look at different headers are chained together.
 	//
-	// The desired behavior would instead be for http.Request.Referer() to
-	// return an error of some sort or an empty string when there are more
+	// The desired behavior would be for http.Request.Referer() to
+	// return an error or an empty string when there are more
 	// than one Referer header.
 
 	request := []byte("GET / HTTP/1.1\r\n" +

--- a/tests/headers/referer_test.go
+++ b/tests/headers/referer_test.go
@@ -100,9 +100,8 @@ func TestRefererOrdering(t *testing.T) {
 	// are ignored. This could potentially lead to security issues if two
 	// HTTP servers that look at different headers are chained together.
 	//
-	// The desired behavior would be for http.Request.Referer() to
-	// return an error or an empty string when there are more
-	// than one Referer header.
+	// The desired behavior would be to respond with 400 (Bad Request)
+	// when there is more than one Referer header.
 
 	request := []byte("GET / HTTP/1.1\r\n" +
 		"Host: localhost:8080\r\n" +
@@ -132,18 +131,15 @@ func TestRefererOrdering(t *testing.T) {
 
 	t.Run("Desired behavior", func(t *testing.T) {
 		t.Skip()
-		_, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
-			wantHeaders := map[string][]string{"Referer": []string{"http://example.com", "http://evil.com"}}
-			if diff := cmp.Diff(wantHeaders, map[string][]string(r.Header)); diff != "" {
-				t.Errorf("r.Header mismatch (-want +got):\n%s", diff)
-			}
-
-			if want := ""; r.Referer() != want {
-				t.Errorf("r.Referer() got: %q want: %q", r.Referer(), want)
-			}
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			t.Error("Expected handler to not be called!")
 		})
 		if err != nil {
 			t.Fatalf("MakeRequest() got err: %v want: nil", err)
+		}
+
+		if got, want := extractStatus(resp), statusBadRequest; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
 		}
 	})
 }

--- a/tests/headers/useragent_test.go
+++ b/tests/headers/useragent_test.go
@@ -99,9 +99,8 @@ func TestUserAgentOrdering(t *testing.T) {
 	// are ignored. This could potentially lead to security issues if two
 	// HTTP servers that look at different headers are chained together.
 	//
-	// The desired behavior would be for http.Request.UserAgent() to
-	// return an error or an empty string when there are more
-	// than one User-Agent header.
+	// The desired behavior would be to respond with 400 (Bad Request)
+	// when there is more than one User-Agent header.
 
 	request := []byte("GET / HTTP/1.1\r\n" +
 		"Host: localhost:8080\r\n" +
@@ -131,18 +130,15 @@ func TestUserAgentOrdering(t *testing.T) {
 
 	t.Run("Desired behavior", func(t *testing.T) {
 		t.Skip()
-		_, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
-			wantHeaders := map[string][]string{"User-Agent": []string{"BlahBlah", "FooFoo"}}
-			if diff := cmp.Diff(wantHeaders, map[string][]string(r.Header)); diff != "" {
-				t.Errorf("r.Header mismatch (-want +got):\n%s", diff)
-			}
-
-			if want := ""; r.UserAgent() != want {
-				t.Errorf("r.UserAgent() got: %q want: %q", r.UserAgent(), want)
-			}
+		resp, err := requesttesting.MakeRequest(context.Background(), request, func(r *http.Request) {
+			t.Error("Expected handler to not be called!")
 		})
 		if err != nil {
 			t.Fatalf("MakeRequest() got err: %v want: nil", err)
+		}
+
+		if got, want := extractStatus(resp), statusBadRequest; got != want {
+			t.Errorf("status code got: %q want: %q", got, want)
 		}
 	})
 }

--- a/tests/headers/useragent_test.go
+++ b/tests/headers/useragent_test.go
@@ -94,13 +94,13 @@ func TestUserAgent(t *testing.T) {
 }
 
 func TestUserAgentOrdering(t *testing.T) {
-	// It is not clear from the documentation of http.Request.UserAgent()
-	// that only the first User-Agent header is used and any other ones
+	// The documentation of http.Request.UserAgent() doesn't clearly specify
+	// that only the first User-Agent header is used and that the other ones
 	// are ignored. This could potentially lead to security issues if two
-	// HTTP servers are chained that look at different headers.
+	// HTTP servers that look at different headers are chained together.
 	//
-	// The desired behavior would instead be for http.Request.UserAgent() to
-	// return an error of some sort or an empty string when there are more
+	// The desired behavior would be for http.Request.UserAgent() to
+	// return an error or an empty string when there are more
 	// than one User-Agent header.
 
 	request := []byte("GET / HTTP/1.1\r\n" +


### PR DESCRIPTION
Adresses #23 for the header tests.
All of the tests that show strange or undesirable behavior have now been more clearly documented.