### PR TITLE
Static security header plugin added which sets XCTO and XXP.

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,3 +8,4 @@ responding to incoming requests before they reach the handler.
 
 - [HSTS](plugins/hsts.md): Automatically redirects HTTP traffic to HTTPS and
 sets the `Strict-Transport-Security` header.
+- [staticheaders](plugins/staticheaders.md): Sets the `X-Content-Type-Options` header and the `X-XSS-Protection` header.

--- a/docs/plugins/hsts.md
+++ b/docs/plugins/hsts.md
@@ -5,7 +5,7 @@ _Authors: grenfeldt@google.com_
 HSTS<sup>1</sup> (HTTP Strict Transport Security) informs browsers that a
 website should only be accessed using HTTPS and not HTTP. This plugin enforces
 HSTS by redirecting all HTTP traffic to HTTPS and by setting the
-`Strict-Transport-Security` header on all outgoing HTTPS traffic.
+`Strict-Transport-Security` header on all HTTPS responses.
 
 1) HSTS: [RFC](https://tools.ietf.org/html/rfc6797),
 [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security),

--- a/docs/plugins/staticheaders.md
+++ b/docs/plugins/staticheaders.md
@@ -2,10 +2,13 @@ _Authors: grenfeldt@google.com_
 
 # Static headers Plugin
 
-This plugin sets the `X-Content-Type-Options` header to `nosniff` and the `X-XSS-Protection` header to `0` on all outgoing responses.
+This plugin sets the `X-Content-Type-Options` header to `nosniff` and the
+`X-XSS-Protection` header to `0` on all outgoing responses.
 
 - `X-Content-Type-Options: nosniff` tells browsers to not try to sniff the
- `Content-Type` of responses.
+`Content-Type` of responses.
+[MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options).
 - `X-XSS-Protection: 0` tells the browser to disable any built in XSS filters.
 These built in XSS filters are unnecessary when CSP is implemented and can
 cause cross-site leaks.
+[MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection).

--- a/docs/plugins/staticheaders.md
+++ b/docs/plugins/staticheaders.md
@@ -8,4 +8,4 @@ This plugin sets the `X-Content-Type-Options` header to `nosniff` and the `X-XSS
  `Content-Type` of responses.
 - `X-XSS-Protection: 0` tells the browser to disable any built in XSS filters.
 These built in XSS filters are unnecessary when CSP is implemented and can
-cause cross site leaks.
+cause cross-site leaks.

--- a/docs/plugins/staticheaders.md
+++ b/docs/plugins/staticheaders.md
@@ -1,0 +1,11 @@
+_Authors: grenfeldt@google.com_
+
+# Static headers Plugin
+
+This plugin sets the `X-Content-Type-Options` header to `nosniff` and the `X-XSS-Protection` header to `0` on all outgoing responses.
+
+- `X-Content-Type-Options: nosniff` tells browsers to not try to sniff the
+ `Content-Type` of responses.
+- `X-XSS-Protection: 0` tells the browser to disable any built in XSS filters.
+These built in XSS filters are unnecessary when CSP is implemented and can
+cause cross site leaks.

--- a/docs/plugins/staticheaders.md
+++ b/docs/plugins/staticheaders.md
@@ -3,12 +3,12 @@ _Authors: grenfeldt@google.com_
 # Static headers Plugin
 
 This plugin sets the `X-Content-Type-Options` header to `nosniff` and the
-`X-XSS-Protection` header to `0` on all outgoing responses.
+`X-XSS-Protection` header to `0` on all responses.
 
 - `X-Content-Type-Options: nosniff` tells browsers to not try to sniff the
 `Content-Type` of responses.
 [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options).
 - `X-XSS-Protection: 0` tells the browser to disable any built in XSS filters.
-These built in XSS filters are unnecessary when CSP is implemented and can
-cause cross-site leaks.
+These built in XSS filters are unnecessary when other, stronger, protections are
+available and can introduce cross-site leaks vulnerabilities.
 [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection).

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package staticheaders
+
+import (
+	"github.com/google/go-safeweb/safehttp"
+)
+
+// Plugin claims and sets static headers on outgoing responses. The zero value
+// is ready to use.
+type Plugin struct{}
+
+// Before claims and sets the following headers:
+//  - X-Content-Type-Options: nosniff
+//  - X-XSS-Protection: 0
+func (Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+	h := w.Header()
+	setXCTO, err := h.Claim("X-Content-Type-Options")
+	if err != nil {
+		return w.ServerError(safehttp.StatusInternalServerError)
+	}
+	setXCTO([]string{"nosniff"})
+
+	setXXP, err := h.Claim("X-XSS-Protection")
+	if err != nil {
+		return w.ServerError(safehttp.StatusInternalServerError)
+	}
+	setXXP([]string{"0"})
+	return safehttp.Result{}
+}

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/go-safeweb/safehttp"
 )
 
-// Plugin claims and sets static headers on outgoing responses.
+// Plugin claims and sets static headers on responses.
 type Plugin struct{}
 
 // Before claims and sets the following headers:

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -18,8 +18,7 @@ import (
 	"github.com/google/go-safeweb/safehttp"
 )
 
-// Plugin claims and sets static headers on outgoing responses. The zero value
-// is ready to use.
+// Plugin claims and sets static headers on outgoing responses.
 type Plugin struct{}
 
 // Before claims and sets the following headers:

--- a/safehttp/plugins/staticheaders/staticheaders_test.go
+++ b/safehttp/plugins/staticheaders/staticheaders_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-safeweb/safehttp/safehttptest"
 )
 
-func TestWorkingAsIntended(t *testing.T) {
+func TestPlugin(t *testing.T) {
 	req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
 	rr := safehttptest.NewResponseRecorder()
 

--- a/safehttp/plugins/staticheaders/staticheaders_test.go
+++ b/safehttp/plugins/staticheaders/staticheaders_test.go
@@ -30,7 +30,7 @@ func TestPlugin(t *testing.T) {
 	p := staticheaders.Plugin{}
 	p.Before(rr.ResponseWriter, req)
 
-	if got, want := rr.Status(), 200; got != want {
+	if got, want := rr.Status(), int(safehttp.StatusOK); got != want {
 		t.Errorf("rr.Status() got: %v want: %v", got, want)
 	}
 
@@ -61,7 +61,7 @@ func TestAlreadyClaimed(t *testing.T) {
 			p := staticheaders.Plugin{}
 			p.Before(rr.ResponseWriter, req)
 
-			if got, want := rr.Status(), 500; got != want {
+			if got, want := rr.Status(), int(safehttp.StatusInternalServerError); got != want {
 				t.Errorf("rr.Status() got: %v want: %v", got, want)
 			}
 

--- a/safehttp/plugins/staticheaders/staticheaders_test.go
+++ b/safehttp/plugins/staticheaders/staticheaders_test.go
@@ -1,0 +1,81 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package staticheaders_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/plugins/staticheaders"
+	"github.com/google/go-safeweb/safehttp/safehttptest"
+)
+
+func TestAlreadyClaimed(t *testing.T) {
+	alreadyClaimed := []string{"X-Content-Type-Options", "X-XSS-Protection"}
+
+	for _, h := range alreadyClaimed {
+		t.Run(h, func(t *testing.T) {
+			req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+			rr := safehttptest.NewResponseRecorder()
+			if _, err := rr.ResponseWriter.Header().Claim(h); err != nil {
+				t.Fatalf("rr.ResponseWriter.Header().Claim(h) got: %v want: nil", err)
+			}
+
+			p := staticheaders.Plugin{}
+			p.Before(rr.ResponseWriter, req)
+
+			if got, want := rr.Status(), 500; got != want {
+				t.Errorf("rr.Status() got: %v want: %v", got, want)
+			}
+
+			wantHeaders := map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			}
+			if diff := cmp.Diff(wantHeaders, map[string][]string(rr.Header())); diff != "" {
+				t.Errorf("rr.Header() mismatch (-want +got):\n%s", diff)
+			}
+
+			if got, want := rr.Body(), "Internal Server Error\n"; got != want {
+				t.Errorf("rr.Body() got: %q want: %q", got, want)
+			}
+		})
+	}
+}
+
+func TestWorkingAsIntended(t *testing.T) {
+	req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+	rr := safehttptest.NewResponseRecorder()
+
+	p := staticheaders.Plugin{}
+	p.Before(rr.ResponseWriter, req)
+
+	if got, want := rr.Status(), 200; got != want {
+		t.Errorf("rr.Status() got: %v want: %v", got, want)
+	}
+
+	wantHeaders := map[string][]string{
+		"X-Content-Type-Options": {"nosniff"},
+		"X-Xss-Protection":       {"0"},
+	}
+	if diff := cmp.Diff(wantHeaders, map[string][]string(rr.Header())); diff != "" {
+		t.Errorf("rr.Header() mismatch (-want +got):\n%s", diff)
+	}
+
+	if got, want := rr.Body(), ""; got != want {
+		t.Errorf("rr.Body() got: %q want: %q", got, want)
+	}
+}

--- a/tests/integration/staticheaders/staticheaders_test.go
+++ b/tests/integration/staticheaders/staticheaders_test.go
@@ -1,0 +1,106 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package staticheaders_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/plugins/staticheaders"
+	"github.com/google/safehtml"
+)
+
+type dispatcher struct{}
+
+func (dispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
+	switch x := resp.(type) {
+	case safehtml.HTML:
+		_, err := rw.Write([]byte(x.String()))
+		return err
+	default:
+		panic("not a safe response type")
+	}
+}
+
+func (dispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
+	switch x := t.(type) {
+	case *template.Template:
+		return x.Execute(rw, data)
+	default:
+		panic("not a safe response type")
+	}
+}
+
+type responseRecorder struct {
+	header http.Header
+	writer io.Writer
+	status int
+}
+
+func newResponseRecorder(w io.Writer) *responseRecorder {
+	return &responseRecorder{header: http.Header{}, writer: w, status: http.StatusOK}
+}
+
+func (r *responseRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *responseRecorder) WriteHeader(statusCode int) {
+	r.status = statusCode
+}
+
+func (r *responseRecorder) Write(data []byte) (int, error) {
+	return r.writer.Write(data)
+}
+
+func TestServeMuxInstallStaticHeaders(t *testing.T) {
+	mux := safehttp.NewServeMux(dispatcher{}, "foo.com")
+
+	handler := safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/asdf", safehttp.MethodGet, handler)
+
+	mux.Install("staticheaders", staticheaders.Plugin{})
+
+	b := strings.Builder{}
+	rr := newResponseRecorder(&b)
+
+	req := httptest.NewRequest(http.MethodGet, "https://foo.com/asdf", nil)
+
+	mux.ServeHTTP(rr, req)
+
+	if want := 200; rr.status != want {
+		t.Errorf("rr.status got: %v want: %v", rr.status, want)
+	}
+
+	wantHeaders := map[string][]string{
+		"X-Content-Type-Options": {"nosniff"},
+		"X-Xss-Protection":       {"0"},
+	}
+	if diff := cmp.Diff(wantHeaders, map[string][]string(rr.header)); diff != "" {
+		t.Errorf("rr.header mismatch (-want +got):\n%s", diff)
+	}
+
+	if got, want := b.String(), "&lt;h1&gt;Hello World!&lt;/h1&gt;"; got != want {
+		t.Errorf("b.String() got: %v want: %v", got, want)
+	}
+}

--- a/tests/integration/staticheaders/staticheaders_test.go
+++ b/tests/integration/staticheaders/staticheaders_test.go
@@ -88,7 +88,7 @@ func TestServeMuxInstallStaticHeaders(t *testing.T) {
 
 	mux.ServeHTTP(rr, req)
 
-	if want := 200; rr.status != want {
+	if want := int(safehttp.StatusOK); rr.status != want {
 		t.Errorf("rr.status got: %v want: %v", rr.status, want)
 	}
 


### PR DESCRIPTION
Fixes #80 

This plugin sets
```
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
```
on all outgoing responses.

There is currently no way to disable setting these headers.