### PR TITLE
Added integration test which installs the HSTS plugin on a ServeMux and serves a request.

### DIFF
--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -65,7 +65,7 @@ func NewPlugin() Plugin {
 // The function redirects HTTP requests to HTTPS. When HTTPS traffic
 // is received the Strict-Transport-Security header is applied to the
 // response.
-func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+func (p Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 	if p.MaxAge < 0 {
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}

--- a/tests/integration/hsts/hsts_test.go
+++ b/tests/integration/hsts/hsts_test.go
@@ -73,8 +73,7 @@ func TestHSTSServeMuxInstall(t *testing.T) {
 	})
 	mux.Handle("/asdf", safehttp.MethodGet, handler)
 
-	p := hsts.NewPlugin()
-	mux.Install("hsts", &p)
+	mux.Install("hsts", hsts.NewPlugin())
 
 	b := strings.Builder{}
 	rr := newResponseRecorder(&b)

--- a/tests/integration/hsts/hsts_test.go
+++ b/tests/integration/hsts/hsts_test.go
@@ -1,0 +1,100 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hsts_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/plugins/hsts"
+	"github.com/google/safehtml"
+)
+
+type dispatcher struct{}
+
+func (dispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
+	switch x := resp.(type) {
+	case safehtml.HTML:
+		_, err := rw.Write([]byte(x.String()))
+		return err
+	default:
+		panic("not a safe response type")
+	}
+}
+
+func (dispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
+	return nil
+}
+
+type responseRecorder struct {
+	header http.Header
+	writer io.Writer
+	status int
+}
+
+func newResponseRecorder(w io.Writer) *responseRecorder {
+	return &responseRecorder{header: http.Header{}, writer: w, status: http.StatusOK}
+}
+
+func (r *responseRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *responseRecorder) WriteHeader(statusCode int) {
+	r.status = statusCode
+}
+
+func (r *responseRecorder) Write(data []byte) (int, error) {
+	return r.writer.Write(data)
+}
+
+func TestHSTSServeMuxInstall(t *testing.T) {
+	mux := safehttp.NewServeMux(&dispatcher{}, "foo.com")
+
+	handler := safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/asdf", safehttp.MethodGet, handler)
+
+	p := hsts.NewPlugin()
+	mux.Install("hsts", &p)
+
+	b := strings.Builder{}
+	rr := newResponseRecorder(&b)
+
+	req := httptest.NewRequest(http.MethodGet, "https://foo.com/asdf", nil)
+
+	mux.ServeHTTP(rr, req)
+
+	if want := 200; rr.status != want {
+		t.Errorf("rr.status got: %v want: %v", rr.status, want)
+	}
+
+	wantHeaders := map[string][]string{
+		"Strict-Transport-Security": {"max-age=63072000; includeSubDomains"},
+	}
+	if diff := cmp.Diff(wantHeaders, map[string][]string(rr.header)); diff != "" {
+		t.Errorf("rr.header mismatch (-want +got):\n%s", diff)
+	}
+
+	if got, want := b.String(), "&lt;h1&gt;Hello World!&lt;/h1&gt;"; got != want {
+		t.Errorf("b.String() got: %v want: %v", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #68 

Now that there is plugin infrastructure in the `ServeMux` there should be integration tests with the HSTS plugin.