### PR TITLE
Remove httptest.ResponseRecorder in form test

### DIFF
--- a/safehttp/dispatcher_test.go
+++ b/safehttp/dispatcher_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp_test
+
+import (
+	"net/http"
+	"text/template"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+)
+
+type testDispatcher struct{}
+
+func (d *testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
+	switch x := resp.(type) {
+	case safehtml.HTML:
+		_, err := rw.Write([]byte(x.String()))
+		return err
+	default:
+		panic("not a safe response type")
+	}
+}
+
+func (d *testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
+	switch x := t.(type) {
+	case *template.Template:
+		return x.Execute(rw, data)
+	default:
+		panic("not a safe response type")
+	}
+}

--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -86,10 +86,10 @@ func TestFormValidInt(t *testing.T) {
 			}
 			return safehttp.Result{}
 		}, &testDispatcher{})
-		recorder := httptest.NewRecorder()
-		m.HandleRequest(recorder, test.req)
-		if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-			t.Errorf("response status: got %v, want %v", respStatus, want)
+		rec := newResponseRecorder(&strings.Builder{})
+		m.HandleRequest(rec, test.req)
+		if want := 200; rec.status != want {
+			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
 }
@@ -174,10 +174,10 @@ func TestFormInvalidInt(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -240,10 +240,10 @@ func TestFormValidUint(t *testing.T) {
 			}
 			return safehttp.Result{}
 		}, &testDispatcher{})
-		recorder := httptest.NewRecorder()
-		m.HandleRequest(recorder, test.req)
-		if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-			t.Errorf("response status: got %v, want %v", respStatus, want)
+		rec := newResponseRecorder(&strings.Builder{})
+		m.HandleRequest(rec, test.req)
+		if want := 200; rec.status != want {
+			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
 }
@@ -326,10 +326,10 @@ func TestFormInvalidUint(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -405,10 +405,10 @@ func TestFormValidString(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -485,10 +485,10 @@ func TestFormValidFloat64(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -572,10 +572,10 @@ func TestFormInvalidFloat64(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -650,10 +650,10 @@ func TestFormValidBool(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -730,10 +730,10 @@ func TestFormInvalidBool(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -858,10 +858,10 @@ func TestFormValidSlice(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -982,10 +982,10 @@ func TestFormInvalidSlice(t *testing.T) {
 				}
 				return safehttp.Result{}
 			}, &testDispatcher{})
-			recorder := httptest.NewRecorder()
-			m.HandleRequest(recorder, req)
-			if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-				t.Errorf("response status: got %v, want %v", respStatus, want)
+			rec := newResponseRecorder(&strings.Builder{})
+			m.HandleRequest(rec, req)
+			if want := 200; rec.status != want {
+				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
 	}
@@ -1069,10 +1069,10 @@ func TestFormErrorHandling(t *testing.T) {
 			}
 			return safehttp.Result{}
 		}, &testDispatcher{})
-		recorder := httptest.NewRecorder()
-		m.HandleRequest(recorder, req)
-		if respStatus, want := recorder.Result().StatusCode, 200; respStatus != want {
-			t.Errorf("response status: got %v, want %v", respStatus, want)
+		rec := newResponseRecorder(&strings.Builder{})
+		m.HandleRequest(rec, req)
+		if want := 200; rec.status != want {
+			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
 }

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -25,7 +25,7 @@ import (
 
 type testDispatcher struct{}
 
-func (d *testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
+func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
 		_, err := rw.Write([]byte(x.String()))
@@ -35,7 +35,7 @@ func (d *testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) e
 	}
 }
 
-func (d *testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
 		return x.Execute(rw, data)

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -51,7 +51,10 @@ type responseRecorder struct {
 }
 
 func newResponseRecorder(w io.Writer) *responseRecorder {
-	return &responseRecorder{header: http.Header{}, writer: w, status: http.StatusOK}
+	return &responseRecorder{
+		writer: w,
+		status: http.StatusOK,
+	}
 }
 
 func (r *responseRecorder) Header() http.Header {

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/google/safehtml"
 )
 
+// This file contains a test dispatcher and a responserecorder
+// that implements a http.ResponseWriter. These are used for
+// testing.
+
 type testDispatcher struct{}
 
 func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -15,6 +15,7 @@
 package safehttp_test
 
 import (
+	"io"
 	"net/http"
 	"text/template"
 
@@ -41,4 +42,26 @@ func (d *testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Temp
 	default:
 		panic("not a safe response type")
 	}
+}
+
+type responseRecorder struct {
+	header http.Header
+	writer io.Writer
+	status int
+}
+
+func newResponseRecorder(w io.Writer) *responseRecorder {
+	return &responseRecorder{header: http.Header{}, writer: w, status: http.StatusOK}
+}
+
+func (r *responseRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *responseRecorder) WriteHeader(statusCode int) {
+	r.status = statusCode
+}
+
+func (r *responseRecorder) Write(data []byte) (int, error) {
+	return r.writer.Write(data)
 }


### PR DESCRIPTION
Fixes #27 in `/safehttp/form_test.go`. 