### PR TITLE
Skeleton for safe multiplexer.

### DIFF
--- a/safehttp/handler.go
+++ b/safehttp/handler.go
@@ -14,10 +14,6 @@
 
 package safehttp
 
-import (
-	"net/http"
-)
-
 // HandleFunc TODO
 type HandleFunc func(ResponseWriter, *IncomingRequest) Result
 
@@ -32,11 +28,4 @@ type HandlerFunc func(ResponseWriter, *IncomingRequest) Result
 // ServeHTTP calls f(w, r).
 func (f HandlerFunc) ServeHTTP(w ResponseWriter, r *IncomingRequest) Result {
 	return f(w, r)
-}
-
-func safeHandler(h http.Handler) Handler {
-	return HandlerFunc(func(w ResponseWriter, r *IncomingRequest) Result {
-		h.ServeHTTP(w.rw, r.req)
-		return Result{}
-	})
 }

--- a/safehttp/handler.go
+++ b/safehttp/handler.go
@@ -14,5 +14,29 @@
 
 package safehttp
 
+import (
+	"net/http"
+)
+
 // HandleFunc TODO
 type HandleFunc func(ResponseWriter, *IncomingRequest) Result
+
+// Handler TODO
+type Handler interface {
+	ServeHTTP(ResponseWriter, *IncomingRequest) Result
+}
+
+// HandlerFunc TODO
+type HandlerFunc func(ResponseWriter, *IncomingRequest) Result
+
+// ServeHTTP calls f(w, r).
+func (f HandlerFunc) ServeHTTP(w ResponseWriter, r *IncomingRequest) Result {
+	return f(w, r)
+}
+
+func safeHandler(h http.Handler) Handler {
+	return HandlerFunc(func(w ResponseWriter, r *IncomingRequest) Result {
+		h.ServeHTTP(w.rw, r.req)
+		return Result{}
+	})
+}

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -28,8 +28,8 @@ type IncomingRequest struct {
 	parseOnce sync.Once
 }
 
