### PR TITLE
Added HSTS plugin documentation and structure for adding documentation about other plugins in the future.

### DIFF
--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -74,7 +74,7 @@ address, following issues (not an exhaustive list):
 - [**CSP (content security policy)**](https://csp.withgoogle.com/docs/index.html) -
   e.g. by automatically adding script nonces to HTML responses, adding relevant
   security headers
-- **Transport Security** - e.g. by enforcing HSTS support
+- **Transport Security** - e.g. by [enforcing HSTS support](https://github.com/google/go-safeweb/blob/master/docs/plugins/hsts.md)
 - **IFraming** - e.g. by setting relevant HTTP headers to restrict framing or
   providing server-side support for origin selection
 - **Auth (access control)** - e.g. by providing infrastructure for plugging in

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -74,7 +74,7 @@ address, following issues (not an exhaustive list):
 - [**CSP (content security policy)**](https://csp.withgoogle.com/docs/index.html) -
   e.g. by automatically adding script nonces to HTML responses, adding relevant
   security headers
-- **Transport Security** - e.g. by [enforcing HSTS support](https://github.com/google/go-safeweb/blob/master/docs/plugins/hsts.md)
+- **Transport Security** - e.g. by [enforcing HSTS support](plugins/hsts.md)
 - **IFraming** - e.g. by setting relevant HTTP headers to restrict framing or
   providing server-side support for origin selection
 - **Auth (access control)** - e.g. by providing infrastructure for plugging in

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,7 +2,7 @@ _Authors: grenfeldt@google.com_
 
 # Plugins
 
-The framework will support plugins. Plugins can run before and after the request handlers. They provide a flexible way to address security issues by setting non-overridable security headers or interrupting and responding to incoming requests before they reach the handler.
+The framework will support plugins that run before and after the request handlers. They provide a flexible way to address security issues by setting non-overridable security headers or interrupting and responding to incoming requests before they reach the handler.
 
 ## Provided plugins
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,4 +4,4 @@ The framework will support plugins that run before and after the request handler
 
 ## Provided plugins
 
-- [HSTS](https://github.com/google/go-safeweb/blob/master/docs/plugins/hsts.md): Automatically redirects HTTP traffic to HTTPS and sets the `Strict-Transport-Security` header.
+- [HSTS](plugins/hsts.md): Automatically redirects HTTP traffic to HTTPS and sets the `Strict-Transport-Security` header.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,5 +1,3 @@
-_Authors: grenfeldt@google.com_
-
 # Plugins
 
 The framework will support plugins that run before and after the request handlers. They provide a flexible way to address security issues by setting non-overridable security headers or interrupting and responding to incoming requests before they reach the handler.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,9 @@
+_Authors: grenfeldt@google.com_
+
+# Plugins
+
+The framework will support plugins. Plugins can run before and after the request handlers. They provide a flexible way to address security issues by setting non-overridable security headers or interrupting and responding to incoming requests before they reach the handler.
+
+## Provided plugins
+
+- [HSTS](https://github.com/google/go-safeweb/blob/master/docs/plugins/hsts.md): Automatically redirects HTTP traffic to HTTPS and sets the `Strict-Transport-Security` header.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,7 +1,10 @@
 # Plugins
 
-The framework will support plugins that run before and after the request handlers. They provide a flexible way to address security issues by setting non-overridable security headers or interrupting and responding to incoming requests before they reach the handler.
+The framework supports plugins. They provide a flexible way to address security 
+issues by setting non-overridable security headers or interrupting and
+responding to incoming requests before they reach the handler.
 
 ## Provided plugins
 
-- [HSTS](plugins/hsts.md): Automatically redirects HTTP traffic to HTTPS and sets the `Strict-Transport-Security` header.
+- [HSTS](plugins/hsts.md): Automatically redirects HTTP traffic to HTTPS and
+sets the `Strict-Transport-Security` header.

--- a/docs/plugins/hsts.md
+++ b/docs/plugins/hsts.md
@@ -2,9 +2,14 @@ _Authors: grenfeldt@google.com_
 
 # HSTS Plugin
 
-HSTS<sup>1</sup> (HTTP Strict Transport Security) informs browsers that a website should only be accessed using HTTPS and not HTTP. This plugin enforces HSTS by redirecting all HTTP traffic to HTTPS and by setting the `Strict-Transport-Security` header on all outgoing HTTPS traffic.
+HSTS<sup>1</sup> (HTTP Strict Transport Security) informs browsers that a
+website should only be accessed using HTTPS and not HTTP. This plugin enforces
+HSTS by redirecting all HTTP traffic to HTTPS and by setting the
+`Strict-Transport-Security` header on all outgoing HTTPS traffic.
 
-1) HSTS: [RFC](https://tools.ietf.org/html/rfc6797), [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security), [Wikipedia](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security)
+1) HSTS: [RFC](https://tools.ietf.org/html/rfc6797),
+[MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security),
+[Wikipedia](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security)
 
 ## Usage
 
@@ -14,7 +19,16 @@ To construct the plugin with safe default settings, use: `hsts.NewPlugin()`.
 
 **Option (Default value)**: Description.
 
-- **MaxAge (`2 years`)**: The amount of time that the browser should remember to only access this site using HTTPS. The default value is 2 years as recommended by https://hstspreload.org/.
-- **IncludeSubDomains (`enabled`)**: When this is enabled, the browser knows that all subdomains should also only be accessed via HTTPS.
-- **Preload (`disabled`)**: If enabled, the domain is eligible to be added as part of the browser HSTS preload list. This is disabled by default to prevent adding domains to the preload list unintentionally. For more info, see: https://hstspreload.org/.
-- **BehindProxy (`disabled`)**: If this server is placed behind a proxy that terminates HTTPS traffic then only HTTP traffic will be received by this server. This option disables redirection of HTTP to HTTPS and always sends the `Strict-Transport-Security` header, even over HTTP.
+- **MaxAge (`2 years`)**: The amount of time that the browser should remember to
+only access this site using HTTPS. The default value is 2 years as recommended
+by https://hstspreload.org/.
+- **IncludeSubDomains (`enabled`)**: When this is enabled, the browser knows
+that all subdomains should also only be accessed via HTTPS.
+- **Preload (`disabled`)**: If enabled, the domain is eligible to be added as
+part of the browser HSTS preload list. This is disabled by default to prevent
+adding domains to the preload list unintentionally. For more info, see:
+https://hstspreload.org/.
+- **BehindProxy (`disabled`)**: If this server is placed behind a proxy that
+terminates HTTPS traffic then only HTTP traffic will be received by this server.
+This option disables redirection of HTTP to HTTPS and always sends the
+`Strict-Transport-Security` header, even over HTTP.

--- a/docs/plugins/hsts.md
+++ b/docs/plugins/hsts.md
@@ -2,7 +2,7 @@ _Authors: grenfeldt@google.com_
 
 # HSTS Plugin
 
-HSTS<sup>1</sup> (HTTP Strict Transport Security) tells browsers that they should only access your site using HTTPS and not HTTP. This plugin enforces HSTS by redirecting all HTTP traffic to HTTPS and by setting the `Strict-Transport-Security` header on all outgoing HTTPS traffic.
+HSTS<sup>1</sup> (HTTP Strict Transport Security) informs browsers that a website should only be accessed using HTTPS and not HTTP. This plugin enforces HSTS by redirecting all HTTP traffic to HTTPS and by setting the `Strict-Transport-Security` header on all outgoing HTTPS traffic.
 
 1) HSTS: [RFC](https://tools.ietf.org/html/rfc6797), [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security), [Wikipedia](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security)
 
@@ -16,5 +16,5 @@ To construct the plugin with safe default settings, use: `hsts.NewPlugin()`.
 
 - **MaxAge (`2 years`)**: The amount of time that the browser should remember to only access this site using HTTPS. The default value is 2 years since this is part of the deployment recommendations of https://hstspreload.org/.
 - **IncludeSubDomains (`enabled`)**: When this is enabled, the browser knows that all subdomains should also only be accessed via HTTPS.
-- **Preload (`disabled`)**: Must be enabled for this domain to eligible to be added to the browser HSTS preload list. For more info, see: https://hstspreload.org/. This is disabled by default so that your domain can't be added to the preload list unintentionally.
+- **Preload (`disabled`)**: Must be enabled for this domain to be eligible to be added to the browser HSTS preload list. For more info, see: https://hstspreload.org/. This is disabled by default so that your domain can't be added to the preload list unintentionally.
 - **BehindProxy (`disabled`)**: If this server is placed behind a proxy that terminates HTTPS then only HTTP traffic will be received. This option disables redirection of HTTP to HTTPS and always sends the `Strict-Transport-Security` header, even over HTTP.

--- a/docs/plugins/hsts.md
+++ b/docs/plugins/hsts.md
@@ -14,7 +14,7 @@ To construct the plugin with safe default settings, use: `hsts.NewPlugin()`.
 
 **Option (Default value)**: Description.
 
-- **MaxAge (`2 years`)**: The amount of time that the browser should remember to only access this site using HTTPS. The default value is 2 years since this is part of the deployment recommendations of https://hstspreload.org/.
+- **MaxAge (`2 years`)**: The amount of time that the browser should remember to only access this site using HTTPS. The default value is 2 years as recommended by https://hstspreload.org/.
 - **IncludeSubDomains (`enabled`)**: When this is enabled, the browser knows that all subdomains should also only be accessed via HTTPS.
-- **Preload (`disabled`)**: Must be enabled for this domain to be eligible to be added to the browser HSTS preload list. For more info, see: https://hstspreload.org/. This is disabled by default so that your domain can't be added to the preload list unintentionally.
-- **BehindProxy (`disabled`)**: If this server is placed behind a proxy that terminates HTTPS then only HTTP traffic will be received. This option disables redirection of HTTP to HTTPS and always sends the `Strict-Transport-Security` header, even over HTTP.
+- **Preload (`disabled`)**: If enabled, the domain is eligible to be added as part of the browser HSTS preload list. This is disabled by default to prevent adding domains to the preload list unintentionally. For more info, see: https://hstspreload.org/.
+- **BehindProxy (`disabled`)**: If this server is placed behind a proxy that terminates HTTPS traffic then only HTTP traffic will be received by this server. This option disables redirection of HTTP to HTTPS and always sends the `Strict-Transport-Security` header, even over HTTP.

--- a/docs/plugins/hsts.md
+++ b/docs/plugins/hsts.md
@@ -1,0 +1,20 @@
+_Authors: grenfeldt@google.com_
+
+# HSTS Plugin
+
+HSTS<sup>1</sup> (HTTP Strict Transport Security) tells browsers that they should only access your site using HTTPS and not HTTP. This plugin enforces HSTS by redirecting all HTTP traffic to HTTPS and by setting the `Strict-Transport-Security` header on all outgoing HTTPS traffic.
+
+1) HSTS: [RFC](https://tools.ietf.org/html/rfc6797), [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security), [Wikipedia](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security)
+
+## Usage
+
+To construct the plugin with safe default settings, use: `hsts.NewPlugin()`.
+
+## Options
+
+**Option (Default value)**: Description.
+
+- **MaxAge (`2 years`)**: The amount of time that the browser should remember to only access this site using HTTPS. The default value is 2 years since this is part of the deployment recommendations of https://hstspreload.org/.
+- **IncludeSubDomains (`enabled`)**: When this is enabled, the browser knows that all subdomains should also only be accessed via HTTPS.
+- **Preload (`disabled`)**: Must be enabled for this domain to eligible to be added to the browser HSTS preload list. For more info, see: https://hstspreload.org/. This is disabled by default so that your domain can't be added to the preload list unintentionally.
+- **BehindProxy (`disabled`)**: If this server is placed behind a proxy that terminates HTTPS then only HTTP traffic will be received. This option disables redirection of HTTP to HTTPS and always sends the `Strict-Transport-Security` header, even over HTTP.

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -28,7 +28,7 @@ import (
 type Plugin struct {
 	// MaxAge is the duration that the browser should remember
 	// that a site is only to be accessed using HTTPS. MaxAge
-	// must be positive.
+	// must be positive. Will be rounded to seconds before use.
 	MaxAge time.Duration
 
 	// DisableIncludeSubDomains disables the includeSubDomains directive.

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -28,7 +28,7 @@ import (
 type Plugin struct {
 	// MaxAge is the duration that the browser should remember
 	// that a site is only to be accessed using HTTPS. MaxAge
-	// must be positive. Will be rounded to seconds before use.
+	// must be positive. It will be rounded to seconds before use.
 	MaxAge time.Duration
 
 	// DisableIncludeSubDomains disables the includeSubDomains directive.


### PR DESCRIPTION
Fixes #51 

Documentation for the HSTS plugin has been added. Also added a `plugins.md` file which can be used to describe plugins more in the future. `plugins.md` also contains a list of all the plugins we have currently implemented.

I also updated a godoc comment in the `hsts.Plugin` struct.

The links will point to the right place once this is merged.