### PR TITLE
ResponeWriter.ClientError support

### DIFF
--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -53,6 +53,16 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	return Result{}
 }
 
+// ClientError TODO
+func (w *ResponseWriter) ClientError(code StatusCode) Result {
+	if code < 400 || code >= 500 {
+		// TODO(@mihalimara22): Replace this when we decide how to handle this case
+		panic("wrong method called")
+	}
+	http.Error(w.rw, http.StatusText(int(code)), int(code))
+	return Result{}
+}
+
 // ServerError TODO
 func (w *ResponseWriter) ServerError(code StatusCode, resp Response) Result {
 	return Result{}


### PR DESCRIPTION
Fixes #52 .

Adds functionality to the `safehttp.ResponseWriter` so that a response with the `4xx` status code can be returned when the request fails because of a client error.