### PR TITLE
Implementing safehttp.URL type and a way of accessing URL query parameters

### DIFF
--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 )
@@ -29,7 +28,7 @@ type IncomingRequest struct {
 	Header    Header
 	parseOnce sync.Once
 	TLS       *tls.ConnectionState
-	URL       *url.URL
+	URL       URL
 }
 
 func newIncomingRequest(req *http.Request) *IncomingRequest {
@@ -37,7 +36,7 @@ func newIncomingRequest(req *http.Request) *IncomingRequest {
 		req:    req,
 		Header: newHeader(req.Header),
 		TLS:    req.TLS,
-		URL:    req.URL,
+		URL:    URL{url: req.URL},
 	}
 }
 

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -28,7 +28,7 @@ type IncomingRequest struct {
 	Header    Header
 	parseOnce sync.Once
 	TLS       *tls.ConnectionState
-	URL       URL
+	URL       *URL
 }
 
 func newIncomingRequest(req *http.Request) *IncomingRequest {
@@ -36,7 +36,7 @@ func newIncomingRequest(req *http.Request) *IncomingRequest {
 		req:    req,
 		Header: newHeader(req.Header),
 		TLS:    req.TLS,
-		URL:    URL{url: req.URL},
+		URL:    &URL{url: req.URL},
 	}
 }
 

