### PR TITLE
Added functions for retrieving the context.Context and changing it for a safehttp.IncomingRequest

### DIFF
--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -147,14 +147,13 @@ func (r *IncomingRequest) Cookies() []*Cookie {
 	return res
 }
 
-// Context returns the http.Request Context. This is always non-nil and will
-// default to the background context.
+// Context returns the underlying http.Request context for a
+// safehttp.IncomingRequest. This is always non-nil and will default to the
+// background context.
 //
-// For outgoing client requests, the context controls cancellation.
-//
-// For incoming server requests, the context is canceled when the client's
-// connection closes, the request is canceled (with HTTP/2), or when the
-// ServeHTTP method returns.
+// The context is cancelled when the client's connection
+// closes, the request is canceled (with HTTP/2), or when the ServeHTTP method
+// returns.
 func (r *IncomingRequest) Context() context.Context {
 	return r.req.Context()
 }

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -15,6 +15,7 @@
 package safehttp
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -144,4 +145,25 @@ func (r *IncomingRequest) Cookies() []*Cookie {
 		res = append(res, &Cookie{wrapped: c})
 	}
 	return res
+}
+
+// Context returns the http.Request Context. This is always non-nil and will
+// default to the background context.
+//
+// For outgoing client requests, the context controls cancellation.
+//
+// For incoming server requests, the context is canceled when the client's
+// connection closes, the request is canceled (with HTTP/2), or when the
+// ServeHTTP method returns.
+func (r *IncomingRequest) Context() context.Context {
+	return r.req.Context()
+}
+
+// SetContext sets the context of the safehttp.IncomingRequest to ctx. The
+// provided context must be non-nil, otherwise the method will panic.
+func (r *IncomingRequest) SetContext(ctx context.Context) {
+	if ctx == nil {
+		panic("nil context")
+	}
+	r.req = r.req.WithContext(ctx)
 }

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -147,9 +147,9 @@ func (r *IncomingRequest) Cookies() []*Cookie {
 	return res
 }
 
-// Context returns the underlying http.Request context for a
-// safehttp.IncomingRequest. This is always non-nil and will default to the
-// background context.
+// Context returns the context of a safehttp.IncomingRequest. This is always
+// non-nil and will default to the background context. The context of a
+// safehttp.IncomingRequest is the context of the underlying http.Request.
 //
 // The context is cancelled when the client's connection
 // closes, the request is canceled (with HTTP/2), or when the ServeHTTP method

--- a/safehttp/incoming_request_test.go
+++ b/safehttp/incoming_request_test.go
@@ -176,19 +176,20 @@ func TestRequestSetValidContextWithValue(t *testing.T) {
 			t.Errorf("type match: got %v, want %v", ok, test.wantOk)
 		}
 		if diff := cmp.Diff(test.wantVal, got, cmp.AllowUnexported(pizza{})); diff != "" {
-			t.Errorf("ir.Context().Value(k): mismatch (-want +got): \n%s", diff)
+			t.Errorf("ir.Context().Value(test.key): mismatch (-want +got): \n%s", diff)
 		}
 	}
 }
 
 func TestRequestSetNilContext(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	ir := safehttp.NewIncomingRequest(req)
+
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf(`ir.SetContext(nil): expected panic`)
 		}
 	}()
 
-	req := httptest.NewRequest("GET", "/", nil)
-	ir := safehttp.NewIncomingRequest(req)
 	ir.SetContext(nil)
 }


### PR DESCRIPTION
Fixes #70 

Extended the `safehttp.IncomingRequest` API to add functions for getting and setting the context of the underlying `http.Request` as well as tests.