-func newIncomingRequest(req *http.Request) IncomingRequest {
-	return IncomingRequest{req: req, Header: newHeader(req.Header)}
+func newIncomingRequest(req *http.Request) *IncomingRequest {
+	return &IncomingRequest{req: req, Header: newHeader(req.Header)}
 }
 
 // PostForm parses the form parameters provided in the body of a POST, PATCH or

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -30,7 +30,11 @@ const (
 // request against a list of registered patterns and calls the handler for
 // the pattern that most closely matches the URL.
 //
-// Patterns name are fixed, rooted paths, like "/favicon.ico", or rooted
+// When creating the multiplexer, the user needs to specify a list of allowed
+// domains. The server will only serve requests target to those domains and
+// otherwise will reply with HTTP 404 Not Found.
+//
+// Patterns names are fixed, rooted paths, like "/favicon.ico", or rooted
 // subtrees like "/images/" (note the trailing slash). Longer patterns take
 // precedence over shorter ones, so that if there are handlers registered for
 // both "/images/" and "/images/thumbnails/", the latter handler will be called

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -77,16 +77,16 @@ type ServeMux struct {
 }
 
 // NewServeMux allocates and returns a new ServeMux
-func NewServeMux(dispatcher Dispatcher, domains ...string) *ServeMux {
+func NewServeMux(d Dispatcher, domains ...string) *ServeMux {
 	// TODO(@mattiasgrenfeldt, @mihalimara22): make domains a variadic of string **literals**.
-	d := map[string]bool{}
+	dm := map[string]bool{}
 	for _, host := range domains {
-		d[host] = true
+		dm[host] = true
 	}
 	return &ServeMux{
 		mux:      http.NewServeMux(),
-		domains:  d,
-		disp:     dispatcher,
+		domains:  dm,
+		disp:     d,
 		handlers: map[string]methodHandler{},
 	}
 }
@@ -94,23 +94,23 @@ func NewServeMux(dispatcher Dispatcher, domains ...string) *ServeMux {
 // Handle registers a handler for the given pattern and method. If another
 // handler is already registered for the same pattern and method, Handle panics.
 func (m *ServeMux) Handle(pattern string, method string, h Handler) {
-	ch, ok := m.handlers[pattern]
+	mh, ok := m.handlers[pattern]
 	if !ok {
-		ch := methodHandler{
+		mh := methodHandler{
 			handlers: map[string]Handler{method: h},
 			domains:  m.domains,
 			disp:     m.disp,
 		}
 
-		m.handlers[pattern] = ch
-		m.mux.Handle(pattern, ch)
+		m.handlers[pattern] = mh
+		m.mux.Handle(pattern, mh)
 		return
 	}
 
-	if _, ok := ch.handlers[method]; ok {
+	if _, ok := mh.handlers[method]; ok {
 		panic("method already registered")
 	}
-	ch.handlers[method] = h
+	mh.handlers[method] = h
 }
 
 // ServeHTTP dispatches the request to the handler whose method matches the

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -33,6 +33,8 @@ const (
 // When creating the multiplexer, the user needs to specify a list of allowed
 // domains. The server will only serve requests target to those domains and
 // otherwise will reply with HTTP 404 Not Found.
+// TODO(@mihalimara22, @mattiasgrenfeldt): add a link to docs/ explaining
+// why this is done.
 //
 // Patterns names are fixed, rooted paths, like "/favicon.ico", or rooted
 // subtrees like "/images/" (note the trailing slash). Longer patterns take
@@ -45,14 +47,16 @@ const (
 // pattern "/" matches all paths not matched by other registered patterns,
 // not just the URL with Path == "/".
 //
-// If a subtree has been registered and a request is received naming the subtree root without its trailing slash, ServeMux redirects that request to
+// If a subtree has been registered and a request is received naming the subtree
+// root without its trailing slash, ServeMux redirects that request to
 // the subtree root (adding the trailing slash). This behavior can be overridden
 // with a separate registration for the path without the trailing slash. For
 // example, registering "/images/" causes ServeMux to redirect a request for
 // "/images" to "/images/", unless "/images" has been registered separately.
 //
 // Patterns may optionally begin with a host name, restricting matches to URLs
-// on that host only. Host-specific patterns take precedence over general
+// on that host only. This host name must be in the list of allowed domains passed
+// when creating the ServeMux. Host-specific patterns take precedence over general
 // patterns, so that a handler might register for the two patterns "/codesearch"
 // and "codesearch.google.com/" without also taking over requests for
 // "http://www.google.com/".
@@ -61,23 +65,20 @@ const (
 // header, stripping the port number and redirecting any request containing . or
 // .. elements or repeated slashes to an equivalent, cleaner URL.
 //
-// Multiple HTTP methods can be served for one pattern and the user is expected
-// to register a handler for each method supported. These will be combined
-// into one handler per pattern. The framework will then match each
-// incoming request to its underlying handler according to its HTTP method.
+// Multiple handlers can be registered for a single pattern, as long as they
+// handle different HTTP methods.
 type ServeMux struct {
 	mux     *http.ServeMux
 	domains map[string]bool
 	disp    Dispatcher
 
-	// Maps user-provided patterns to combined handlers which encapsulate
-	// multiple handlers, each one associated with an HTTP method.
+	// Maps patterns to handlers supporting multiple HTTP methods.
 	handlers map[string]methodHandler
 }
 
 // NewServeMux allocates and returns a new ServeMux
-// TODO(@mattiasgrenfeldt, @mihalimara22): make domains a variadic of string ..//**literals**.
 func NewServeMux(dispatcher Dispatcher, domains ...string) *ServeMux {
+	// TODO(@mattiasgrenfeldt, @mihalimara22): make domains a variadic of string **literals**.
 	d := map[string]bool{}
 	for _, host := range domains {
 		d[host] = true

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -65,11 +65,10 @@ func (m *ServeMux) Handle(pattern string, method string, h Handler) {
 	ch, ok := m.handlers[pattern]
 	if !ok {
 		ch := methodHandler{
-			h:       make(map[string]Handler),
+			h:       map[string]Handler{method: h},
 			domains: m.domains,
 			d:       m.dispatcher,
 		}
-		ch.h[method] = h
 
 		m.handlers[pattern] = ch
 		m.mux.Handle(pattern, ch)

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -1,0 +1,156 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp
+
+import (
+	"errors"
+	"net/http"
+)
+
+// TODO: add the missing methods
+const (
+	// HTTP GET request
+	MethodGet = "GET"
+	// HTTP Post request
+	MethodPost = "POST"
+)
+
+// ServeMux TODO
+type ServeMux struct {
+	mux        *http.ServeMux
+	domains    map[string]bool
+	dispatcher Dispatcher
+
+	// Maps user-provided patterns to combined handlers which encapsulate
+	// multiple handlers, each one associated with an HTTP method.
+	handlers map[string]combinedHandler
+}
+
+// NewServeMux returns a safe multiplex containing the list of allowed domains
+// and dispatcher provided by the user.
+func NewServeMux(dispatcher Dispatcher, domains ...string) *ServeMux {
+	d := map[string]bool{}
+	for _, host := range domains {
+		d[host] = true
+	}
+	return &ServeMux{mux: http.NewServeMux(), domains: d, dispatcher: dispatcher, handlers: map[string]combinedHandler{}}
+}
+
+// Handle registers a handler for the given pattern and method. The options
+// are applied to the middleware. If another handler is already registered
+// for the same pattern and method, Handle panics.
+func (m *ServeMux) Handle(pattern string, h map[string]Handler) {
+	ch := combinedHandler{h: h}
+	m.handlers[pattern] = ch
+	m.mux.Handle(pattern, ch.combine(m.domains, m.dispatcher))
+}
+
+// HandleFunc registers a handler for the given pattern and method. The options
+// are applied to the middleware. If another handler is already registered
+// for the same pattern and method, HandleFunc panics.
+func (m *ServeMux) HandleFunc(pattern string, h map[string]HandleFunc) {
+	if h == nil {
+		return
+	}
+	newH := make(map[string]Handler)
+	for key, val := range h {
+		newH[key] = HandlerFunc(val)
+	}
+	m.Handle(pattern, newH)
+}
+
+// NotFound registers a handler which will be called when an unhandled
+// path is visited. If another handler has already been registered for
+// this purpose, NotFound panics.
+func (*ServeMux) NotFound(h Handler) {
+	panic("not implemented")
+}
+
+// NotFoundFunc registers a handler which will be called when an unhandled
+// path is visited. If another handler has already been registered for
+// this purpose, NotFound panics.
+func (*ServeMux) NotFoundFunc(h HandleFunc) {
+	panic("not implemented")
+}
+
+// Handler returns the handler to use for the incoming request and the pattern.
+func (m *ServeMux) Handler(r *IncomingRequest) (Handler, string) {
+	h, pattern := m.mux.Handler(r.req)
+
+	if pattern == "" {
+		// If the pattern is empty, no handler was registered and the handler is
+		// an http.NotFoundHandler
+		// TODO: replace http.NotFoundHandler to a safehttp.NotFoundHandler
+		return safeHandler(h), pattern
+	}
+
+	// See if it is redirect or combined
+	c, ok := m.handlers[pattern]
+	if !ok {
+		// We got a http.RedirectHandler from m.mux.Handler()
+		return safeHandler(h), pattern
+	}
+
+	safeH, err := c.lookup(r.req.Method)
+	if err != nil {
+		// err is nil unless no HTTP method was registered for this pattern
+		// TODO: replace http.NotFoundHandler to a safehttp.MethodNotAllowedHandler
+		return safeHandler(http.NotFoundHandler()), pattern
+	}
+
+	return safeH, pattern
+}
+
+func (m *ServeMux) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	m.mux.ServeHTTP(w, r)
+}
+
+// combinedHandler is collection of handlers based on the request method.
+type combinedHandler struct {
+	// Maps an HTTP method to its handler
+	h map[string]Handler
+}
+
+// lookup returns the handler associated with the HTTP method provided as an
+// argument and a nil error, unless no handler was registered for the HTTP
+// method.
+func (c *combinedHandler) lookup(httpMethod string) (Handler, error) {
+	h, ok := c.h[httpMethod]
+	if !ok {
+		return nil, errors.New("method not registered")
+	}
+	return h, nil
+}
+
+// combine creates a combined handler to be registered with http.ServeMux.Handle
+// which calls the correct safe handler based on the request method.
+func (c combinedHandler) combine(domains map[string]bool, d Dispatcher) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !domains[r.Host] {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		h, ok := c.h[r.Method]
+		if !ok {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		rw := newResponseWriter(d, w)
+		ir := newIncomingRequest(r)
+		h.ServeHTTP(rw, &ir)
+	})
+}

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -65,9 +65,9 @@ func (m *ServeMux) Handle(pattern string, method string, h Handler) {
 	ch, ok := m.handlers[pattern]
 	if !ok {
 		ch := combinedHandler{
-			h: make(map[string]Handler),
+			h:       make(map[string]Handler),
 			domains: m.domains,
-			d: m.dispatcher,
+			d:       m.dispatcher,
 		}
 		ch.h[method] = h
 
@@ -80,26 +80,6 @@ func (m *ServeMux) Handle(pattern string, method string, h Handler) {
 		panic("method already registered")
 	}
 	ch.h[method] = h
-}
-
-// HandleFunc registers a handler for the given pattern and method.If another
-// handler is already registered for the same pattern and method, HandleFunc
-// panics.
-func (m *ServeMux) HandleFunc(pattern string, method string, h HandleFunc) {
-	if h == nil {
-		return
-	}
-	m.Handle(pattern, method, HandlerFunc(h))
-}
-
-// NotFound is not yet implemented.
-func (*ServeMux) NotFound(h Handler) {
-	panic("not implemented")
-}
-
-// NotFoundFunc is not yet implemented.
-func (*ServeMux) NotFoundFunc(h HandleFunc) {
-	panic("not implemented")
 }
 
 // ServeHTTP dispatches the request to the handler whose method matches the

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -92,9 +92,9 @@ func (m *ServeMux) Handle(pattern string, method string, h Handler) {
 	ch, ok := m.handlers[pattern]
 	if !ok {
 		ch := methodHandler{
-			methodMap: map[string]Handler{method: h},
-			domains:   m.domains,
-			disp:      m.disp,
+			handlers: map[string]Handler{method: h},
+			domains:  m.domains,
+			disp:     m.disp,
 		}
 
 		m.handlers[pattern] = ch
@@ -102,10 +102,10 @@ func (m *ServeMux) Handle(pattern string, method string, h Handler) {
 		return
 	}
 
-	if _, ok := ch.methodMap[method]; ok {
+	if _, ok := ch.handlers[method]; ok {
 		panic("method already registered")
 	}
-	ch.methodMap[method] = h
+	ch.handlers[method] = h
 }
 
 // ServeHTTP dispatches the request to the handler whose method matches the
@@ -117,9 +117,9 @@ func (m *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // methodHandler is collection of handlers based on the request method.
 type methodHandler struct {
 	// Maps an HTTP method to its handler
-	methodMap map[string]Handler
-	domains   map[string]bool
-	disp      Dispatcher
+	handlers map[string]Handler
+	domains  map[string]bool
+	disp     Dispatcher
 }
 
 // ServeHTTP dispatches the request to the handler associated with
@@ -130,7 +130,7 @@ func (m methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h, ok := m.methodMap[r.Method]
+	h, ok := m.handlers[r.Method]
 	if !ok {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 		return

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -1,0 +1,196 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp
+
+import (
+	"github.com/google/safehtml"
+	"github.com/google/safehtml/template"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type fakeDispatcher struct{}
+
+func (fakeDispatcher) Write(rw http.ResponseWriter, resp Response) error {
+	switch x := resp.(type) {
+	case safehtml.HTML:
+		_, err := rw.Write([]byte(x.String()))
+		return err
+	default:
+		panic("not a safe response type")
+	}
+}
+
+func (fakeDispatcher) ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}) error {
+	switch x := t.(type) {
+	case *template.Template:
+		return x.Execute(rw, data)
+	default:
+		panic("not a safe response type")
+	}
+}
+
+type fakeResponseWriter struct {
+	header http.Header
+	writer io.Writer
+	status int
+}
+
+func newFakeResponseWriter(w io.Writer) *fakeResponseWriter {
+	return &fakeResponseWriter{header: http.Header{}, writer: w, status: http.StatusOK}
+}
+
+func (r *fakeResponseWriter) Header() http.Header {
+	return r.header
+}
+
+func (r *fakeResponseWriter) WriteHeader(statusCode int) {
+	r.status = statusCode
+}
+
+func (r *fakeResponseWriter) Write(data []byte) (int, error) {
+	return r.writer.Write(data)
+}
+
+func TestValidHost(t *testing.T) {
+	mux := NewServeMux(fakeDispatcher{}, "foo.com")
+
+	h := HandlerFunc(func(w ResponseWriter, r *IncomingRequest) Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/", map[string]Handler{MethodGet: h})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Host = "foo.com"
+	b := &strings.Builder{}
+	rw := newFakeResponseWriter(b)
+
+	mux.serveHTTP(rw, req)
+
+	if got, want := b.String(), "&lt;h1&gt;Hello World!&lt;/h1&gt;"; got != want {
+		t.Errorf("response body: got %q want %q", got, want)
+	}
+}
+
+func TestInvalidHost(t *testing.T) {
+	mux := NewServeMux(fakeDispatcher{}, "foo.com")
+
+	h := HandlerFunc(func(w ResponseWriter, r *IncomingRequest) Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/", map[string]Handler{MethodGet: h})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Host = "bar.com"
+	b := &strings.Builder{}
+	rw := newFakeResponseWriter(b)
+
+	mux.serveHTTP(rw, req)
+
+	if got, want := b.String(), ""; got != want {
+		t.Errorf("response body: got %q want %q", got, want)
+	}
+
+	if want := 403; rw.status != want {
+		t.Errorf("rw.status: got %q want %q", rw.status, want)
+	}
+}
+
+func TestInvalidMethod(t *testing.T) {
+	mux := NewServeMux(fakeDispatcher{}, "foo.com")
+
+	h := HandlerFunc(func(w ResponseWriter, r *IncomingRequest) Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/", map[string]Handler{MethodGet: h})
+
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Host = "foo.com"
+	b := &strings.Builder{}
+	rw := newFakeResponseWriter(b)
+
+	mux.serveHTTP(rw, req)
+
+	if got, want := b.String(), ""; got != want {
+		t.Errorf("response body: got %q want %q", got, want)
+	}
+
+	if want := 405; rw.status != want {
+		t.Errorf("rw.status: got %q want %q", rw.status, want)
+	}
+}
+
+func TestHandlerRegistered(t *testing.T) {
+	d := fakeDispatcher{}
+	mux := NewServeMux(d, "foo.com")
+
+	registeredHandler := HandlerFunc(func(w ResponseWriter, r *IncomingRequest) Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/bar", map[string]Handler{MethodGet: registeredHandler})
+
+	req := httptest.NewRequest("GET", "/bar", nil)
+	req.Host = "foo.com"
+	ir := newIncomingRequest(req)
+
+	retrievedHandler, pattern := mux.Handler(&ir)
+
+	if want := "/bar"; pattern != want {
+		t.Errorf("mux.Handler(&ir) pattern got: %q want: %q", pattern, want)
+	}
+
+	b := &strings.Builder{}
+	fakeRW := newFakeResponseWriter(b)
+
+	rw := newResponseWriter(d, fakeRW)
+	retrievedHandler.ServeHTTP(rw, &ir)
+
+	if got, want := b.String(), "&lt;h1&gt;Hello World!&lt;/h1&gt;"; got != want {
+		t.Errorf("response body: got %q want %q", got, want)
+	}
+}
+
+func TestHandlerWrongMethod(t *testing.T) {
+	d := fakeDispatcher{}
+	mux := NewServeMux(d, "foo.com")
+
+	registeredHandler := HandlerFunc(func(w ResponseWriter, r *IncomingRequest) Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/bar", map[string]Handler{MethodGet: registeredHandler})
+
+	req := httptest.NewRequest("POST", "/bar", nil)
+	req.Host = "foo.com"
+	ir := newIncomingRequest(req)
+
+	retrievedHandler, pattern := mux.Handler(&ir)
+
+	if want := "/bar"; pattern != want {
+		t.Errorf("mux.Handler(&ir) pattern got: %q want: %q", pattern, want)
+	}
+
+	b := &strings.Builder{}
+	fakeRW := newFakeResponseWriter(b)
+
+	rw := newResponseWriter(d, fakeRW)
+	retrievedHandler.ServeHTTP(rw, &ir)
+
+	if want := 404; fakeRW.status != want {
+		t.Errorf("fakeRW.status: got %q want %q", fakeRW.status, want)
+	}
+}

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -184,3 +184,21 @@ func TestHandleTwoMethods(t *testing.T) {
 		t.Errorf("response body: got %q want %q", got, want)
 	}
 }
+
+func TestHandleSameMethodTwice(t *testing.T) {
+	d := testDispatcher{}
+	mux := NewServeMux(d, "foo.com")
+
+	registeredHandler := HandlerFunc(func(w ResponseWriter, r *IncomingRequest) Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/bar", MethodGet, registeredHandler)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf(`mux.Handle("/bar", MethodGet, registeredHandler) expected panic`)
+		}
+	}()
+
+	mux.Handle("/bar", MethodGet, registeredHandler)
+}

--- a/safehttp/prototype.go
+++ b/safehttp/prototype.go
@@ -33,5 +33,5 @@ func NewMachinery(h HandleFunc, d Dispatcher) *Machinery {
 func (m *Machinery) HandleRequest(w http.ResponseWriter, req *http.Request) {
 	rw := newResponseWriter(m.d, w)
 	ir := newIncomingRequest(req)
-	m.h(rw, &ir)
+	m.h(rw, ir)
 }


### PR DESCRIPTION
`safehttp.ServeMux` is a wrapper around the `http.ServeMux`. Currently, it supports registering based on methods and specifying the list of allowed domains.
Co-authored-by: mattiasgrenfeldt <grenfeldt@google.com>
Co-authored-by: mihalimara22 <maramihali@google.com>