### PR TITLE
Make it necessary to provide Content-Type to get a http.ResponseWriter in the dispatcher

### DIFF
--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -31,7 +31,7 @@ type testDispatcher struct{}
 func (testDispatcher) Write(c ResponseWriterContainer, resp Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -42,7 +42,7 @@ func (testDispatcher) Write(c ResponseWriterContainer, resp Response) error {
 func (testDispatcher) ExecuteTemplate(c ResponseWriterContainer, t Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -28,10 +28,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(h ResponseWriterHolder, resp Response) error {
+func (testDispatcher) Write(c ResponseWriterContainer, resp Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -39,10 +39,10 @@ func (testDispatcher) Write(h ResponseWriterHolder, resp Response) error {
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(h ResponseWriterHolder, t Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(c ResponseWriterContainer, t Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/safehttp/plugins/hsts/hsts_test.go
+++ b/safehttp/plugins/hsts/hsts_test.go
@@ -31,9 +31,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
+func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
+		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -41,9 +42,10 @@ func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) erro
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(h safehttp.ResponseWriterHolder, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
+		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/safehttp/plugins/hsts/hsts_test.go
+++ b/safehttp/plugins/hsts/hsts_test.go
@@ -31,10 +31,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Response) error {
+func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -42,10 +42,10 @@ func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Respo
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(h safehttp.ResponseWriterHolder, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(c safehttp.ResponseWriterContainer, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/safehttp/plugins/hsts/hsts_test.go
+++ b/safehttp/plugins/hsts/hsts_test.go
@@ -34,7 +34,7 @@ type testDispatcher struct{}
 func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(safehttp.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -45,7 +45,7 @@ func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Re
 func (testDispatcher) ExecuteTemplate(c safehttp.ResponseWriterContainer, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(safehttp.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -29,10 +29,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Response) error {
+func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -40,10 +40,10 @@ func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Respo
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(h safehttp.ResponseWriterHolder, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(c safehttp.ResponseWriterContainer, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -29,9 +29,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
+func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
+		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -39,9 +40,10 @@ func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) erro
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(h safehttp.ResponseWriterHolder, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
+		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -32,7 +32,7 @@ type testDispatcher struct{}
 func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(safehttp.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -43,7 +43,7 @@ func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Re
 func (testDispatcher) ExecuteTemplate(c safehttp.ResponseWriterContainer, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(safehttp.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -93,8 +93,8 @@ type ResponseWriterContainer struct {
 // Release releases the held http.ResponseWriter given that a status code
 // and a content type are provided. The status code and the content type are
 // written to the response before returning the ResponseWriter.
-func (c ResponseWriterContainer) Release(statusCode int, contentType string) http.ResponseWriter {
+func (c ResponseWriterContainer) Release(statusCode StatusCode, contentType string) http.ResponseWriter {
 	c.w.Header().Set("Content-Type", contentType)
-	c.w.WriteHeader(statusCode)
+	c.w.WriteHeader(int(statusCode))
 	return c.w
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -39,7 +39,7 @@ type Result struct{}
 
 // Write TODO
 func (w *ResponseWriter) Write(resp Response) Result {
-	if err := w.d.Write(ResponseWriterHolder{w: w.rw}, resp); err != nil {
+	if err := w.d.Write(ResponseWriterContainer{w: w.rw}, resp); err != nil {
 		panic("error")
 	}
 	return Result{}
@@ -47,7 +47,7 @@ func (w *ResponseWriter) Write(resp Response) Result {
 
 // WriteTemplate TODO
 func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
-	if err := w.d.ExecuteTemplate(ResponseWriterHolder{w: w.rw}, t, data); err != nil {
+	if err := w.d.ExecuteTemplate(ResponseWriterContainer{w: w.rw}, t, data); err != nil {
 		panic("error")
 	}
 	return Result{}
@@ -80,21 +80,21 @@ func (w ResponseWriter) Header() Header {
 
 // Dispatcher TODO
 type Dispatcher interface {
-	Write(h ResponseWriterHolder, resp Response) error
-	ExecuteTemplate(h ResponseWriterHolder, t Template, data interface{}) error
+	Write(c ResponseWriterContainer, resp Response) error
+	ExecuteTemplate(c ResponseWriterContainer, t Template, data interface{}) error
 }
 
-// ResponseWriterHolder holds an http.ResponseWriter until
+// ResponseWriterContainer holds an http.ResponseWriter until
 // a status code and a content type to be written is provided.
-type ResponseWriterHolder struct {
+type ResponseWriterContainer struct {
 	w http.ResponseWriter
 }
 
 // Release releases the held http.ResponseWriter given that a status code
 // and a content type is provided. The status code and the content type are
 // written to the response before returning the responsewriter.
-func (h ResponseWriterHolder) Release(statusCode int, contentType string) http.ResponseWriter {
-	h.w.Header().Set("Content-Type", contentType)
-	h.w.WriteHeader(statusCode)
-	return h.w
+func (c ResponseWriterContainer) Release(statusCode int, contentType string) http.ResponseWriter {
+	c.w.Header().Set("Content-Type", contentType)
+	c.w.WriteHeader(statusCode)
+	return c.w
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -85,14 +85,14 @@ type Dispatcher interface {
 }
 
 // ResponseWriterContainer holds an http.ResponseWriter until
-// a status code and a content type to be written is provided.
+// a status code and a content type to be written are provided.
 type ResponseWriterContainer struct {
 	w http.ResponseWriter
 }
 
 // Release releases the held http.ResponseWriter given that a status code
-// and a content type is provided. The status code and the content type are
-// written to the response before returning the responsewriter.
+// and a content type are provided. The status code and the content type are
+// written to the response before returning the ResponseWriter.
 func (c ResponseWriterContainer) Release(statusCode int, contentType string) http.ResponseWriter {
 	c.w.Header().Set("Content-Type", contentType)
 	c.w.WriteHeader(statusCode)

--- a/tests/integration/header/header_test.go
+++ b/tests/integration/header/header_test.go
@@ -29,9 +29,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
+func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
+		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -39,7 +40,7 @@ func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) erro
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(h safehttp.ResponseWriterHolder, t safehttp.Template, data interface{}) error {
 	return nil
 }
 

--- a/tests/integration/header/header_test.go
+++ b/tests/integration/header/header_test.go
@@ -29,10 +29,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Response) error {
+func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -40,7 +40,7 @@ func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Respo
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(h safehttp.ResponseWriterHolder, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(c safehttp.ResponseWriterContainer, t safehttp.Template, data interface{}) error {
 	return nil
 }
 

--- a/tests/integration/header/header_test.go
+++ b/tests/integration/header/header_test.go
@@ -32,7 +32,7 @@ type testDispatcher struct{}
 func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(safehttp.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -28,9 +28,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
+func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
+		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -38,9 +39,10 @@ func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) erro
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(h safehttp.ResponseWriterHolder, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
+		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -31,7 +31,7 @@ type testDispatcher struct{}
 func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(safehttp.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -42,7 +42,7 @@ func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Re
 func (testDispatcher) ExecuteTemplate(c safehttp.ResponseWriterContainer, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
-		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(safehttp.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -28,10 +28,10 @@ import (
 
 type testDispatcher struct{}
 
-func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Response) error {
+func (testDispatcher) Write(c safehttp.ResponseWriterContainer, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		_, err := rw.Write([]byte(x.String()))
 		return err
 	default:
@@ -39,10 +39,10 @@ func (testDispatcher) Write(h safehttp.ResponseWriterHolder, resp safehttp.Respo
 	}
 }
 
-func (testDispatcher) ExecuteTemplate(h safehttp.ResponseWriterHolder, t safehttp.Template, data interface{}) error {
+func (testDispatcher) ExecuteTemplate(c safehttp.ResponseWriterContainer, t safehttp.Template, data interface{}) error {
 	switch x := t.(type) {
 	case *template.Template:
-		rw := h.Release(http.StatusOK, "text/html; charset=utf-8")
+		rw := c.Release(http.StatusOK, "text/html; charset=utf-8")
 		return x.Execute(rw, data)
 	default:
 		panic("not a safe response type")


### PR DESCRIPTION
Addresses #60 

To ensure that a Content-Type is written to each response a wrapper called ResponseWriterHolder which wraps a http.ResponseWriter is introduced in the safehttp.Dispatcher interface. For the Dispatcher to get access to the responsewriter it first needs to call ResponseWriterHolder.Release with a specific status code and a content type. The responsewriter is then returned and can be used as normal.