### PR TITLE
Removed Response from ServerError

### DIFF
--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -67,13 +67,13 @@ func NewPlugin() Plugin {
 // response.
 func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 	if p.MaxAge < 0 {
-		return w.ServerError(safehttp.StatusInternalServerError, "Internal Server Error")
+		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 
 	if !p.BehindProxy && r.TLS == nil {
 		u, err := url.Parse(r.URL.String())
 		if err != nil {
-			return w.ServerError(safehttp.StatusInternalServerError, "Internal Server Error")
+			return w.ServerError(safehttp.StatusInternalServerError)
 		}
 		u.Scheme = "https"
 		return w.Redirect(r, u.String(), safehttp.StatusMovedPermanently)
@@ -91,10 +91,10 @@ func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) 
 	h := w.Header()
 	if err := h.Set("Strict-Transport-Security", value.String()); err != nil {
 		// TODO(@mattiasgrenfeldt): Replace the response with an actual saferesponse somehow.
-		return w.ServerError(safehttp.StatusInternalServerError, "Internal Server Error")
+		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	if _, err := h.Claim("Strict-Transport-Security"); err != nil {
-		return w.ServerError(safehttp.StatusInternalServerError, "Internal Server Error")
+		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -90,7 +90,6 @@ func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) 
 	}
 	h := w.Header()
 	if err := h.Set("Strict-Transport-Security", value.String()); err != nil {
-		// TODO(@mattiasgrenfeldt): Replace the response with an actual saferesponse somehow.
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	if _, err := h.Claim("Strict-Transport-Security"); err != nil {

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -56,6 +56,9 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 // ServerError TODO
 func (w *ResponseWriter) ServerError(code StatusCode) Result {
 	if code < 500 || code >= 600 {
+		// TODO(@mattiasgrenfeldt, @mihalimara22, @kele, @empijei): Decide how it should
+		// be communicated to the user of the framework that they've called the wrong
+		// method.
 		return Result{}
 	}
 	http.Error(w.rw, http.StatusText(int(code)), int(code))

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -54,7 +54,11 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 }
 
 // ServerError TODO
-func (w *ResponseWriter) ServerError(code StatusCode, resp Response) Result {
+func (w *ResponseWriter) ServerError(code StatusCode) Result {
+	if code < 500 || code >= 600 {
+		return Result{}
+	}
+	http.Error(w.rw, http.StatusText(int(code)), int(code))
 	return Result{}
 }
 


### PR DESCRIPTION
Fixes #40 

`safehttp.ResponseWriter.ServerError` currently has the following signature:
```go
func (w *ResponseWriter) ServerError(code StatusCode, resp Response) Result
```
It takes a `safehttp.Response` as an argument, but there might be places where we want to respond with a server error without having the ability to create safe responses. For example if a plugin needs to interrupt the handling of an incoming request. We have therefore decided that **for now** `Response` should be removed from the `ServerError` signature.