### PR TITLE
Interceptors Infrastructure

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,10 @@
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/safehtml v0.0.2 h1:ZOt2VXg4x24bW0m2jtzAOkhoXV0iM8vNKc0paByCZqM=
 github.com/google/safehtml v0.0.2/go.mod h1:L4KWwDsUJdECRAEpZoBn3O64bQaywRscowZjJAzjHnU=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/safehttp/interceptor.go
+++ b/safehttp/interceptor.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp
+
+// Interceptor can be installed on a ServeMux in order to apply its
+// functionality on an IncomingRequest before it is sent to its corresponding
+// handler.
+type Interceptor interface {
+	// Before runs before the IncomingRequest is sent to the handler. If a
+	// response is written to the ResponseWriter, then the remaining
+	// interceptors and the handler won't execute.
+	Before(w ResponseWriter, r *IncomingRequest) Result
+}

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -118,14 +118,17 @@ func (m *ServeMux) Handle(pattern string, method string, h Handler) {
 	mh.handlers[method] = h
 }
 
-// Install installs interceps which will be applied to all requests coming to
-// the ServeMux. The key is used to access the interceptor and should be unique.
+// Install installs an Interceptor. Interceptor keys need to be unique. If an
+// Interceptor with the same key has already been installed, Install panics.
 //
 // TODO(@empijei, @grenfeldt, @kele, @mihalimara22): Right now you could install
 // the same interceptor twice with different keys, we need to figure out how
 // exactly we want to avoid that and how we define key uniqueness.
-func (m *ServeMux) Install(key string, p Interceptor) {
-	m.interceps[key] = p
+func (m *ServeMux) Install(key string, i Interceptor) {
+	if _, exists := m.interceps[key]; exists {
+		panic("interceptor with same key already installed")
+	}
+	m.interceps[key] = i
 }
 
 // ServeHTTP dispatches the request to the handler whose method matches the
@@ -134,7 +137,7 @@ func (m *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.mux.ServeHTTP(w, r)
 }
 
-// methodHandler is collection of handlers based on the request method.
+// methodHandler is a collection of handlers based on the request method.
 type methodHandler struct {
 	// Maps an HTTP method to its handler
 	handlers     map[string]Handler

--- a/safehttp/prototype.go
+++ b/safehttp/prototype.go
@@ -31,7 +31,7 @@ func NewMachinery(h HandleFunc, d Dispatcher) *Machinery {
 
 // HandleRequest TODO
 func (m *Machinery) HandleRequest(w http.ResponseWriter, req *http.Request) {
-	rw := NewResponseWriter(m.d, w)
+	rw := NewResponseWriter(m.d, w, nil)
 	ir := NewIncomingRequest(req)
 	m.h(rw, ir)
 }

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -56,6 +56,7 @@ type responseRecorder struct {
 
 func newResponseRecorder(w io.Writer) *responseRecorder {
 	return &responseRecorder{
+		header: http.Header{},
 		writer: w,
 		status: http.StatusOK,
 	}

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -42,7 +42,7 @@ func NewResponseWriter(d Dispatcher, rw http.ResponseWriter, muxInterceps map[st
 	}
 }
 
-// Interceptor returns the plugin associated with the given key.
+// Interceptor returns the interceptor associated with the given key.
 func (w *ResponseWriter) Interceptor(key string) Interceptor {
 	mp, ok := w.muxInterceps[key]
 	if !ok {

--- a/safehttp/safehttptest/recorder.go
+++ b/safehttp/safehttptest/recorder.go
@@ -61,7 +61,7 @@ func NewResponseRecorder() *ResponseRecorder {
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
-		ResponseWriter: safehttp.NewResponseWriter(testDispatcher{}, rw),
+		ResponseWriter: safehttp.NewResponseWriter(testDispatcher{}, rw, nil),
 	}
 }
 
@@ -73,7 +73,7 @@ func NewResponseRecorderFromDispatcher(d safehttp.Dispatcher) *ResponseRecorder 
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
-		ResponseWriter: safehttp.NewResponseWriter(d, rw),
+		ResponseWriter: safehttp.NewResponseWriter(d, rw, nil),
 	}
 }
 


### PR DESCRIPTION
Fixes #64 

Implemented the interceptors infrastructure that supports adding interceptors for `ServeMux`. To install an interceptor, the user needs to pass it to one of the installation functions, together with a key that will uniquely identify the interceptor and that the user will need to keep track of.  The `Interceptor.Before` function will run prior to accessing a handler for all the interceptors installed. Within the handler, interaction with an interceptor is possible by calling the `Interceptor()` getter function on the `ResponseWriter` and passing the interceptor key as a parameter to the function.