### PR TITLE
Introduced the safehttptest to aid end-to-end testing

### DIFF
--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -32,7 +32,9 @@ type IncomingRequest struct {
 	URL       *url.URL
 }
 
-func newIncomingRequest(req *http.Request) *IncomingRequest {
+// NewIncomingRequest creates an safehttp.IncomingRequest
+// from an http.Request.
+func NewIncomingRequest(req *http.Request) *IncomingRequest {
 	return &IncomingRequest{
 		req:    req,
 		Header: newHeader(req.Header),

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -32,7 +32,7 @@ type IncomingRequest struct {
 	URL       *url.URL
 }
 
-// NewIncomingRequest creates an safehttp.IncomingRequest
+// NewIncomingRequest creates an IncomingRequest
 // from an http.Request.
 func NewIncomingRequest(req *http.Request) *IncomingRequest {
 	return &IncomingRequest{

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -141,5 +141,5 @@ func (m methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.ServeHTTP(newResponseWriter(m.disp, w), newIncomingRequest(r))
+	h.ServeHTTP(NewResponseWriter(m.disp, w), NewIncomingRequest(r))
 }

--- a/safehttp/prototype.go
+++ b/safehttp/prototype.go
@@ -31,7 +31,7 @@ func NewMachinery(h HandleFunc, d Dispatcher) *Machinery {
 
 // HandleRequest TODO
 func (m *Machinery) HandleRequest(w http.ResponseWriter, req *http.Request) {
-	rw := newResponseWriter(m.d, w)
-	ir := newIncomingRequest(req)
+	rw := NewResponseWriter(m.d, w)
+	ir := NewIncomingRequest(req)
 	m.h(rw, ir)
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -29,7 +29,9 @@ type ResponseWriter struct {
 	header Header
 }
 
-func newResponseWriter(d Dispatcher, rw http.ResponseWriter) ResponseWriter {
+// NewResponseWriter creates a safehttp.ResponseWriter from
+// a safehttp.Dispatcher and a http.ResponseWriter.
+func NewResponseWriter(d Dispatcher, rw http.ResponseWriter) ResponseWriter {
 	header := newHeader(rw.Header())
 	return ResponseWriter{d: d, rw: rw, header: header}
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -29,7 +29,7 @@ type ResponseWriter struct {
 	header Header
 }
 
-// NewResponseWriter creates a safehttp.ResponseWriter from
+// NewResponseWriter creates a ResponseWriter from
 // a safehttp.Dispatcher and a http.ResponseWriter.
 func NewResponseWriter(d Dispatcher, rw http.ResponseWriter) ResponseWriter {
 	header := newHeader(rw.Header())

--- a/safehttp/safehttptest/recorder.go
+++ b/safehttp/safehttptest/recorder.go
@@ -50,14 +50,14 @@ func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Templat
 // should be passed as part of the handler function in tests.
 type ResponseRecorder struct {
 	safehttp.ResponseWriter
-	rw *responseRecorder
+	rw *responseWriter
 	b  *strings.Builder
 }
 
 // NewResponseRecorder creates a ResponseRecorder from the default testDispatcher.
 func NewResponseRecorder() *ResponseRecorder {
 	var b strings.Builder
-	rw := newResponseRecorder(&b)
+	rw := newResponseWriter(&b)
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
@@ -69,7 +69,7 @@ func NewResponseRecorder() *ResponseRecorder {
 // provided safehttp.Dispatcher.
 func NewResponseRecorderFromDispatcher(d safehttp.Dispatcher) *ResponseRecorder {
 	var b strings.Builder
-	rw := newResponseRecorder(&b)
+	rw := newResponseWriter(&b)
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
@@ -92,28 +92,30 @@ func (r *ResponseRecorder) Body() string {
 	return r.b.String()
 }
 
-type responseRecorder struct {
+// responseWriter is an implementation of the http.ResponseWriter interface used
+// for constructing an HTTP response.
+type responseWriter struct {
 	header http.Header
 	writer io.Writer
 	status int
 }
 
-func newResponseRecorder(w io.Writer) *responseRecorder {
-	return &responseRecorder{
+func newResponseWriter(w io.Writer) *responseWriter {
+	return &responseWriter{
 		header: http.Header{},
 		writer: w,
 		status: http.StatusOK,
 	}
 }
 
-func (r *responseRecorder) Header() http.Header {
+func (r *responseWriter) Header() http.Header {
 	return r.header
 }
 
-func (r *responseRecorder) WriteHeader(statusCode int) {
+func (r *responseWriter) WriteHeader(statusCode int) {
 	r.status = statusCode
 }
 
-func (r *responseRecorder) Write(data []byte) (int, error) {
+func (r *responseWriter) Write(data []byte) (int, error) {
 	return r.writer.Write(data)
 }

--- a/safehttp/safehttptest/request.go
+++ b/safehttp/safehttptest/request.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttptest
+
+import (
+	"io"
+	"net/http/httptest"
+
+	"github.com/google/go-safeweb/safehttp"
+)
+
+// NewRequest returns a new incoming server Request,
+// suitable for passing to an http.Handler for testing.
+//
+// The target is the RFC 7230 "request-target": it may
+// be either a path or an absolute URL. If target is an
+// absolute URL, the host name from the URL is used.
+// Otherwise, "example.com" is used.
+//
+// The TLS field is set to a non-nil dummy value if
+// target has scheme "https".
+//
+// The Request.Proto is always HTTP/1.1.
+//
+// An empty method means "GET".
+//
+// The provided body may be nil. If the body is of type
+// *bytes.Reader, *strings.Reader, or *bytes.Buffer, the
+// Request.ContentLength is set.
+//
+// NewRequest panics on error for ease of use in testing,
+// where a panic is acceptable.
+//
+// To generate a client HTTP request instead of a server
+// request, see the NewRequest function in the net/http
+// package.
+func NewRequest(method, target string, body io.Reader) *safehttp.IncomingRequest {
+	req := httptest.NewRequest(method, target, body)
+	return safehttp.NewIncomingRequest(req)
+}


### PR DESCRIPTION
Fixes #46 

We implemented a test helper package to use when testing plugins. It uses the `httptest` package internally.