--- a/safehttp/url.go
+++ b/safehttp/url.go
@@ -37,6 +37,7 @@ func (u URL) Query() (Form, error) {
 // The method uses the net/url.EscapedPath method to obtain the path.
 // See the net/url.EscapedPath method for more details.
 func (u URL) String() string {
+	// The escaping is perfomed by u.url.String()
 	return u.url.String()
 }
 

--- a/safehttp/url.go
+++ b/safehttp/url.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp
+
+import "net/url"
+
+// URL represents a parsed URL (technically, a URI reference).
+type URL struct {
+	url *url.URL
+}
+
+// Query parses the query string in the URL and returns a form
+// containing its values.
+func (u URL) Query() (Form, error) {
+	v, err := url.ParseQuery(u.url.RawQuery)
+	if err != nil {
+		return Form{}, err
+	}
+	return Form{values: map[string][]string(v)}, nil
+}
+
+// String reassembles the URL into a valid URL string.
+func (u URL) String() string {
+	return u.url.String()
+}
+
+// Host returns the host or the host:port of the URL.
+func (u URL) Host() string {
+	return u.url.Host
+}
+
+// Hostname returns the host of the URL, stripping any valid
+// port number if present.
+//
+// If the result is enclosed in square brackets, as literal IPv6
+// addresses are, the square brackets are removed from the result.
+func (u URL) Hostname() string {
+	return u.url.Hostname()
+}
+
+// Port returns the port part of the URL. If the
+// host doesn't contain a valid port number, Port returns an
+// empty string.
+func (u URL) Port() string {
+	return u.url.Port()
+}
+
+// Path returns the path of the URL.
+func (u URL) Path() string {
+	return u.url.Path
+}

--- a/safehttp/url.go
+++ b/safehttp/url.go
@@ -22,7 +22,8 @@ type URL struct {
 }
 
 // Query parses the query string in the URL and returns a form
-// containing its values.
+// containing its values. The returned error describes the first
+// decoding error encountered, if any.
 func (u URL) Query() (Form, error) {
 	v, err := url.ParseQuery(u.url.RawQuery)
 	if err != nil {
@@ -32,6 +33,9 @@ func (u URL) Query() (Form, error) {
 }
 
 // String reassembles the URL into a valid URL string.
+//
+// The method uses the net/url.EscapedPath method to obtain the path.
+// See the net/url.EscapedPath method for more details.
 func (u URL) String() string {
 	return u.url.String()
 }
@@ -58,6 +62,11 @@ func (u URL) Port() string {
 }
 
 // Path returns the path of the URL.
+//
+// Note that the path is stored in decoded form: /%47%6f%2f
+// becomes /Go/. A consequence is that it is impossible to tell
+// which slashes in the path were slashes in the raw URL and which
+// were %2f.
 func (u URL) Path() string {
 	return u.url.Path
 }

--- a/safehttp/url_test.go
+++ b/safehttp/url_test.go
@@ -24,7 +24,7 @@ func TestURLToString(t *testing.T) {
 
 	netURL, err := url.Parse(want)
 	if err != nil {
-		t.Errorf(`url.Parse("http://www.example.com/asdf?fruit=apple") got: %v want: nil`, err)
+		t.Fatalf(`url.Parse("http://www.example.com/asdf?fruit=apple") got: %v want: nil`, err)
 	}
 
 	u := URL{url: netURL}
@@ -55,7 +55,7 @@ func TestURLHost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			netURL, err := url.Parse(tt.url)
 			if err != nil {
-				t.Errorf("url.Parse(tt.url) got: %v want: nil", err)
+				t.Fatalf("url.Parse(tt.url) got: %v want: nil", err)
 			}
 
 			u := URL{url: netURL}
@@ -93,7 +93,7 @@ func TestURLHostname(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			netURL, err := url.Parse(tt.url)
 			if err != nil {
-				t.Errorf("url.Parse(tt.url) got: %v want: nil", err)
+				t.Fatalf("url.Parse(tt.url) got: %v want: nil", err)
 			}
 
 			u := URL{url: netURL}
@@ -131,7 +131,7 @@ func TestURLPort(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			netURL, err := url.Parse(tt.url)
 			if err != nil {
-				t.Errorf("url.Parse(tt.url) got: %v want: nil", err)
+				t.Fatalf("url.Parse(tt.url) got: %v want: nil", err)
 			}
 
 			u := URL{url: netURL}
@@ -145,7 +145,7 @@ func TestURLPort(t *testing.T) {
 func TestURLPath(t *testing.T) {
 	netURL, err := url.Parse("http://www.example.com/asdf?fruit=apple")
 	if err != nil {
-		t.Errorf(`url.Parse("http://www.example.com/asdf?fruit=apple") got: %v want: nil`, err)
+		t.Fatalf(`url.Parse("http://www.example.com/asdf?fruit=apple") got: %v want: nil`, err)
 	}
 
 	u := URL{url: netURL}
@@ -176,7 +176,7 @@ func TestURLQuery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			netURL, err := url.Parse(tt.url)
 			if err != nil {
-				t.Errorf("url.Parse(tt.url) got: %v want: nil", err)
+				t.Fatalf("url.Parse(tt.url) got: %v want: nil", err)
 			}
 
 			u := URL{url: netURL}
@@ -195,7 +195,7 @@ func TestURLQuery(t *testing.T) {
 func TestURLInvalidQuery(t *testing.T) {
 	netURL, err := url.Parse("http://www.example.com/asdf?%xx=abc")
 	if err != nil {
-		t.Errorf(`url.Parse("http://www.example.com/asdf?%%xx=abc") got: %v want: nil`, err)
+		t.Fatalf(`url.Parse("http://www.example.com/asdf?%%xx=abc") got: %v want: nil`, err)
 	}
 
 	u := URL{url: netURL}

--- a/safehttp/url_test.go
+++ b/safehttp/url_test.go
@@ -1,0 +1,205 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestURLToString(t *testing.T) {
+	want := "http://www.example.com/asdf?fruit=apple"
+
+	netURL, err := url.Parse(want)
+	if err != nil {
+		t.Errorf(`url.Parse("http://www.example.com/asdf?fruit=apple") got: %v want: nil`, err)
+	}
+
+	u := URL{url: netURL}
+	if got := u.String(); got != want {
+		t.Errorf("u.String() got: %v want: %v", got, want)
+	}
+}
+
+func TestURLHost(t *testing.T) {
+	var test = []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "Just host",
+			url:  "http://www.example.com/asdf?fruit=apple",
+			want: "www.example.com",
+		},
+		{
+			name: "Host and port",
+			url:  "http://www.example.com:1337/asdf?fruit=apple",
+			want: "www.example.com:1337",
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			netURL, err := url.Parse(tt.url)
+			if err != nil {
+				t.Errorf("url.Parse(tt.url) got: %v want: nil", err)
+			}
+
+			u := URL{url: netURL}
+			if got := u.Host(); got != tt.want {
+				t.Errorf("u.Host() got: %v want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURLHostname(t *testing.T) {
+	var test = []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "Just host",
+			url:  "http://www.example.com/asdf?fruit=apple",
+			want: "www.example.com",
+		},
+		{
+			name: "Host and port",
+			url:  "http://www.example.com:1337/asdf?fruit=apple",
+			want: "www.example.com",
+		},
+		{
+			name: "Ipv6 and port",
+			url:  "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:17000/asdf?fruit=apple",
+			want: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			netURL, err := url.Parse(tt.url)
+			if err != nil {
+				t.Errorf("url.Parse(tt.url) got: %v want: nil", err)
+			}
+
+			u := URL{url: netURL}
+			if got := u.Hostname(); got != tt.want {
+				t.Errorf("u.Hostname() got: %v want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURLPort(t *testing.T) {
+	var test = []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "Just host",
+			url:  "http://www.example.com/asdf?fruit=apple",
+			want: "",
+		},
+		{
+			name: "Host and port",
+			url:  "http://www.example.com:1337/asdf?fruit=apple",
+			want: "1337",
+		},
+		{
+			name: "HTTPS",
+			url:  "https://www.example.com/asdf?fruit=apple",
+			want: "",
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			netURL, err := url.Parse(tt.url)
+			if err != nil {
+				t.Errorf("url.Parse(tt.url) got: %v want: nil", err)
+			}
+
+			u := URL{url: netURL}
+			if got := u.Port(); got != tt.want {
+				t.Errorf("u.Port() got: %v want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURLPath(t *testing.T) {
+	netURL, err := url.Parse("http://www.example.com/asdf?fruit=apple")
+	if err != nil {
+		t.Errorf(`url.Parse("http://www.example.com/asdf?fruit=apple") got: %v want: nil`, err)
+	}
+
+	u := URL{url: netURL}
+	if got, want := u.Path(), "/asdf"; got != want {
+		t.Errorf("u.Path() got: %v want: %v", got, want)
+	}
+}
+
+func TestURLQuery(t *testing.T) {
+	var test = []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "Normal",
+			url:  "http://www.example.com/asdf?fruit=apple",
+			want: "apple",
+		},
+		{
+			name: "Empty",
+			url:  "http://www.example.com/asdf",
+			want: "",
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			netURL, err := url.Parse(tt.url)
+			if err != nil {
+				t.Errorf("url.Parse(tt.url) got: %v want: nil", err)
+			}
+
+			u := URL{url: netURL}
+			f, err := u.Query()
+			if err != nil {
+				t.Errorf("u.Query() got: %v want: nil", err)
+			}
+
+			if got := f.String("fruit", ""); got != tt.want {
+				t.Errorf(`f.String("fruit", "") got: %q want: %q`, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURLInvalidQuery(t *testing.T) {
+	netURL, err := url.Parse("http://www.example.com/asdf?%xx=abc")
+	if err != nil {
+		t.Errorf(`url.Parse("http://www.example.com/asdf?%%xx=abc") got: %v want: nil`, err)
+	}
+
+	u := URL{url: netURL}
+	if _, err = u.Query(); err == nil {
+		t.Error("u.Query() got: nil want: error")
+	}
+}


### PR DESCRIPTION
Fixes #33

A new `safehttp.URL` type is implemented. It is very similar to the `net/url.URL` type. 

You can now access URL query parameters by using the `safehttp.URL.Query` method which returns a `safehttp.Form` containing the values.

`net/url.URL` contains a lot more functionality than `safehttp.URL`. The rest of the functionality can be implemented later as needed.