### PR TITLE
safesql: Add first implementation.

### DIFF
--- a/safesql/internal/raw/raw.go
+++ b/safesql/internal/raw/raw.go
@@ -13,8 +13,14 @@
 // limitations under the License.
 
 // Package raw is used to provide a bypass mechanism to implement unchecked and legacy conversions packages.
+// This package works as a proxy between safesql and any other "conversions" package.
+//
+// The way it functions is to expect safesql to provide the unexported constructors for TrustedSQLString at init() time.
+// Since this package is in internal/ it can only be imported by a parent package, so it is known at compile time that
+// these constructors are not unsafely passed around.
 package raw
 
 // TrustedSQLString is the constructor for a TrustedSQLString to be used by the unchecked and legacy conversions packages.
 // This variable will be assigned by the safesql package at init time.
+// The reason why this is an empty interface is to avoid cyclic dependency between safeslq and this package.
 var TrustedSQLString interface{}

--- a/safesql/internal/raw/raw.go
+++ b/safesql/internal/raw/raw.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package raw is used to provide a bypass mechanism to implement unchecked and legacy conversions packages.
+package raw
+
+// TrustedSQLString is the constructor for a TrustedSQLString to be used by the unchecked and legacy conversions packages.
+// This variable will be assigned by the safesql package at init time.
+var TrustedSQLString interface{}

--- a/safesql/legacyconversions/legacyconversions.go
+++ b/safesql/legacyconversions/legacyconversions.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package legacyconversions provides functions to create values of package safesql types from plain strings.
+// Use of these functions could potentially result in instances of safesql types that violate their type contracts, and hence result in security vulnerabilities.
+// This package should only be used to gradually migrate to use the safesql package but every use of it should eventually be removed as it represents a security risk.
+package legacyconversions
+
+import (
+	"github.com/google/go-safeweb/safesql"
+	"github.com/google/go-safeweb/safesql/internal/raw"
+)
+
+var trustedSQLStringCtor = raw.TrustedSQLString.(func(string) safesql.TrustedSQLString)
+
+// RiskilyAssumeTrustedSQLString riskily promotes the given string to a trusted string.
+// Uses of this function should only be used when migrating to use safesql and should eventually be removed.
+func RiskilyAssumeTrustedSQLString(trusted string) safesql.TrustedSQLString {
+	return trustedSQLStringCtor(trusted)
+}

--- a/safesql/safesql.go
+++ b/safesql/safesql.go
@@ -17,6 +17,18 @@
 // The concept of this package is to provide "safe by construction" SQL strings so that code that would accidentally introduce
 // SQL injection vulnerabilities does not compile.
 //
+// Examples
+// Code like the following is trivial to migrate from sql to safesql:
+// 	db.Query("SELECT ...", args...)
+// The only change required would be to promote the string literal to a trusted string:
+// 	db.Query(safesql.New("SELECT ...", args...)
+// For more complicated cases it might be needed to use the helper functions like Join and Concat.
+// If the queries for the service are stored in a trusted runtime-only source that cannot be controlled by a user
+// the uncheckedconversions package can be used to assert that those strings are under the programmer control.
+// Note that unchecked conversions should be very limited, ideally never used, as they pose a security risk.
+//
+// Note on missing documentation
+//
 // For documentation on methods and types that wrap the standard ones please refer to the stdlib package doc instead, as
 // all the types exported by this package are tiny wrappers around the standard ones and thus follow their behavior.
 // The only relevant difference is that functions accept TrustedSQLString instances instead of plain "strings" and that some

--- a/safesql/safesql.go
+++ b/safesql/safesql.go
@@ -21,7 +21,7 @@
 // Code like the following is trivial to migrate from sql to safesql:
 // 	db.Query("SELECT ...", args...)
 // The only change required would be to promote the string literal to a trusted string:
-// 	db.Query(safesql.New("SELECT ...", args...)
+// 	db.Query(safesql.New("SELECT ..."), args...)
 // For more complicated cases it might be needed to use the helper functions like Join and Concat.
 // If the queries for the service are stored in a trusted runtime-only source that cannot be controlled by a user
 // the uncheckedconversions package can be used to assert that those strings are under the programmer control.

