### PR TITLE
Added copyright linter to CI so that we don't forget copyright information at the top of source files.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,3 +77,22 @@ jobs:
     - name: Go Vet
       run: |
         go vet ./...
+
+  copyright:
+    name: copyright
+    runs-on: ubuntu-18.04
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Copyright linter
+      run: |
+        go get github.com/denis-tingajkin/go-header/cmd/go-header
+        find . -name "*.go" | xargs go-header

--- a/.go-header.yml
+++ b/.go-header.yml
@@ -1,0 +1,2 @@
+# Config for https://github.com/denis-tingajkin/go-header
+template-path: ./source-code-copyright-header.txt

--- a/source-code-copyright-header.txt
+++ b/source-code-copyright-header.txt
@@ -1,0 +1,13 @@
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/tests/formparams/form_params_test.go
+++ b/tests/formparams/form_params_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//  https://www.apache.org/licenses/LICENSE-2.0
+// 	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Fixes #81 

Uses [this](https://github.com/denis-tingajkin/go-header) to check that the copyright notice is present on all `.go` files.