### PR TITLE
Remove use of httptest.ResponseRecorder in header tests

### DIFF
--- a/tests/integration/header/header_test.go
+++ b/tests/integration/header/header_test.go
@@ -53,7 +53,7 @@ func newResponseWriter(w io.Writer) *responseWriter {
 	return &responseWriter{header: http.Header{}, writer: w, status: http.StatusOK}
 }
 
-func (r responseWriter) Header() http.Header {
+func (r *responseWriter) Header() http.Header {
 	return r.header
 }
 
@@ -61,7 +61,7 @@ func (r *responseWriter) WriteHeader(statusCode int) {
 	r.status = statusCode
 }
 
-func (r responseWriter) Write(data []byte) (int, error) {
+func (r *responseWriter) Write(data []byte) (int, error) {
 	return r.writer.Write(data)
 }
 

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -57,7 +57,7 @@ func newResponseWriter(w io.Writer) *responseWriter {
 	return &responseWriter{header: http.Header{}, writer: w, status: http.StatusOK}
 }
 
-func (r responseWriter) Header() http.Header {
+func (r *responseWriter) Header() http.Header {
 	return r.header
 }
 
@@ -65,7 +65,7 @@ func (r *responseWriter) WriteHeader(statusCode int) {
 	r.status = statusCode
 }
 
-func (r responseWriter) Write(data []byte) (int, error) {
+func (r *responseWriter) Write(data []byte) (int, error) {
 	return r.writer.Write(data)
 }
 


### PR DESCRIPTION
Addresses #27 for tests in `tests/integration/header/header_test.go`.