--- a/safesql/safesql.go
+++ b/safesql/safesql.go
@@ -58,12 +58,12 @@ type TrustedSQLString struct {
 // a string literal or an untyped string const.
 func New(text stringConstant) TrustedSQLString { return TrustedSQLString{string(text)} }
 
-// NewFromUint64 constructs a TrustedSQLString from an int64.
+// NewFromUint64 constructs a TrustedSQLString from a uint64.
 func NewFromUint64(i uint64) TrustedSQLString { return TrustedSQLString{strconv.FormatUint(i, 10)} }
 
 // TrustedSQLStringConcat concatenates the given trusted SQL strings into a trusted string.
 //
-// Note: this function should not be abused to create arbitrary queries from user input, but it is just
+// Note: this function should not be abused to create arbitrary queries from user input, it is just
 // intended as a helper to compose queries at runtime to avoid redundant constants.
 func TrustedSQLStringConcat(ss ...TrustedSQLString) TrustedSQLString {
 	return TrustedSQLStringJoin(ss, TrustedSQLString{})
@@ -71,7 +71,7 @@ func TrustedSQLStringConcat(ss ...TrustedSQLString) TrustedSQLString {
 
 // TrustedSQLStringJoin joins the given trusted SQL with the given separator the same way strings.Join would.
 //
-// Note: this function should not be abused to create arbitrary queries from user input, but it is just
+// Note: this function should not be abused to create arbitrary queries from user input, it is just
 // intended as a helper to compose queries at runtime to avoid redundant constants.
 func TrustedSQLStringJoin(ss []TrustedSQLString, sep TrustedSQLString) TrustedSQLString {
 	accum := make([]string, 0, len(ss))

--- a/safesql/safesql.go
+++ b/safesql/safesql.go
@@ -1,0 +1,83 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package safesql implements a safe version of the standard sql package while trying to keep the API as similar as
+// possible to the original one.
+// The concept of this package is to provide "safe by construction" SQL strings so that code that would accidentally introduce
+// SQL injection vulnerabilities does not compile.
+//
+// For documentation on methods and types that wrap the standard ones please refer to the stdlib package doc instead, as
+// all the types exported by this package are tiny wrappers around the standard ones and thus follow their behavior.
+// The only relevant difference is that functions accept TrustedSQLString instances instead of plain "strings" and that some
+// dangerous methods have been removed.
+package safesql
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/google/go-safeweb/safesql/internal/raw"
+)
+
+func init() {
+	raw.TrustedSQLString = func(unsafe string) TrustedSQLString { return TrustedSQLString{unsafe} }
+}
+
+type stringConstant string
+
+// TrustedSQLString is a string representing a SQL query that is known to be safe and not contain potentially malicious inputs.
+type TrustedSQLString struct {
+	s string
+}
+
+// New constructs a TrustedSQLString from a compile-time constant string.
+// Since the stringConstant type is unexported the only way to call this function outside of this package is to pass
+// a string literal or an untyped string const.
+func New(text stringConstant) TrustedSQLString { return TrustedSQLString{string(text)} }
+
+// NewFromUint64 constructs a TrustedSQLString from an int64.
+func NewFromUint64(i uint64) TrustedSQLString { return TrustedSQLString{strconv.FormatUint(i, 10)} }
+
+// TrustedSQLStringConcat concatenates the given trusted SQL strings into a trusted string.
+//
+// Note: this function should not be abused to create arbitrary queries from user input, but it is just
+// intended as a helper to compose queries at runtime to avoid redundant constants.
+func TrustedSQLStringConcat(ss ...TrustedSQLString) TrustedSQLString {
+	return TrustedSQLStringJoin(ss, TrustedSQLString{})
+}
+
+// TrustedSQLStringJoin joins the given trusted SQL with the given separator the same way strings.Join would.
+//
+// Note: this function should not be abused to create arbitrary queries from user input, but it is just
+// intended as a helper to compose queries at runtime to avoid redundant constants.
+func TrustedSQLStringJoin(ss []TrustedSQLString, sep TrustedSQLString) TrustedSQLString {
+	accum := make([]string, 0, len(ss))
+	for _, s := range ss {
+		accum = append(accum, s.s)
+	}
+	return TrustedSQLString{strings.Join(accum, sep.s)}
+}
+func (t TrustedSQLString) String() string {
+	return t.s
+}
+
+// TrustedSQLStringSplit functions as strings.Split but for TrustedSQLStrings.
+func TrustedSQLStringSplit(s TrustedSQLString, sep TrustedSQLString) []TrustedSQLString {
+	spl := strings.Split(s.s, sep.s)
+	accum := make([]TrustedSQLString, 0, len(spl))
+	for _, s := range spl {
+		accum = append(accum, TrustedSQLString{s})
+	}
+	return accum
+}

--- a/safesql/safesql_test.go
+++ b/safesql/safesql_test.go
@@ -1,0 +1,121 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safesql
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestTrustedSQLConcat(t *testing.T) {
+	var tests = []struct {
+		name string
+		ss   []TrustedSQLString
+		want TrustedSQLString
+	}{
+		{name: "nothing"},
+		{
+			name: "one word",
+			ss:   []TrustedSQLString{New("foo")},
+			want: New("foo"),
+		},
+		{
+			name: "two words",
+			ss:   []TrustedSQLString{New("foo"), New("ffa")},
+			want: New("fooffa"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TrustedSQLStringConcat(tt.ss...)
+			if got != tt.want {
+				t.Errorf("got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+func TestTrustedSQLJoin(t *testing.T) {
+	var tests = []struct {
+		name string
+		ss   []TrustedSQLString
+		sep  TrustedSQLString
+		want TrustedSQLString
+	}{
+		{name: "nothing"},
+		{
+			name: "one word",
+			ss:   []TrustedSQLString{New("foo")},
+			sep:  New("bar"),
+			want: New("foo"),
+		},
+		{
+			name: "two words",
+			ss:   []TrustedSQLString{New("foo"), New("ffa")},
+			sep:  New("bar"),
+			want: New("foobarffa"),
+		},
+		{
+			name: "empty sep",
+			ss:   []TrustedSQLString{New("foo"), New("ffa")},
+			want: New("fooffa"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TrustedSQLStringJoin(tt.ss, tt.sep)
+			if got != tt.want {
+				t.Errorf("got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrustedSQLStringSplit(t *testing.T) {
+	var tests = []struct {
+		name string
+		in   TrustedSQLString
+		sep  TrustedSQLString
+		want []TrustedSQLString
+	}{
+		{name: "nothing"},
+		{
+			name: "no sep",
+			in:   New("foo"),
+			want: []TrustedSQLString{New("foo")},
+			sep:  New("bar"),
+		},
+		{
+			name: "two words",
+			in:   New("foobarffa"),
+			sep:  New("bar"),
+			want: []TrustedSQLString{New("foo"), New("ffa")},
+		},
+		{
+			name: "empty sep",
+			in:   New("foo"),
+			want: []TrustedSQLString{New("f"), New("o"), New("o")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TrustedSQLStringSplit(tt.in, tt.sep)
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty(), cmp.AllowUnexported(TrustedSQLString{})); diff != "" {
+				t.Errorf("-want +got: %s", diff)
+			}
+		})
+	}
+}

--- a/safesql/safesql_test.go
+++ b/safesql/safesql_test.go
@@ -95,8 +95,8 @@ func TestTrustedSQLStringSplit(t *testing.T) {
 		{
 			name: "no sep",
 			in:   New("foo"),
-			want: []TrustedSQLString{New("foo")},
 			sep:  New("bar"),
+			want: []TrustedSQLString{New("foo")},
 		},
 		{
 			name: "two words",

--- a/safesql/sqlwrap.go
+++ b/safesql/sqlwrap.go
@@ -1,0 +1,158 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safesql
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"time"
+)
+
+func Drivers() []string { return sql.Drivers() }
+
+func Register(name string, driver driver.Driver) { sql.Register(name, driver) }
+
+type ColumnType = sql.ColumnType
+type DBStats = sql.DBStats
+type IsolationLevel = sql.IsolationLevel
+type NamedArg = sql.NamedArg
+type NullBool = sql.NullBool
+type NullFloat64 = sql.NullFloat64
+type NullInt32 = sql.NullInt32
+type NullInt64 = sql.NullInt64
+type NullString = sql.NullString
+type NullTime = sql.NullTime
+type Out = sql.Out
+type RawBytes = sql.RawBytes
+type Result = sql.Result
+type Row = sql.Row
+type Rows = sql.Rows
+type Scanner = sql.Scanner
+type Stmt = sql.Stmt
+type TxOptions = sql.TxOptions
+
+// Conn behaves as the standard SQL package one, with the exception that it does not implement the `Raw` method for security reasons.
+type Conn struct {
+	c *sql.Conn
+}
+
+/*
+func (c *Conn) Raw(f func(driverConn interface{}) error) (err error) {
+	// Dangerous to expose
+}
+*/
+func (c Conn) BeginTx(ctx context.Context, opts *TxOptions) (Tx, error) {
+	t, err := c.c.BeginTx(ctx, opts)
+	return Tx{t}, err
+}
+func (c Conn) Close() error { return c.c.Close() }
+func (c Conn) ExecContext(ctx context.Context, query TrustedSQLString, args ...interface{}) (Result, error) {
+	return c.c.ExecContext(ctx, query.s, args)
+}
+func (c Conn) PingContext(ctx context.Context) error { return c.c.PingContext(ctx) }
+func (c Conn) PrepareContext(ctx context.Context, query TrustedSQLString) (*Stmt, error) {
+	return c.c.PrepareContext(ctx, query.s)
+}
+func (c Conn) QueryContext(ctx context.Context, query TrustedSQLString, args ...interface{}) (*Rows, error) {
+	return c.c.QueryContext(ctx, query.s, args)
+}
+func (c Conn) QueryRowContext(ctx context.Context, query TrustedSQLString, args ...interface{}) *Row {
+	return c.c.QueryRowContext(ctx, query.s, args)
+}
+
+// DB behaves as the standard SQL package one, with the exception that it does not implement the `Driver` method for security reasons.
+type DB struct {
+	db *sql.DB
+}
+
+func Open(driverName, dataSourceName string) (DB, error) {
+	db, err := sql.Open(driverName, dataSourceName)
+	return DB{db}, err
+}
+func OpenDB(c driver.Connector) DB { return DB{sql.OpenDB(c)} }
+func (db DB) Begin() (Tx, error) {
+	t, err := db.db.Begin()
+	return Tx{t}, err
+}
+func (db DB) BeginTx(ctx context.Context, opts *TxOptions) (Tx, error) {
+	t, err := db.db.BeginTx(ctx, opts)
+	return Tx{t}, err
+}
+func (db DB) Close() error { return db.db.Close() }
+func (db DB) Conn(ctx context.Context) (Conn, error) {
+	c, err := db.db.Conn(ctx)
+	return Conn{c}, err
+}
+func (db DB) Exec(query TrustedSQLString, args ...interface{}) (Result, error) {
+	return db.db.Exec(query.s, args)
+}
+func (db DB) ExecContext(ctx context.Context, query TrustedSQLString, args ...interface{}) (Result, error) {
+	return db.db.ExecContext(ctx, query.s, args)
+}
+func (db DB) Ping() error                                   { return db.db.Ping() }
+func (db DB) PingContext(ctx context.Context) error         { return db.db.PingContext(ctx) }
+func (db DB) Prepare(query TrustedSQLString) (*Stmt, error) { return db.db.Prepare(query.s) }
+func (db DB) PrepareContext(ctx context.Context, query TrustedSQLString) (*Stmt, error) {
+	return db.db.PrepareContext(ctx, query.s)
+}
+func (db DB) Query(query TrustedSQLString, args ...interface{}) (*Rows, error) {
+	return db.db.Query(query.s, args)
+}
+func (db DB) QueryContext(ctx context.Context, query TrustedSQLString, args ...interface{}) (*Rows, error) {
+	return db.db.QueryContext(ctx, query.s, args)
+}
+func (db DB) QueryRow(query TrustedSQLString, args ...interface{}) *Row {
+	return db.db.QueryRow(query.s, args)
+}
+func (db DB) QueryRowContext(ctx context.Context, query TrustedSQLString, args ...interface{}) *Row {
+	return db.db.QueryRowContext(ctx, query.s, args)
+}
+func (db DB) SetConnMaxIdleTime(d time.Duration) { db.db.SetConnMaxIdleTime(d) }
+func (db DB) SetConnMaxLifetime(d time.Duration) { db.db.SetConnMaxLifetime(d) }
+func (db DB) SetMaxIdleConns(n int)              { db.db.SetMaxIdleConns(n) }
+func (db DB) SetMaxOpenConns(n int)              { db.db.SetMaxOpenConns(n) }
+func (db DB) Stats() DBStats                     { return db.db.Stats() }
+
+type Tx struct {
+	tx *sql.Tx
+}
+
+func (tx Tx) Commit() error { return tx.tx.Commit() }
+func (tx Tx) Exec(query TrustedSQLString, args ...interface{}) (Result, error) {
+	return tx.tx.Exec(query.s, args)
+}
+func (tx Tx) ExecContext(ctx context.Context, query TrustedSQLString, args ...interface{}) (Result, error) {
+	return tx.tx.ExecContext(ctx, query.s, args)
+}
+func (tx Tx) Prepare(query TrustedSQLString) (*Stmt, error) { return tx.tx.Prepare(query.s) }
+func (tx Tx) PrepareContext(ctx context.Context, query TrustedSQLString) (*Stmt, error) {
+	return tx.tx.PrepareContext(ctx, query.s)
+}
+func (tx Tx) Query(query TrustedSQLString, args ...interface{}) (*Rows, error) {
+	return tx.tx.Query(query.s, args)
+}
+func (tx Tx) QueryContext(ctx context.Context, query TrustedSQLString, args ...interface{}) (*Rows, error) {
+	return tx.tx.QueryContext(ctx, query.s, args)
+}
+func (tx Tx) QueryRow(query TrustedSQLString, args ...interface{}) *Row {
+	return tx.tx.QueryRow(query.s, args)
+}
+func (tx Tx) QueryRowContext(ctx context.Context, query TrustedSQLString, args ...interface{}) *Row {
+	return tx.tx.QueryRowContext(ctx, query.s, args)
+}
+func (tx Tx) Rollback() error                                   { return tx.tx.Rollback() }
+func (tx Tx) Stmt(stmt *Stmt) *Stmt                             { return tx.tx.Stmt(stmt) }
+func (tx Tx) StmtContext(ctx context.Context, stmt *Stmt) *Stmt { return tx.tx.StmtContext(ctx, stmt) }

--- a/safesql/sqlwrap.go
+++ b/safesql/sqlwrap.go
@@ -120,7 +120,8 @@ func (db DB) QueryRow(query TrustedSQLString, args ...interface{}) *Row {
 func (db DB) QueryRowContext(ctx context.Context, query TrustedSQLString, args ...interface{}) *Row {
 	return db.db.QueryRowContext(ctx, query.s, args)
 }
-func (db DB) SetConnMaxIdleTime(d time.Duration) { db.db.SetConnMaxIdleTime(d) }
+
+// Go 1.15 func (db DB) SetConnMaxIdleTime(d time.Duration) { db.db.SetConnMaxIdleTime(d) }
 func (db DB) SetConnMaxLifetime(d time.Duration) { db.db.SetConnMaxLifetime(d) }
 func (db DB) SetMaxIdleConns(n int)              { db.db.SetMaxIdleConns(n) }
 func (db DB) SetMaxOpenConns(n int)              { db.db.SetMaxOpenConns(n) }

--- a/safesql/uncheckedconversions/uncheckedconversions.go
+++ b/safesql/uncheckedconversions/uncheckedconversions.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package uncheckedconversions provides functions to create values of package safesql types from plain strings.
-// Use of these functions could potentially result in instances of safesql types that violate their type contracts, and hence result in security vulnerabilities.
+// Uses of these functions could potentially result in instances of safesql types that violate their type contracts, and hence result in security vulnerabilities.
 package uncheckedconversions
 
 import (

--- a/safesql/uncheckedconversions/uncheckedconversions.go
+++ b/safesql/uncheckedconversions/uncheckedconversions.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package uncheckedconversions provides functions to create values of package safesql types from plain strings.
+// Use of these functions could potentially result in instances of safesql types that violate their type contracts, and hence result in security vulnerabilities.
+package uncheckedconversions
+
+import (
+	"github.com/google/go-safeweb/safesql"
+	"github.com/google/go-safeweb/safesql/internal/raw"
+)
+
+var trustedSQLStringCtor = raw.TrustedSQLString.(func(string) safesql.TrustedSQLString)
+
+// TrustedSQLStringFromStringKnownToSatisfyTypeContract promotes the given string to a trusted string.
+// Only strings known to be under the programmer control and trusted strings should be passed to this function.
+//
+// One example of correct use of this function would be to cast a query that was retrieved from a query storage to be used with the safesql package.
+// If the query storage is under the programmer control and user input cannot be put into it then the string is known to satisfy the type contract.
+func TrustedSQLStringFromStringKnownToSatisfyTypeContract(trusted string) safesql.TrustedSQLString {
+	return trustedSQLStringCtor(trusted)
+}


### PR DESCRIPTION
This implementation does not yet provide `FromIdentifierComponents` and `FromQuotedIdentifierComponents` as they are SQL-dialect dependent and there seems to not be a good way to create a generic helper for them.

If the need for them arises I'll try to work some magic to implement something that provides a similar functionality.