### PR TITLE
Fetch Metadata Plugin Implementation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/safehtml v0.0.2 h1:ZOt2VXg4x24bW0m2jtzAOkhoXV0iM8vNKc0paByCZqM=
 github.com/google/safehtml v0.0.2/go.mod h1:L4KWwDsUJdECRAEpZoBn3O64bQaywRscowZjJAzjHnU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -44,16 +44,21 @@ func NewIncomingRequest(req *http.Request) *IncomingRequest {
 	}
 }
 
+// Method specifies the HTTP method of an IncomingRequest.
+func (r *IncomingRequest) Method() string {
+	return r.req.Method
+}
+
 // Host returns the host the request is targeted to.
-// TODO(@mihalimara22): Remove this after the safehttp.URL type has been
-// implemented.
+// Method specifies the HTTP method of an IncomingRequest.
+// TODO(@mihalimara22): Remove this after the safehttp.URL type has been    implemented
 func (r *IncomingRequest) Host() string {
 	return r.req.Host
 }
 
 // Path returns the relative path of the URL in decoded format (e.g. %47%6f%2f
 // becomes /Go/).
-// TODO(@mihalimara22): Remove this after the safehttp.URL type has been     //
+// TODO(@mihalimara22): Remove this after the safehttp.URL type has been
 // implemented.
 func (r *IncomingRequest) Path() string {
 	return r.req.URL.Path

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -50,8 +50,7 @@ func (r *IncomingRequest) Method() string {
 }
 
 // Host returns the host the request is targeted to.
-// Method specifies the HTTP method of an IncomingRequest.
-// TODO(@mihalimara22): Remove this after the safehttp.URL type has been    implemented
+// TODO(@mihalimara22): Remove this after the safehttp.URL type has been implemented
 func (r *IncomingRequest) Host() string {
 	return r.req.Host
 }

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -133,7 +133,7 @@ func (p *Plugin) SetEnforce() {
 // the  violation is reported. If a redirectURL was provided and the Navigation
 // Isolation Policy is enabled and fails, the IncomingRequest will be
 // redirected to redirectURL.
-func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+func (p *Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 	// TODO(mihalimara22): Remove and disable using configurations when those
 	// have been implemented
 	if p.corsProtected[r.URL.Path()] {

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -1,0 +1,121 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetchmetadata
+
+import (
+	"github.com/google/go-safeweb/safehttp"
+)
+
+const (
+	enforceMode = "enforce"
+	reportMode  = "report"
+)
+
+// LoggingService TODO
+type LoggingService interface {
+	Log(ir *safehttp.IncomingRequest)
+}
+
+// Plugin implements Fetch Metadata functionality.
+// See https://www.w3.org/TR/fetch-metadata/ for more details.
+type Plugin struct {
+	mode   string
+	policy func(*safehttp.IncomingRequest) bool
+	logger LoggingService
+}
+
+// NewPlugin creates a new Fetch Metadata plugin using the defaultPolicy and
+// sets the mode to enforce.
+func NewPlugin() *Plugin {
+	return &Plugin{
+		mode:   enforceMode,
+		policy: defaultPolicy,
+	}
+}
+
+// defaultPolicy applies a Resource Isolation Policy to the
+// safehttp.IncomingRequest, allowing it to pass only if it conforms to it.
+//
+// See https://web.dev/fetch-metadata/ for more information.
+func defaultPolicy(r *safehttp.IncomingRequest) bool {
+	switch r.Header.Get("Sec-Fetch-Site") {
+	case "":
+		// Fetch Metadata is not supported by the browser so we allow the
+		// request to pass.
+		return true
+	case "same-origin", "same-site", "none":
+		// The request originated from a site served by your own server
+		// ("same-origin"), a subdomain of your site ("same-site", e.g.
+		// bar.foo.com made a request to foo.com) or was caused by the user
+		// explicitly interacting with the user-agent ("none"). Therefore it is
+		// allowed to pass.
+		return true
+	}
+	if m := r.Method(); r.Header.Get("Sec-Fetch-Mode") == "navigate" && (m == "GET" || m == "HEAD") {
+		if dest := r.Header.Get("Sec-Fetch-Dest"); dest == "object" || dest == "embed" {
+			// The request is cross-site and originates from <object> or <embed>
+			// so it is rejected.
+			return false
+		}
+		// The request is cross-site, but a simple top-level navigation so we
+		// allow it to pass.
+		return true
+	}
+	// The request is cross-site and not navigational so it is rejected.
+	return false
+}
+
+// SetPolicy allows changing the default Fetch Metadata policy
+// to a user-provided policy.
+func (p *Plugin) SetPolicy(policy func(*safehttp.IncomingRequest) bool) {
+	p.policy = policy
+}
+
+// SetReportMode sets the Fetch Metadata policy mode to "report". This will
+// allow requests that violate the policy to pass, but will report the violation
+// using the LoggingService. The method will panic if no LoggingService is
+// provided.
+func (p *Plugin) SetReportMode(logger LoggingService) {
+	if logger == nil {
+		panic("logging service required for Fetch Metadata report mode")
+	}
+	p.logger = logger
+	p.mode = reportMode
+}
+
+// SetEnforceMode sets the Fetch Metadata policy mode to "enforce". This will
+// reject any requests that violate the policy provided by the plugin.
+func (p *Plugin) SetEnforceMode() {
+	p.mode = enforceMode
+}
+
+// Before validates the safehttp.IncomingRequest using the Fetch Metadata policy
+// provided by the  plugin. It only allows request to pass if they conform to
+// the policy or if the mode is set to "report", in which case the request is
+// allowed to pass but the violation is reported. If the browser does not have
+// Fetch Metadata support implemented, the policy will not be applied and all
+// requests will be allowed to pass.
+func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+	if !p.policy(r) {
+		switch p.mode {
+		case enforceMode:
+			return w.ClientError(safehttp.StatusForbidden)
+		case reportMode:
+			p.logger.Log(r)
+		}
+	}
+
+	return safehttp.Result{}
+}

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -29,7 +29,7 @@ type LoggingService interface {
 type Plugin struct {
 	// Policy is the Fetch Metadata policy that decides whether a request should
 	// be allowed to pass or be rejected. This will be set to a default Resource
-	// Isolation Policy by default but can be changed by the user.
+	// Isolation Policy, but can be changed by the user.
 	Policy     func(*safehttp.IncomingRequest) bool
 	reportOnly bool
 	logger     LoggingService
@@ -62,7 +62,7 @@ func defaultPolicy(r *safehttp.IncomingRequest) bool {
 		// allowed to pass.
 		return true
 	}
-	if m := r.Method(); h.Get("Sec-Fetch-Mode") == "navigate" && (m == "GET" || m == "HEAD") {
+	if m := r.Method(); h.Get("Sec-Fetch-Mode") == "navigate" && (m == safehttp.MethodGet || m == safehttp.MethodHead) {
 		if dest := h.Get("Sec-Fetch-Dest"); dest == "object" || dest == "embed" {
 			// The request is cross-site and originates from <object> or <embed>
 			// so it is rejected.

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -16,8 +16,8 @@ package fetchmetadata
 
 import (
 	"github.com/google/go-safeweb/safehttp"
-	"net/url"
 	"log"
+	"net/url"
 )
 
 // RequestLogger is a user-provided service for logging Fetch Metadata policy
@@ -59,7 +59,7 @@ var (
 
 // Plugin implements Fetch Metadata functionality.
 //
-// See https://www.w3.org/TR/fetch-metadata/ and 
+// See https://www.w3.org/TR/fetch-metadata/ and
 // https://web.dev/fetch-metadata/  for more details.
 type Plugin struct {
 	// NavIsolation indicates whether the Navigation Isolation Policy should
@@ -99,7 +99,7 @@ func (p *Plugin) resourceIsolationPolicy(r *safehttp.IncomingRequest) bool {
 	site := h.Get("Sec-Fetch-Site")
 	mode := h.Get("Sec-Fetch-Mode")
 	dest := h.Get("Sec-Fetch-Dest")
-	log.Print(method,site, mode,dest)
+	log.Print(method, site, mode, dest)
 	if site != "cross-site" {
 		// The request is allowed to pass because one of the following applies:
 		// - Fetch Metadata is not supported by the browser

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -16,6 +16,8 @@ package fetchmetadata
 
 import (
 	"github.com/google/go-safeweb/safehttp"
+	"net/url"
+	"log"
 )
 
 // RequestLogger is a user-provided service for logging Fetch Metadata policy
@@ -24,97 +26,111 @@ type RequestLogger interface {
 	Log(ir *safehttp.IncomingRequest)
 }
 
+var (
+	navigationalModes = map[string]bool{
+		"navigate":        true,
+		"nested-navigate": true,
+	}
+	navigationalDest = map[string]bool{
+		"audio":           true,
+		"audioworklet":    true,
+		"document":        true,
+		"empty":           true,
+		"font":            true,
+		"image":           true,
+		"manifest":        true,
+		"paintworklet":    true,
+		"report":          true,
+		"script":          true,
+		"serviceworker":   true,
+		"sharedworker":    true,
+		"style":           true,
+		"track":           true,
+		"video":           true,
+		"worker":          true,
+		"xslt":            true,
+		"nested-document": true,
+	}
+	statePreservingMethods = map[string]bool{
+		"GET":  true,
+		"HEAD": true,
+	}
+)
+
 // Plugin implements Fetch Metadata functionality.
-// See https://www.w3.org/TR/fetch-metadata/ for more details.
+//
+// See https://www.w3.org/TR/fetch-metadata/ and 
+// https://web.dev/fetch-metadata/  for more details.
 type Plugin struct {
-	// Policy is the Fetch Metadata policy that decides whether a request should
-	// be allowed to pass or be rejected. This will be set to a default Resource
-	// Isolation Policy, but can be changed by the user.
-	//
-	// See https://web.dev/fetch-metadata/ for more information on the default policy
-	Policy func(*safehttp.IncomingRequest, map[string]bool) bool
 	// NavIsolation indicates whether the Navigation Isolation Policy should
-	// also be applied to the request as an additional layer of checking. This
-	// provides a way to mitigate clickjacking and reflected XSS by rejecting
-	// all cross-site navigations unless coming from origins where CORS is
-	// explicitly enabled. This can be used independently from a Resource
-	// Isolation Policy.
+	// be applied to the request before the Resource Isolation Policy as an
+	// additional layer of checking. This provides a way to mitigate
+	// clickjacking and reflected XSS by rejecting all cross-site navigations
+	// unless targeted to endpoints that are CORS-protected.
 	//
-	// WARNING: This is still an experimental feature and will be disabled by default.
+	// WARNING: This is still an experimental feature and will be disabled by
+	// default.
 	NavIsolation bool
-	reportOnly   bool
-	logger       RequestLogger
-	allowedCORS  map[string]bool
+	// RedirectURL can optionally indicate an URL to which the user can be
+	// redirected in case the Navigation Isolation policy rejects the request.
+	RedirectURL   string
+	reportOnly    bool
+	logger        RequestLogger
+	corsProtected map[string]bool
 }
 
-// NewPlugin creates a new Fetch Metadata plugin in enforce mode using the
-// defaultPolicy and a set of user-provided origins on which CORS is enabled.
-func NewPlugin(origins ...string) *Plugin {
+// NewPlugin creates a new Fetch Metadata plugin in enforce mode that will apply
+// the Resource Isolation Policy by default. The user can provide a set of
+// endpoints that are CORS-protected. Any request targeted to those endpoints
+// will be allowed by default without the policies being applied.
+func NewPlugin(endpoints ...string) *Plugin {
 	m := map[string]bool{}
-	for _, origin := range origins {
-		m[origin] = true
+	for _, e := range endpoints {
+		m[e] = true
 	}
 	return &Plugin{
-		allowedCORS: m,
-		Policy:      defaultPolicy,
+		corsProtected: m,
 	}
 }
 
-func defaultPolicy(r *safehttp.IncomingRequest, allowedCORS map[string]bool) bool {
+func (p *Plugin) resourceIsolationPolicy(r *safehttp.IncomingRequest) bool {
 	h := r.Header
-	switch h.Get("Sec-Fetch-Site") {
-	case "":
-		// Fetch Metadata is not supported by the browser so we allow the
-		// request to pass.
-		return true
-	case "same-origin", "same-site", "none":
-		// The request originated from a site served by your own server
-		// ("same-origin"), a subdomain of your site ("same-site", e.g.
-		// bar.foo.com made a request to foo.com) or was caused by the user
-		// explicitly interacting with the user-agent ("none"). Therefore it is
-		// allowed to pass.
-		return true
-	}
-
-	if m := r.Method(); h.Get("Sec-Fetch-Mode") == "navigate" && (m == safehttp.MethodGet || m == safehttp.MethodHead) {
-		if dest := h.Get("Sec-Fetch-Dest"); dest == "object" || dest == "embed" {
-			// The request is cross-site and originates from <object> or <embed>
-			// so it is rejected.
-			return false
-		}
-		// The request is cross-site, but a simple top-level navigation so we
-		// allow it to pass.
+	method := r.Method()
+	site := h.Get("Sec-Fetch-Site")
+	mode := h.Get("Sec-Fetch-Mode")
+	dest := h.Get("Sec-Fetch-Dest")
+	log.Print(method,site, mode,dest)
+	if site != "cross-site" {
+		// The request is allowed to pass because one of the following applies:
+		// - Fetch Metadata is not supported by the browser
+		// - the request is same-origin, same-site or caused by the user
+		// explicitly interacting with the user-agent
 		return true
 	}
 
-	origin := h.Get("Origin")
-	if _, ok := allowedCORS[origin]; ok && h.Get("Sec-Fetch-Mode") == "cors" {
-		// The request is cross-site but sent from an
-		// origin where Cross-Origin Resource Sharing is explicitly allowed.
+	// Allow CORS options requests if neither Mode nor Dest is set.
+	// https://github.com/w3c/webappsec-fetch-metadata/issues/35
+	// https://bugs.chromium.org/p/chromium/issues/detail?id=979946
+	if mode == "" && dest == "" && method == safehttp.MethodOptions {
 		return true
 	}
 
-	// The request is cross-site, not navigational and sent from an endpoint
-	// where CORS is not enabled therefore it is rejected.
+	if navigationalModes[mode] && navigationalDest[dest] && statePreservingMethods[method] {
+		// The rquest is cross-site, but a simple top-level navigation from a
+		// safe destination so we  allow it to pass .
+		return true
+	}
+	log.Print("here?")
+	// The request is cross-site and not a simple navigation or from an unsafe
+	// destination so it is rejected.
 	return false
 }
 
-func navigationIsolationPolicy(r *safehttp.IncomingRequest, allowedCORS map[string]bool) bool {
-	h := r.Header
-	origin := h.Get("Origin")
-	if h.Get("Sec-Fetch-Site") == "cross-site" && h.Get("Sec-Fetch-Mode") == "navigate" {
-		if _, ok := allowedCORS[origin]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-// SetReportMode sets the Fetch Metadata policy mode to "report". This will
+// SetReportOnly sets the Fetch Metadata policy mode to "report". This will
 // allow requests that violate the policy to pass, but will report the violation
 // using the RequestLogger. The method will panic if no RequestLogger is
 // provided.
-func (p *Plugin) SetReportMode(logger RequestLogger) {
+func (p *Plugin) SetReportOnly(logger RequestLogger) {
 	if logger == nil {
 		panic("logging service required for Fetch Metadata report mode")
 	}
@@ -122,34 +138,49 @@ func (p *Plugin) SetReportMode(logger RequestLogger) {
 	p.reportOnly = true
 }
 
-// SetEnforceMode sets the Fetch Metadata policy mode to "enforce". This will
-// reject any requests that violate the policy provided by the plugin.
-func (p *Plugin) SetEnforceMode() {
+// SetEnforce sets the Fetch Metadata policy mode to "enforce" and sets the
+// RequestLogger to nil. This will reject any requests that violates the policy
+// provided by the plugin.
+func (p *Plugin) SetEnforce() {
 	p.reportOnly = false
+	p.logger = nil
 }
 
-// Before validates the safehttp.IncomingRequest using the Fetch Metadata policy
-// provided by the  plugin. It only allows request to pass if they conform to
-// the policy, if it's sent from a CORS endpoint, or if the mode is set to
+// Before validates the safehttp.IncomingRequest using the Resource Isolation
+// Policy and, if enabled, the Navigation Isolation Policy . It only allows
+// request to pass if they conform to the policy, if it's targeted to a
+// CORS-protected endpoint, or if the mode is set to
 // "report", in which case the request is allowed to pass but the violation is
-// reported. Moreover, if the Navigation Isolation Policy is enabled, the
-// request will also be validated against it.  If the browser does not have
-// Fetch Metadata support implemented, the policy will not be applied and all
-// requests will be allowed to pass.
+// reported. If a redirectURL was provided and the Navigation Isolation Policy
+// fails, the IncomingRequest will be redirected to the redirectURL.
 func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-	if !p.Policy(r, p.allowedCORS) {
-		if !p.reportOnly {
-			return w.ClientError(safehttp.StatusForbidden)
-		}
-		p.logger.Log(r)
+	reject := false
+	endpoint := r.URL.String()
+	if _, ok := p.corsProtected[endpoint]; ok {
+		// The request is targeted to an endpoint on which Fetch Metadata
+		// policies are disabled because it is CORS-protected so we don't apply
+		// the policies.
 		return safehttp.Result{}
 	}
-	if p.NavIsolation && !navigationIsolationPolicy(r, p.allowedCORS) {
+	if p.NavIsolation {
+		h := r.Header
+		if site, mode := h.Get("Sec-Fetch-Site"), h.Get("Sec-Fetch-Mode"); site == "cross-site" && navigationalModes[mode] {
+			if p.RedirectURL != "" {
+				u, err := url.Parse(p.RedirectURL)
+				if err != nil {
+					return w.ServerError(safehttp.StatusInternalServerError)
+				}
+				return w.Redirect(r, u.String(), safehttp.StatusMovedPermanently)
+			}
+			reject = true
+		}
+	}
+	log.Print("here")
+	if reject || !p.resourceIsolationPolicy(r) {
 		if !p.reportOnly {
 			return w.ClientError(safehttp.StatusForbidden)
 		}
 		p.logger.Log(r)
-		return safehttp.Result{}
 	}
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -16,10 +16,10 @@ package fetchmetadata
 
 import (
 	"github.com/google/go-safeweb/safehttp"
+	"log"
 )
 
-// RequestLogger is a user-provided service for logging Fetch Metadata policy
-// violations
+// RequestLogger is used for logging Fetch Metadata policy violations;
 type RequestLogger interface {
 	Log(ir *safehttp.IncomingRequest)
 }
@@ -56,8 +56,8 @@ type Plugin struct {
 	// RedirectURL can optionally indicate an URL to which the user can be
 	// redirected in case the Navigation Isolation policy rejects the request.
 	RedirectURL   *safehttp.URL
+	Logger        RequestLogger
 	reportOnly    bool
-	logger        RequestLogger
 	corsProtected map[string]bool
 }
 
@@ -75,7 +75,6 @@ func NewPlugin(endpoints ...string) *Plugin {
 
 func (p *Plugin) resourceIsolationPolicy(r *safehttp.IncomingRequest) bool {
 	h := r.Header
-
 	if h.Get("Sec-Fetch-Site") != "cross-site" {
 		// The request is allowed to pass because one of the following applies:
 		// - Fetch Metadata is not supported by the browser
@@ -96,7 +95,7 @@ func (p *Plugin) resourceIsolationPolicy(r *safehttp.IncomingRequest) bool {
 
 	if navigationalModes[mode] && navigationalDest[dest] && statePreservingMethods[method] {
 		// The request is cross-site, but a simple top-level navigation from a
-		// safe destination so we  allow it to pass .
+		// safe destination so we  allow it to pass.
 		return true
 	}
 	// The request is cross-site and not a simple navigation or from an unsafe
@@ -104,14 +103,20 @@ func (p *Plugin) resourceIsolationPolicy(r *safehttp.IncomingRequest) bool {
 	return false
 }
 
+func (p *Plugin) navigationIsolationPolicy(r *safehttp.IncomingRequest) bool {
+	if h := r.Header; p.NavIsolation && h.Get("Sec-Fetch-Site") == "cross-site" && navigationalModes[h.Get("Sec-Fetch-Mode")] {
+		return false
+	}
+	return true
+}
+
 // SetReportOnly sets the Fetch Metadata policy mode to "report". This will
 // allow requests that violate the policy to pass, but will report the violation
 // using the RequestLogger. The method will panic if RequestLogger is nil.
-func (p *Plugin) SetReportOnly(logger RequestLogger) {
-	if logger == nil {
+func (p *Plugin) SetReportOnly() {
+	if p.Logger == nil {
 		panic("logging service required for Fetch Metadata report mode")
 	}
-	p.logger = logger
 	p.reportOnly = true
 }
 
@@ -119,7 +124,6 @@ func (p *Plugin) SetReportOnly(logger RequestLogger) {
 // any requests that violates the policy provided by the plugin.
 func (p *Plugin) SetEnforce() {
 	p.reportOnly = false
-	p.logger = nil
 }
 
 // Before validates the safehttp.IncomingRequest using the Resource Isolation
@@ -131,28 +135,30 @@ func (p *Plugin) SetEnforce() {
 // Isolation Policy is enabled and fails, the IncomingRequest will be
 // redirected to redirectURL.
 func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-	endpoint := r.URL.String()
-	if _, ok := p.corsProtected[endpoint]; ok {
+	if p.corsProtected[r.URL.Path()] {
 		// The request is targeted to an endpoint on which Fetch Metadata
 		// policies are disabled because it is CORS-protected so we don't apply
 		// the policies.
 		return safehttp.Result{}
 	}
 
-	reject := false
-	h := r.Header
-	if p.NavIsolation && h.Get("Sec-Fetch-Site") == "cross-site" && navigationalModes[h.Get("Sec-Fetch-Mode")] {
+	rejected := false
+	if !p.navigationIsolationPolicy(r) {
+		rejected = true
 		if p.RedirectURL != nil {
 			return w.Redirect(r, p.RedirectURL.String(), safehttp.StatusMovedPermanently)
 		}
-		reject = true
 	}
 
-	if reject || !p.resourceIsolationPolicy(r) {
-		if !p.reportOnly {
-			return w.ClientError(safehttp.StatusForbidden)
+	if rejected || !p.resourceIsolationPolicy(r) {
+		if p.Logger != nil {
+			p.Logger.Log(r)
 		}
-		p.logger.Log(r)
+		if p.reportOnly {
+			return safehttp.Result{}
+		}
+		return w.ClientError(safehttp.StatusForbidden)
 	}
+
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -18,9 +18,9 @@ import (
 	"github.com/google/go-safeweb/safehttp"
 )
 
-// LoggingService is a user-provided service for logging Fetch Metadata policy
+// RequestLogger is a user-provided service for logging Fetch Metadata policy
 // violations
-type LoggingService interface {
+type RequestLogger interface {
 	Log(ir *safehttp.IncomingRequest)
 }
 
@@ -43,7 +43,7 @@ type Plugin struct {
 	// WARNING: This is still an experimental feature and will be disabled by default.
 	NavIsolation bool
 	reportOnly   bool
-	logger       LoggingService
+	logger       RequestLogger
 	allowedCORS  map[string]bool
 }
 
@@ -112,9 +112,9 @@ func navigationIsolationPolicy(r *safehttp.IncomingRequest, allowedCORS map[stri
 
 // SetReportMode sets the Fetch Metadata policy mode to "report". This will
 // allow requests that violate the policy to pass, but will report the violation
-// using the LoggingService. The method will panic if no LoggingService is
+// using the RequestLogger. The method will panic if no RequestLogger is
 // provided.
-func (p *Plugin) SetReportMode(logger LoggingService) {
+func (p *Plugin) SetReportMode(logger RequestLogger) {
 	if logger == nil {
 		panic("logging service required for Fetch Metadata report mode")
 	}

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -18,12 +18,8 @@ import (
 	"github.com/google/go-safeweb/safehttp"
 )
 
-const (
-	enforceMode = "enforce"
-	reportMode  = "report"
-)
-
-// LoggingService TODO
+// LoggingService is a user-provided service for logging Fetch Metadata policy
+// violations
 type LoggingService interface {
 	Log(ir *safehttp.IncomingRequest)
 }
@@ -31,17 +27,19 @@ type LoggingService interface {
 // Plugin implements Fetch Metadata functionality.
 // See https://www.w3.org/TR/fetch-metadata/ for more details.
 type Plugin struct {
-	mode   string
-	policy func(*safehttp.IncomingRequest) bool
-	logger LoggingService
+	// Policy is the Fetch Metadata policy that decides whether a request should
+	// be allowed to pass or be rejected. This will be set to a default Resource
+	// Isolation Policy by default but can be changed by the user.
+	Policy     func(*safehttp.IncomingRequest) bool
+	reportOnly bool
+	logger     LoggingService
 }
 
 // NewPlugin creates a new Fetch Metadata plugin using the defaultPolicy and
 // sets the mode to enforce.
 func NewPlugin() *Plugin {
 	return &Plugin{
-		mode:   enforceMode,
-		policy: defaultPolicy,
+		Policy: defaultPolicy,
 	}
 }
 
@@ -50,7 +48,8 @@ func NewPlugin() *Plugin {
 //
 // See https://web.dev/fetch-metadata/ for more information.
 func defaultPolicy(r *safehttp.IncomingRequest) bool {
-	switch r.Header.Get("Sec-Fetch-Site") {
+	h := r.Header
+	switch h.Get("Sec-Fetch-Site") {
 	case "":
 		// Fetch Metadata is not supported by the browser so we allow the
 		// request to pass.
@@ -63,8 +62,8 @@ func defaultPolicy(r *safehttp.IncomingRequest) bool {
 		// allowed to pass.
 		return true
 	}
-	if m := r.Method(); r.Header.Get("Sec-Fetch-Mode") == "navigate" && (m == "GET" || m == "HEAD") {
-		if dest := r.Header.Get("Sec-Fetch-Dest"); dest == "object" || dest == "embed" {
+	if m := r.Method(); h.Get("Sec-Fetch-Mode") == "navigate" && (m == "GET" || m == "HEAD") {
+		if dest := h.Get("Sec-Fetch-Dest"); dest == "object" || dest == "embed" {
 			// The request is cross-site and originates from <object> or <embed>
 			// so it is rejected.
 			return false
@@ -77,12 +76,6 @@ func defaultPolicy(r *safehttp.IncomingRequest) bool {
 	return false
 }
 
-// SetPolicy allows changing the default Fetch Metadata policy
-// to a user-provided policy.
-func (p *Plugin) SetPolicy(policy func(*safehttp.IncomingRequest) bool) {
-	p.policy = policy
-}
-
 // SetReportMode sets the Fetch Metadata policy mode to "report". This will
 // allow requests that violate the policy to pass, but will report the violation
 // using the LoggingService. The method will panic if no LoggingService is
@@ -92,13 +85,13 @@ func (p *Plugin) SetReportMode(logger LoggingService) {
 		panic("logging service required for Fetch Metadata report mode")
 	}
 	p.logger = logger
-	p.mode = reportMode
+	p.reportOnly = true
 }
 
 // SetEnforceMode sets the Fetch Metadata policy mode to "enforce". This will
 // reject any requests that violate the policy provided by the plugin.
 func (p *Plugin) SetEnforceMode() {
-	p.mode = enforceMode
+	p.reportOnly = false
 }
 
 // Before validates the safehttp.IncomingRequest using the Fetch Metadata policy
@@ -108,14 +101,13 @@ func (p *Plugin) SetEnforceMode() {
 // Fetch Metadata support implemented, the policy will not be applied and all
 // requests will be allowed to pass.
 func (p *Plugin) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-	if !p.policy(r) {
-		switch p.mode {
-		case enforceMode:
+	if !p.Policy(r) {
+		switch p.reportOnly {
+		case false:
 			return w.ClientError(safehttp.StatusForbidden)
-		case reportMode:
+		case true:
 			p.logger.Log(r)
 		}
 	}
-
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -111,7 +111,7 @@ func (p *Plugin) checkNavigationIsolationPolicy(r *safehttp.IncomingRequest) boo
 
 // SetReportOnly sets the Fetch Metadata policy mode to "report". This will
 // allow requests that violate the policy to pass, but will report the violation
-// using the RequestLogger. The method will panic if RequestLogger is nil.
+// using the Logger. The method will panic if Logger is nil.
 func (p *Plugin) SetReportOnly() {
 	if p.Logger == nil {
 		panic("logging service required for Fetch Metadata report mode")

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -16,7 +16,6 @@ package fetchmetadata
 
 import (
 	"github.com/google/go-safeweb/safehttp"
-	"log"
 )
 
 // RequestLogger is used for logging Fetch Metadata policy violations;

--- a/safehttp/plugins/fetch_metadata/fetch_metadata_test.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata_test.go
@@ -25,54 +25,62 @@ import (
 func TestDefaultPolicy(t *testing.T) {
 	tests := []struct {
 		name    string
+		origins map[string]bool
 		req     *safehttp.IncomingRequest
 		allowed bool
 	}{
 		{
 			name:    `Sec-Fetch-Site: ""`,
-			req:     safehttptest.NewRequest("POST", "/", nil),
+			origins: map[string]bool{},
+			req:     safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil),
 			allowed: true,
 		},
 		{
-			name: "Sec-Fetch-Site: same-origin",
+			name:    "Sec-Fetch-Site: same-origin",
+			origins: map[string]bool{},
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "same-origin")
 				return req
 			}(),
 			allowed: true,
 		},
 		{
-			name: "Sec-Fetch-Site: same-site",
+			name:    "Sec-Fetch-Site: same-site",
+			origins: map[string]bool{},
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "same-site")
 				return req
 			}(),
 			allowed: true,
 		},
 		{
-			name: "Sec-Fetch-Site: none",
+			name:    "Sec-Fetch-Site: none",
+			origins: map[string]bool{},
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "none")
 				return req
 			}(),
 			allowed: true,
 		},
 		{
-			name: "Sec-Fetch-Site: cross-site",
+			name:    "Sec-Fetch-Site: cross-site and Sec-Fetch-Mode: no-cors",
+			origins: map[string]bool{},
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "no-cors")
 				return req
 			}(),
 			allowed: false,
 		},
 		{
-			name: "GET request with Sec-Fetch-Mode: navigate from image",
+			name:    "GET request with Sec-Fetch-Mode: navigate from image",
+			origins: map[string]bool{},
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("GET", "/", nil)
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
 				req.Header.Add("Sec-Fetch-Mode", "navigate")
 				req.Header.Add("Sec-Fetch-Dest", "image")
@@ -81,9 +89,10 @@ func TestDefaultPolicy(t *testing.T) {
 			allowed: true,
 		},
 		{
-			name: "POST request with Sec-Fetch-Mode: navigate from image",
+			name:    "POST request with Sec-Fetch-Mode: navigate from image",
+			origins: map[string]bool{},
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
 				req.Header.Add("Sec-Fetch-Mode", "navigate")
 				req.Header.Add("Sec-Fetch-Dest", "image")
@@ -92,9 +101,10 @@ func TestDefaultPolicy(t *testing.T) {
 			allowed: false,
 		},
 		{
-			name: "GET request with Sec-Fetch-Mode: navigate from object",
+			name:    "GET request with Sec-Fetch-Mode: navigate from object",
+			origins: map[string]bool{},
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("GET", "/", nil)
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
 				req.Header.Add("Sec-Fetch-Mode", "navigate")
 				req.Header.Add("Sec-Fetch-Dest", "object")
@@ -103,12 +113,72 @@ func TestDefaultPolicy(t *testing.T) {
 			allowed: false,
 		},
 		{
-			name: "GET request with Sec-Fetch-Mode: navigate from embed",
+			name:    "GET request with Sec-Fetch-Mode: navigate from embed",
+			origins: map[string]bool{},
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("GET", "/", nil)
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
 				req.Header.Add("Sec-Fetch-Mode", "navigate")
 				req.Header.Add("Sec-Fetch-Dest", "embed")
+				return req
+			}(),
+			allowed: false,
+		},
+		{
+			name:    "Cross-site non-navigational request rejected",
+			origins: map[string]bool{},
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
+				return req
+			}(),
+			allowed: false,
+		},
+		{
+			name:    "Cross-site non-navigational request allowed for origin",
+			origins: map[string]bool{"https://foo.com": true},
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Origin", "https://foo.com")
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
+				return req
+			}(),
+			allowed: true,
+		},
+		{
+			name:    "Cross-site non-navigation request rejected for protocol mismatch",
+			origins: map[string]bool{"https://foo.com": true},
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Origin", "http://foo.com")
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
+				return req
+			}(),
+			allowed: false,
+		},
+		{
+			name:    "Cross-site non-navigational request rejected for host msimatch",
+			origins: map[string]bool{"https://foo.com": true},
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Origin", "https://bar.com")
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
+				return req
+			}(),
+			allowed: false,
+		},
+		{
+			name:    "Cross-site non-navigational request rejected for port msimatch",
+			origins: map[string]bool{"https://foo.com": true},
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Origin", "https://foo.com:100")
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
 				return req
 			}(),
 			allowed: false,
@@ -118,51 +188,121 @@ func TestDefaultPolicy(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			p := fetchmetadata.NewPlugin()
-			got := p.Policy(test.req)
+			got := p.Policy(test.req, test.origins)
 
 			if want := test.allowed; want != got {
-				t.Errorf("p.Policy(test.req): got %v, want %v", got, want)
+				t.Errorf("p.Policy(test.req, test.origins): got %v, want %v", got, want)
 			}
 		})
 	}
 }
 
-func TestEnforceMode(t *testing.T) {
+func TestBeforeEnforceMode(t *testing.T) {
 	tests := []struct {
-		name        string
-		req         *safehttp.IncomingRequest
-		wantStatus  safehttp.StatusCode
-		wantHeaders map[string][]string
-		wantBody    string
+		name         string
+		req          *safehttp.IncomingRequest
+		navIsolation bool
+		origin       string
+		wantStatus   safehttp.StatusCode
+		wantHeaders  map[string][]string
+		wantBody     string
 	}{
 		{
-			name:        "Allowed Request",
-			req:         safehttptest.NewRequest("POST", "/", nil),
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{},
-			wantBody:    "",
+			name:         "Fetch Metadata Unsupported",
+			req:          safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil),
+			navIsolation: false,
+			origin:       "https://foo.com",
+			wantStatus:   safehttp.StatusOK,
+			wantHeaders:  map[string][]string{},
+			wantBody:     "",
 		},
 		{
-			name: "Rejected Request",
+			name: "No CORS endpoints",
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
-				req.Header.Add("Sec-Fetch-Mode", "navigate")
-				req.Header.Add("Sec-Fetch-Dest", "image")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
 				return req
 			}(),
-			wantStatus: safehttp.StatusForbidden,
+			navIsolation: false,
+			origin:       "https://foo.com",
+			wantStatus:   safehttp.StatusForbidden,
 			wantHeaders: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
 			},
 			wantBody: "Forbidden\n",
 		},
+		{
+			name: "CORS endpoints provided",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Origin", "https://foo.com")
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
+				return req
+			}(),
+			navIsolation: false,
+			origin:       "https://foo.com",
+			wantStatus:   safehttp.StatusOK,
+			wantHeaders:  map[string][]string{},
+			wantBody:     "",
+		},
+		{
+			name: "Navigation Isolation Disabled",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			navIsolation: false,
+			origin:       "https://foo.com",
+			wantStatus:   safehttp.StatusOK,
+			wantHeaders:  map[string][]string{},
+			wantBody:     "",
+		},
+		{
+			name: "Navigation Isolation Enabled",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			navIsolation: true,
+			origin:       "https://foo.com",
+			wantStatus:   safehttp.StatusForbidden,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Forbidden\n",
+		},
+		{
+			name: "Navigation Isolation Enabled and CORS endpoints",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Origin", "https://foo.com")
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			navIsolation: true,
+			origin:       "https://foo.com",
+			wantStatus:   safehttp.StatusOK,
+			wantHeaders:  map[string][]string{},
+			wantBody:     "",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p := fetchmetadata.NewPlugin()
+			p := fetchmetadata.NewPlugin(test.origin)
+			p.NavIsolation = test.navIsolation
 			rec := safehttptest.NewResponseRecorder()
 
 			p.Before(rec.ResponseWriter, test.req)
@@ -187,22 +327,39 @@ func (l *fooLog) Log(r *safehttp.IncomingRequest) {
 	l.report = r.Method() + " " + r.URL.Path()
 }
 
-func TestReportModeWithLogger(t *testing.T) {
+func TestBeforeReportMode(t *testing.T) {
 	tests := []struct {
-		name        string
-		req         *safehttp.IncomingRequest
-		wantStatus  safehttp.StatusCode
-		wantHeaders map[string][]string
-		wantBody    string
-		wantReport  string
+		name         string
+		origin       string
+		req          *safehttp.IncomingRequest
+		navIsolation bool
+		wantStatus   safehttp.StatusCode
+		wantHeaders  map[string][]string
+		wantBody     string
+		wantReport   string
 	}{
 		{
-			name: "GET request with Sec-Fetch-Mode: navigate from image",
+			name:   "Sec-Fetch-Site: cross-site",
+			origin: "https://foo.com",
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("GET", "/pizza", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
-				req.Header.Add("Sec-Fetch-Mode", "navigate")
-				req.Header.Add("Sec-Fetch-Dest", "image")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
+				return req
+			}(),
+			wantStatus:  safehttp.StatusOK,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+			wantReport:  "POST /pizza",
+		},
+		{
+			name:   "Sec-Fetch-Site: cross-site from allowed orign",
+			origin: "https://foo.com",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Origin", "https://foo.com")
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "cors")
 				return req
 			}(),
 			wantStatus:  safehttp.StatusOK,
@@ -211,21 +368,10 @@ func TestReportModeWithLogger(t *testing.T) {
 			wantReport:  "",
 		},
 		{
-			name: "Sec-Fetch-Site: cross-site",
+			name:   "POST request with Sec-Fetch-Mode: navigate from image",
+			origin: "https://foo.com",
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/pizza", nil)
-				req.Header.Add("Sec-Fetch-Site", "cross-site")
-				return req
-			}(),
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{},
-			wantBody:    "",
-			wantReport:  "POST /pizza",
-		},
-		{
-			name: "POST request with Sec-Fetch-Mode: navigate from image",
-			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/pizza", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
 				req.Header.Add("Sec-Fetch-Mode", "navigate")
 				req.Header.Add("Sec-Fetch-Dest", "image")
@@ -237,9 +383,10 @@ func TestReportModeWithLogger(t *testing.T) {
 			wantReport:  "POST /pizza",
 		},
 		{
-			name: "GET request with Sec-Fetch-Mode: navigate from object",
+			name:   "GET request with Sec-Fetch-Mode: navigate from object",
+			origin: "https://foo.com",
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("GET", "/pizza", nil)
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
 				req.Header.Add("Sec-Fetch-Mode", "navigate")
 				req.Header.Add("Sec-Fetch-Dest", "object")
@@ -253,7 +400,7 @@ func TestReportModeWithLogger(t *testing.T) {
 		{
 			name: "GET request with Sec-Fetch-Mode: navigate from embed",
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("GET", "/pizza", nil)
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Site", "cross-site")
 				req.Header.Add("Sec-Fetch-Mode", "navigate")
 				req.Header.Add("Sec-Fetch-Dest", "embed")
@@ -264,15 +411,48 @@ func TestReportModeWithLogger(t *testing.T) {
 			wantBody:    "",
 			wantReport:  "GET /pizza",
 		},
+		{
+			name:   "GET request with Sec-Fetch-Mode: navigate from image and Navigation Isolation",
+			origin: "https://foo.com",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			navIsolation: true,
+			wantStatus:   safehttp.StatusOK,
+			wantHeaders:  map[string][]string{},
+			wantBody:     "",
+			wantReport:   "GET /pizza",
+		},
+		{
+			name:   "GET request with Sec-Fetch-Mode: navigate from image and Navigation Isolation from allowed origin",
+			origin: "https://foo.com",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Origin", "https://foo.com")
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			navIsolation: true,
+			wantStatus:   safehttp.StatusOK,
+			wantHeaders:  map[string][]string{},
+			wantBody:     "",
+			wantReport:   "",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p := fetchmetadata.NewPlugin()
+			p := fetchmetadata.NewPlugin(test.origin)
 			logger := &fooLog{}
 			p.SetReportMode(logger)
 			rec := safehttptest.NewResponseRecorder()
-
+			p.NavIsolation = test.navIsolation
 			p.Before(rec.ResponseWriter, test.req)
 
 			if status := safehttp.StatusCode(rec.Status()); status != test.wantStatus {
@@ -304,7 +484,7 @@ func TestReportModeMissingLogger(t *testing.T) {
 func TestChangeMode(t *testing.T) {
 	logger := &fooLog{}
 	p := fetchmetadata.NewPlugin()
-	req := safehttptest.NewRequest("POST", "/pizza", nil)
+	req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 	req.Header.Add("Sec-Fetch-Site", "cross-site")
 	req.Header.Add("Sec-Fetch-Mode", "navigate")
 	rec := safehttptest.NewResponseRecorder()
@@ -325,7 +505,7 @@ func TestChangeMode(t *testing.T) {
 		t.Errorf("response body got: %q want: %q", got, want)
 	}
 
-	req = safehttptest.NewRequest("POST", "/pizza", nil)
+	req = safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 	req.Header.Add("Sec-Fetch-Site", "cross-site")
 	req.Header.Add("Sec-Fetch-Mode", "navigate")
 	rec = safehttptest.NewResponseRecorder()
@@ -348,8 +528,8 @@ func TestChangeMode(t *testing.T) {
 }
 
 func TestCustomPolicy(t *testing.T) {
-	policy := func(r *safehttp.IncomingRequest) bool {
-		if r.Header.Get("Sec-Fetch-Mode") != "cors" {
+	policy := func(r *safehttp.IncomingRequest, allowedCORS map[string]bool) bool {
+		if r.Header.Get("Sec-Fetch-Mode") != "no-cors" {
 			return false
 		}
 		return true
@@ -364,8 +544,8 @@ func TestCustomPolicy(t *testing.T) {
 		{
 			name: "Allowed request for custom policy",
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/pizza", nil)
-				req.Header.Add("Sec-Fetch-Mode", "cors")
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
+				req.Header.Add("Sec-Fetch-Mode", "no-cors")
 				return req
 			}(),
 			wantStatus:  safehttp.StatusOK,
@@ -375,7 +555,7 @@ func TestCustomPolicy(t *testing.T) {
 		{
 			name: "Rejected request for custom policy",
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/pizza", nil)
+				req := safehttptest.NewRequest("POST", "https://spaghetti.com/pizza", nil)
 				req.Header.Add("Sec-Fetch-Mode", "navigate")
 				return req
 			}(),
@@ -406,5 +586,48 @@ func TestCustomPolicy(t *testing.T) {
 				t.Errorf("response body got: %q want: %q", got, test.wantBody)
 			}
 		})
+	}
+}
+
+func TestEnableDisableNavIsolation(t *testing.T) {
+	req := safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
+	req.Header.Add("Sec-Fetch-Site", "cross-site")
+	req.Header.Add("Sec-Fetch-Mode", "navigate")
+	rec := safehttptest.NewResponseRecorder()
+
+	p := fetchmetadata.NewPlugin()
+	p.NavIsolation = true
+	p.Before(rec.ResponseWriter, req)
+
+	if want, got := safehttp.StatusForbidden, safehttp.StatusCode(rec.Status()); want != got {
+		t.Errorf("status code got: %v want: %v", got, want)
+	}
+	wantHeaders := map[string][]string{
+		"Content-Type":           {"text/plain; charset=utf-8"},
+		"X-Content-Type-Options": {"nosniff"},
+	}
+	if diff := cmp.Diff(wantHeaders, map[string][]string(rec.Header())); diff != "" {
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+	}
+	if want, got := "Forbidden\n", rec.Body(); got != want {
+		t.Errorf("response body got: %q want: %q", got, want)
+	}
+
+	req = safehttptest.NewRequest("GET", "https://spaghetti.com/pizza", nil)
+	req.Header.Add("Sec-Fetch-Site", "cross-site")
+	req.Header.Add("Sec-Fetch-Mode", "navigate")
+	rec = safehttptest.NewResponseRecorder()
+
+	p.NavIsolation = false
+	p.Before(rec.ResponseWriter, req)
+
+	if want, got := safehttp.StatusOK, safehttp.StatusCode(rec.Status()); want != got {
+		t.Errorf("status code got: %v want: %v", got, want)
+	}
+	if diff := cmp.Diff(map[string][]string{}, map[string][]string(rec.Header())); diff != "" {
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+	}
+	if want, got := "", rec.Body(); got != want {
+		t.Errorf("response body got: %q want: %q", got, want)
 	}
 }

--- a/safehttp/plugins/fetch_metadata/fetch_metadata_test.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata_test.go
@@ -1,0 +1,401 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetchmetadata_test
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/plugins/fetch_metadata"
+	"github.com/google/go-safeweb/safehttp/safehttptest"
+	"testing"
+)
+
+func TestEnforceMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         *safehttp.IncomingRequest
+		wantStatus  int
+		wantHeaders map[string][]string
+		wantBody    string
+	}{
+		{
+			name:        `Sec-Fetch-Site: ""`,
+			req:         safehttptest.NewRequest("POST", "/", nil),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+		},
+		{
+			name: "Sec-Fetch-Site: same-origin",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/", nil)
+				req.Header.Add("Sec-Fetch-Site", "same-origin")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+		},
+		{
+			name: "Sec-Fetch-Site: same-site",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/", nil)
+				req.Header.Add("Sec-Fetch-Site", "same-site")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+		},
+		{
+			name: "Sec-Fetch-Site: none",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/", nil)
+				req.Header.Add("Sec-Fetch-Site", "none")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+		},
+		{
+			name: "Sec-Fetch-Site: cross-site",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				return req
+			}(),
+			wantStatus: 403,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Forbidden\n",
+		},
+		{
+			name: "GET request with Sec-Fetch-Mode: navigate from image",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "/", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+		},
+		{
+			name: "POST request with Sec-Fetch-Mode: navigate from image",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			wantStatus: 403,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Forbidden\n",
+		},
+		{
+			name: "GET request with Sec-Fetch-Mode: navigate from object",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "/", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "object")
+				return req
+			}(),
+			wantStatus: 403,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Forbidden\n",
+		},
+		{
+			name: "GET request with Sec-Fetch-Mode: navigate from embed",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "/", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "embed")
+				return req
+			}(),
+			wantStatus: 403,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Forbidden\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := fetchmetadata.NewPlugin()
+			rec := safehttptest.NewResponseRecorder()
+
+			p.Before(rec.ResponseWriter, test.req)
+
+			if status := rec.Status(); status != test.wantStatus {
+				t.Errorf("status code got: %v want: %v", status, test.wantStatus)
+			}
+			if diff := cmp.Diff(test.wantHeaders, map[string][]string(rec.Header())); diff != "" {
+				t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+			}
+			if got := rec.Body(); got != test.wantBody {
+				t.Errorf("response body got: %q want: %q", got, test.wantBody)
+			}
+		})
+	}
+
+}
+
+func TestReportModeWithLogger(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         *safehttp.IncomingRequest
+		wantStatus  int
+		wantHeaders map[string][]string
+		wantBody    string
+		wantReport  string
+	}{
+		{
+			name: "GET request with Sec-Fetch-Mode: navigate from image",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+			wantReport:  "",
+		},
+		{
+			name: "Sec-Fetch-Site: cross-site",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+			wantReport:  "POST /pizza",
+		},
+		{
+			name: "POST request with Sec-Fetch-Mode: navigate from image",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "image")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+			wantReport:  "POST /pizza",
+		},
+		{
+			name: "GET request with Sec-Fetch-Mode: navigate from object",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "object")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+			wantReport:  "GET /pizza",
+		},
+		{
+			name: "GET request with Sec-Fetch-Mode: navigate from embed",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("GET", "/pizza", nil)
+				req.Header.Add("Sec-Fetch-Site", "cross-site")
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				req.Header.Add("Sec-Fetch-Dest", "embed")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+			wantReport:  "GET /pizza",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := &fooLog{}
+			p := fetchmetadata.NewPlugin()
+			p.SetReportMode(logger)
+			rec := safehttptest.NewResponseRecorder()
+
+			p.Before(rec.ResponseWriter, test.req)
+
+			if status := rec.Status(); status != test.wantStatus {
+				t.Errorf("status code got: %v want: %v", status, test.wantStatus)
+			}
+			if diff := cmp.Diff(test.wantHeaders, map[string][]string(rec.Header())); diff != "" {
+				t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+			}
+			if got := rec.Body(); got != test.wantBody {
+				t.Errorf("response body got: %q want: %q", got, test.wantBody)
+			}
+			if logger.report != test.wantReport {
+				t.Errorf("logger.report: got %s, want %s", logger.report, test.wantReport)
+			}
+		})
+	}
+}
+
+func TestReportModeMissingLogger(t *testing.T) {
+	p := fetchmetadata.NewPlugin()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("p.SetReportMode(nil) expected panic")
+		}
+	}()
+	p.SetReportMode(nil)
+}
+
+type fooLog struct {
+	report string
+}
+
+func (l *fooLog) Log(r *safehttp.IncomingRequest) {
+	l.report = r.Method() + " " + r.URL.Path()
+}
+
+func TestChangeMode(t *testing.T) {
+	logger := &fooLog{}
+	p := fetchmetadata.NewPlugin()
+	req := safehttptest.NewRequest("POST", "/pizza", nil)
+	req.Header.Add("Sec-Fetch-Site", "cross-site")
+	req.Header.Add("Sec-Fetch-Mode", "navigate")
+	rec := safehttptest.NewResponseRecorder()
+
+	p.Before(rec.ResponseWriter, req)
+
+	if status := rec.Status(); status != 403 {
+		t.Errorf("status code got: %v want: %v", status, 403)
+	}
+	wantHeaders := map[string][]string{
+		"Content-Type":           {"text/plain; charset=utf-8"},
+		"X-Content-Type-Options": {"nosniff"},
+	}
+	if diff := cmp.Diff(wantHeaders, map[string][]string(rec.Header())); diff != "" {
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+	}
+
+	if wantBody, got := "Forbidden\n", rec.Body(); got != wantBody {
+		t.Errorf("response body got: %q want: %q", got, wantBody)
+	}
+
+	req = safehttptest.NewRequest("POST", "/pizza", nil)
+	req.Header.Add("Sec-Fetch-Site", "cross-site")
+	req.Header.Add("Sec-Fetch-Mode", "navigate")
+	rec = safehttptest.NewResponseRecorder()
+	p.SetReportMode(logger)
+
+	p.Before(rec.ResponseWriter, req)
+
+	if status := rec.Status(); status != 200 {
+		t.Errorf("status code got: %v want: %v", status, 200)
+	}
+	if diff := cmp.Diff(map[string][]string{}, map[string][]string(rec.Header())); diff != "" {
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+	}
+	if wantBody, got := "", rec.Body(); got != wantBody {
+		t.Errorf("response body got: %q want: %q", got, wantBody)
+	}
+	if want := "POST /pizza"; logger.report != want {
+		t.Errorf("logger.report: got %s, want %s", logger.report, want)
+	}
+}
+
+func TestCustomPolicy(t *testing.T) {
+	policy := func(r *safehttp.IncomingRequest) bool {
+		if r.Header.Get("Sec-Fetch-Mode") != "cors" {
+			return false
+		}
+		return true
+	}
+	tests := []struct {
+		name        string
+		req         *safehttp.IncomingRequest
+		wantStatus  int
+		wantHeaders map[string][]string
+		wantBody    string
+	}{
+		{
+			name: "Allowed request for custom policy",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/pizza", nil)
+				req.Header.Add("Sec-Fetch-Mode", "cors")
+				return req
+			}(),
+			wantStatus:  200,
+			wantHeaders: map[string][]string{},
+			wantBody:    "",
+		},
+		{
+			name: "Rejected request for custom policy",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest("POST", "/pizza", nil)
+				req.Header.Add("Sec-Fetch-Mode", "navigate")
+				return req
+			}(),
+			wantStatus: 403,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Forbidden\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := fetchmetadata.NewPlugin()
+			p.SetPolicy(policy)
+			rec := safehttptest.NewResponseRecorder()
+
+			p.Before(rec.ResponseWriter, test.req)
+
+			if status := rec.Status(); status != test.wantStatus {
+				t.Errorf("status code got: %v want: %v", status, test.wantStatus)
+			}
+			if diff := cmp.Diff(test.wantHeaders, map[string][]string(rec.Header())); diff != "" {
+				t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+			}
+			if got := rec.Body(); got != test.wantBody {
+				t.Errorf("response body got: %q want: %q", got, test.wantBody)
+			}
+		})
+	}
+
+}

--- a/safehttp/plugins/fetch_metadata/fetch_metadata_test.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata_test.go
@@ -306,9 +306,6 @@ func TestResourceIsolationReportMode(t *testing.T) {
 			p.SetReportOnly()
 			p.Before(rec.ResponseWriter, req)
 
-			if want, got := safehttp.StatusOK, safehttp.StatusCode(rec.Status()); want != got {
-				t.Errorf("status code got: %v want: %v", got, want)
-			}
 			if want, got := safehttp.StatusOK, safehttp.StatusCode(rec.Status()); got != want {
 				t.Errorf("status code got: %v want: %v", got, want)
 			}
@@ -407,9 +404,6 @@ func TestNavIsolationReportMode(t *testing.T) {
 			p.Before(rec.ResponseWriter, req)
 
 			if want, got := safehttp.StatusOK, safehttp.StatusCode(rec.Status()); want != got {
-				t.Errorf("status code got: %v want: %v", got, want)
-			}
-			if want, got := safehttp.StatusOK, safehttp.StatusCode(rec.Status()); got != want {
 				t.Errorf("status code got: %v want: %v", got, want)
 			}
 			if diff := cmp.Diff(map[string][]string{}, map[string][]string(rec.Header())); diff != "" {

--- a/safehttp/plugins/fetch_metadata/fetch_metadata_test.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata_test.go
@@ -503,7 +503,7 @@ func TestCORSAfterRedirect(t *testing.T) {
 
 			p := fetchmetadata.NewPlugin("/carbonara")
 			p.NavIsolation = true
-			p.RedirectURL, _ = safehttp.Parse("https://spaghetti.com/carbonara")
+			p.RedirectURL, _ = safehttp.ParseURL("https://spaghetti.com/carbonara")
 			p.Before(rec.ResponseWriter, req)
 
 			if want, got := safehttp.StatusMovedPermanently, safehttp.StatusCode(rec.Status()); got != want {

--- a/safehttp/url.go
+++ b/safehttp/url.go
@@ -74,9 +74,9 @@ func (u URL) Path() string {
 	return u.url.Path
 }
 
-// ParseURL parses a rawURL string into a URL structure.
+// ParseURL parses a raw URL string into a URL structure.
 //
-// The rawURl may be relative (a path, without a host) or absolute (starting
+// The raw URl may be relative (a path, without a host) or absolute (starting
 // with a scheme). Trying to parse a hostname and path without a scheme is
 // invalid but may not necessarily return an error, due to parsing ambiguities.
 func ParseURL(rawurl string) (*URL, error) {

--- a/safehttp/url.go
+++ b/safehttp/url.go
@@ -74,12 +74,12 @@ func (u URL) Path() string {
 	return u.url.Path
 }
 
-// Parse parses a rawURL string into a URL structure.
+// ParseURL parses a rawURL string into a URL structure.
 //
 // The rawURl may be relative (a path, without a host) or absolute (starting
 // with a scheme). Trying to parse a hostname and path without a scheme is
 // invalid but may not necessarily return an error, due to parsing ambiguities.
-func Parse(rawurl string) (*URL, error) {
+func ParseURL(rawurl string) (*URL, error) {
 	parsed, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, err

--- a/safehttp/url.go
+++ b/safehttp/url.go
@@ -14,7 +14,9 @@
 
 package safehttp
 
-import "net/url"
+import (
+	"net/url"
+)
 
 // URL represents a parsed URL (technically, a URI reference).
 type URL struct {
@@ -70,4 +72,18 @@ func (u URL) Port() string {
 // were %2f.
 func (u URL) Path() string {
 	return u.url.Path
+}
+
+// Parse parses a rawurl string into a URL structure.
+//
+// The rawurl may be relative (a path, without a host) or absolute
+// (starting with a scheme). Trying to parse a hostname and path
+// without a scheme is invalid but may not necessarily return an
+// error, due to parsing ambiguities.
+func Parse(rawurl string) (*URL, error) {
+	parsed, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, err
+	}
+	return &URL{url: parsed}, nil
 }

--- a/safehttp/url.go
+++ b/safehttp/url.go
@@ -68,18 +68,17 @@ func (u URL) Port() string {
 //
 // Note that the path is stored in decoded form: /%47%6f%2f
 // becomes /Go/. A consequence is that it is impossible to tell
-// which slashes in the path were slashes in the raw URL and which
+// which slashes in the path were slashes in the rawURL and which
 // were %2f.
 func (u URL) Path() string {
 	return u.url.Path
 }
 
-// Parse parses a rawurl string into a URL structure.
+// Parse parses a rawURL string into a URL structure.
 //
-// The rawurl may be relative (a path, without a host) or absolute
-// (starting with a scheme). Trying to parse a hostname and path
-// without a scheme is invalid but may not necessarily return an
-// error, due to parsing ambiguities.
+// The rawURl may be relative (a path, without a host) or absolute (starting
+// with a scheme). Trying to parse a hostname and path without a scheme is
+// invalid but may not necessarily return an error, due to parsing ambiguities.
 func Parse(rawurl string) (*URL, error) {
 	parsed, err := url.Parse(rawurl)
 	if err != nil {

--- a/safehttp/url_test.go
+++ b/safehttp/url_test.go
@@ -55,7 +55,7 @@ func TestURLHost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			netURL, err := url.Parse(tt.url)
 			if err != nil {
-				t.Fatalf("url.Parse(tt.url) got: %v want: nil", err)
+				t.Fatalf("url.Parse(tt.url) got err %v", err)
 			}
 
 			u := URL{url: netURL}
@@ -93,7 +93,7 @@ func TestURLHostname(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			netURL, err := url.Parse(tt.url)
 			if err != nil {
-				t.Fatalf("url.Parse(tt.url) got: %v want: nil", err)
+				t.Fatalf("url.Parse(tt.url) got err %v", err)
 			}
 
 			u := URL{url: netURL}
@@ -204,7 +204,7 @@ func TestURLInvalidQuery(t *testing.T) {
 	}
 }
 
-func TestURLParse(t *testing.T) {
+func TestURLParseURL(t *testing.T) {
 	var tests = []struct {
 		name, url string
 	}{
@@ -220,12 +220,12 @@ func TestURLParse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			url, err := Parse(test.url)
+			url, err := ParseURL(test.url)
 			if url == nil {
-				t.Error("Parse(test.url): got nil, want URL")
+				t.Error("ParseURL(test.url): got nil, want URL")
 			}
 			if err != nil {
-				t.Errorf("Parse(test.url): got %v, want nil", err)
+				t.Errorf("ParseURL(test.url): got err %v", err)
 			}
 			if got := url.String(); got != test.url {
 				t.Errorf("url.String(): got %v, want %v", got, test.url)
@@ -234,12 +234,12 @@ func TestURLParse(t *testing.T) {
 	}
 }
 
-func TestURLInvalidParse(t *testing.T) {
-	url, err := Parse("http://www.example.com/path%%%x=0")
+func TestURLInvalidParseURL(t *testing.T) {
+	url, err := ParseURL("http://www.example.com/path%%%x=0")
 	if url != nil {
-		t.Errorf(`Parse: got %v, want nil`, url)
+		t.Errorf(`ParseURL: got err %v`, url)
 	}
 	if err == nil {
-		t.Errorf(`Parse: got nil, want error`)
+		t.Errorf(`ParseURL: got nil, want error`)
 	}
 }

--- a/safehttp/url_test.go
+++ b/safehttp/url_test.go
@@ -227,6 +227,9 @@ func TestURLParse(t *testing.T) {
 			if err != nil {
 				t.Errorf("Parse(test.url): got %v, want nil", err)
 			}
+			if got := url.String(); got != test.url {
+				t.Errorf("url.String(): got %v, want %v", got, test.url)
+			}
 		})
 	}
 }

--- a/safehttp/url_test.go
+++ b/safehttp/url_test.go
@@ -203,3 +203,40 @@ func TestURLInvalidQuery(t *testing.T) {
 		t.Error("u.Query() got: nil want: error")
 	}
 }
+
+func TestURLParse(t *testing.T) {
+	var tests = []struct {
+		name, url string
+	}{
+		{
+			name: "Absolute url",
+			url:  "http://www.example.com/path?foo=bar#tar",
+		},
+		{
+			name: "Relative url",
+			url:  "example.com/path",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			url, err := Parse(test.url)
+			if url == nil {
+				t.Error("Parse(test.url): got nil, want URL")
+			}
+			if err != nil {
+				t.Errorf("Parse(test.url): got %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestURLInvalidParse(t *testing.T) {
+	url, err := Parse("http://www.example.com/path%%%x=0")
+	if url != nil {
+		t.Errorf(`Parse: got %v, want nil`, url)
+	}
+	if err == nil {
+		t.Errorf(`Parse: got nil, want error`)
+	}
+}


### PR DESCRIPTION
Fixes #78 

Implemented the initial version of Fetch Metadata plugin. It enforces a Resource Isolation Policy by default and supports enabling and disabling a Navigation Isolation Policy. The user can provide a custom policy instead of the default policy if needed. It also supports switching to a reporting mode that allows all requests to pass and only logs violation.