### PR TITLE
Added copyright linter to CI so that we don't forget copyright information at the top of source files.

### DIFF
--- a/.github/workflows/copyright_linter.sh
+++ b/.github/workflows/copyright_linter.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+status=0
+lines=$(cat $1 | wc -l)
+for f in $(find . -name "*.go")
+do
+    diff=$(head $f -n $lines | diff $1 -)
+    if [ ! -z "$diff" ]
+    then
+        echo $f
+        echo "< want, > got"
+        echo "${diff}"
+        echo ""
+        status=1
+    fi
+done
+exit $status

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,3 +77,21 @@ jobs:
     - name: Go Vet
       run: |
         go vet ./...
+
+  copyright:
+    name: copyright
+    runs-on: ubuntu-18.04
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Copyright linter
+      run: |
+        ./.github/workflows/copyright_linter.sh ./.github/workflows/source-code-copyright-header.txt

--- a/.github/workflows/source-code-copyright-header.txt
+++ b/.github/workflows/source-code-copyright-header.txt
@@ -1,0 +1,13 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/tests/formparams/form_params_test.go
+++ b/tests/formparams/form_params_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//  https://www.apache.org/licenses/LICENSE-2.0
+// 	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Fixes #81 

We have forgotten to put the copyright notice in a couple of PRs. Now this won't happen.
