### PR TITLE
Added first version of CSP plugin.

### DIFF
--- a/safehttp/header.go
+++ b/safehttp/header.go
@@ -49,6 +49,9 @@ func (h Header) Claim(name string) (set func([]string), err error) {
 	}
 	h.claimed[name] = true
 	return func(v []string) {
+		if v == nil {
+			return
+		}
 		h.wrapped[name] = v
 	}, nil
 }

--- a/safehttp/interceptor.go
+++ b/safehttp/interceptor.go
@@ -20,6 +20,8 @@ package safehttp
 type Interceptor interface {
 	// Before runs before the IncomingRequest is sent to the handler. If a
 	// response is written to the ResponseWriter, then the remaining
-	// interceptors and the handler won't execute.
+	// interceptors and the handler won't execute. If the interceptor panics
+	// during the execution of Before, the panic will be recovered and the ServeMux
+	// will responds with 500 Internal Server Error.
 	Before(w ResponseWriter, r *IncomingRequest) Result
 }

--- a/safehttp/interceptor.go
+++ b/safehttp/interceptor.go
@@ -20,8 +20,7 @@ package safehttp
 type Interceptor interface {
 	// Before runs before the IncomingRequest is sent to the handler. If a
 	// response is written to the ResponseWriter, then the remaining
-	// interceptors and the handler won't execute. If the interceptor panics
-	// during the execution of Before, the panic will be recovered and the ServeMux
-	// will responds with 500 Internal Server Error.
+	// interceptors and the handler won't execute. If Before panics, it will be
+	// recovered and the ServeMux will respond with 500 Internal Server Error.
 	Before(w ResponseWriter, r *IncomingRequest) Result
 }

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -164,7 +164,9 @@ func (m methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: run After/Commit stages if Before panics.
+	// The `net/http` package recovers handler panics, but we cannot rely on that behavior here.
+	// The reason is, we might need to run After/Commit stages of the interceptors before we
+	// respond with a 500 Internal Server Error.
 	defer func() {
 		if r := recover(); r != nil {
 			rw.ServerError(StatusInternalServerError)

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -164,6 +164,7 @@ func (m methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO: run After/Commit stages if Before panics.
 	defer func() {
 		if r := recover(); r != nil {
 			rw.ServerError(StatusInternalServerError)

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -164,6 +164,12 @@ func (m methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			rw.ServerError(StatusInternalServerError)
+		}
+	}()
+
 	for _, intercep := range m.muxInterceps {
 		if res := intercep.Before(rw, ir); res.written {
 			return

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -202,12 +202,7 @@ func (p *claimHeaderInterceptor) SetHeader(value string) {
 type panickingInterceptor struct{}
 
 func (panickingInterceptor) Before(w safehttp.ResponseWriter, _ *safehttp.IncomingRequest) safehttp.Result {
-	// Don't remove this if-statement, then "go vet" will complain about
-	// unreachable code.
-	if true {
-		panic("bad")
-	}
-	return safehttp.Result{}
+	panic("bad")
 }
 
 func TestMuxInterceptors(t *testing.T) {

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -100,7 +100,7 @@ func NewPolicy(reportURI string) *Policy {
 
 // Serialize serializes this policy for use in a Content-Security-Policy header
 // or in a Content-Security-Policy-Report-Only header. The nonces generated for
-// each directive is also returned.
+// each directive are also returned.
 func (p Policy) Serialize() (csp string, nonces map[Directive]string) {
 	nonces = make(map[Directive]string)
 	b := strings.Builder{}
@@ -132,8 +132,8 @@ type Interceptor struct {
 	// EnforcementPolicy will be applied as the Content-Security-Policy header.
 	EnforcementPolicy *Policy
 
-	// ReportOnlyPolicy will be applied as the
-	// Content-Security-Policy-Report-Only header.
+	// ReportOnlyPolicy will be applied as the Content-Security-Policy-Report-Only
+	// header.
 	ReportOnlyPolicy *Policy
 }
 

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -15,7 +15,6 @@
 package csp
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -152,11 +151,9 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	if it.EnforcementPolicy != nil {
-		s, nonces := it.EnforcementPolicy.Serialize()
+		s, _ := it.EnforcementPolicy.Serialize()
+		// TODO: add nonces to context.
 		setCSP([]string{s})
-		if len(nonces) != 0 {
-			r.SetContext(context.WithValue(r.Context(), ctxKey("enforce"), nonces))
-		}
 	}
 
 	setCSPReportOnly, err := h.Claim("Content-Security-Policy-Report-Only")
@@ -164,11 +161,9 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	if it.ReportOnlyPolicy != nil {
-		s, nonces := it.ReportOnlyPolicy.Serialize()
+		s, _ := it.ReportOnlyPolicy.Serialize()
+		// TODO: add nonces to context.
 		setCSPReportOnly([]string{s})
-		if len(nonces) != 0 {
-			r.SetContext(context.WithValue(r.Context(), ctxKey("report"), nonces))
-		}
 	}
 
 	return safehttp.Result{}

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -28,10 +28,10 @@ type Directive string
 
 const (
 	DirectiveScriptSrc Directive = "script-src"
-	DirectiveStyleSrc  Directive = "style-src"
-	DirectiveObjectSrc Directive = "object-src"
-	DirectiveBaseURI   Directive = "base-uri"
-	DirectiveReportURI Directive = "report-uri"
+	DirectiveStyleSrc            = "style-src"
+	DirectiveObjectSrc           = "object-src"
+	DirectiveBaseURI             = "base-uri"
+	DirectiveReportURI           = "report-uri"
 )
 
 const (

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -113,11 +113,19 @@ func (s StrictCSPBuilder) Build() Policy {
 // FramingPolicy creates a new CSP policy with frame-ancestors set to 'self'.
 //
 // TODO: allow relaxation on specific endpoints according to #77.
-func FramingPolicy(reportOnly bool) Policy {
+func FramingPolicy(reportOnly bool, reportURI string) Policy {
 	return Policy{
 		reportOnly: reportOnly,
 		serialize: func(ctx context.Context) (string, context.Context) {
-			return "frame-ancestors 'self'", ctx
+			var b strings.Builder
+			b.WriteString("frame-ancestors 'self'")
+
+			if reportURI != "" {
+				b.WriteString("; report-uri ")
+				b.WriteString(reportURI)
+			}
+
+			return b.String(), ctx
 		},
 	}
 }
@@ -135,7 +143,7 @@ func NewInterceptor(p ...Policy) Interceptor {
 // Default creates a new CSP interceptor with a strict nonce-based policy and a
 // framing policy, both in enforcement mode.
 func Default(reportURI string) Interceptor {
-	return NewInterceptor(StrictCSPBuilder{ReportURI: reportURI}.Build(), FramingPolicy(false))
+	return NewInterceptor(StrictCSPBuilder{ReportURI: reportURI}.Build(), FramingPolicy(false, reportURI))
 }
 
 // Before claims and sets the Content-Security-Policy header and the

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -175,13 +175,13 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 	nonce := generateNonce()
 	r.SetContext(context.WithValue(r.Context(), ctxKey{}, nonce))
 
-	var csps []string
+	var CSPs []string
 	for _, p := range it.Enforce {
-		csps = append(csps, p.serialize(nonce))
+		CSPs = append(CSPs, p.serialize(nonce))
 	}
-	var reportCsps []string
+	var reportCSPs []string
 	for _, p := range it.ReportOnly {
-		reportCsps = append(reportCsps, p.serialize(nonce))
+		reportCSPs = append(reportCSPs, p.serialize(nonce))
 	}
 
 	h := w.Header()
@@ -194,8 +194,8 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 
-	setCSP(csps)
-	setCSPReportOnly(reportCsps)
+	setCSP(CSPs)
+	setCSPReportOnly(reportCSPs)
 
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -141,19 +141,8 @@ func Default(reportURI string) Interceptor {
 // Before claims and sets the Content-Security-Policy header and the
 // Content-Security-Policy-Report-Only header.
 func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-	h := w.Header()
-	setCSP, err := h.Claim("Content-Security-Policy")
-	if err != nil {
-		return w.ServerError(safehttp.StatusInternalServerError)
-	}
-
-	setCSPReportOnly, err := h.Claim("Content-Security-Policy-Report-Only")
-	if err != nil {
-		return w.ServerError(safehttp.StatusInternalServerError)
-	}
-
-	csps := make([]string, 0)
-	reportCsps := make([]string, 0)
+	var csps []string
+	var reportCsps []string
 	for _, p := range it.Policies {
 		v, ctx := p.serialize(r.Context())
 		r.SetContext(ctx)
@@ -163,7 +152,18 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 			csps = append(csps, v)
 		}
 	}
+
+	h := w.Header()
+	setCSP, err := h.Claim("Content-Security-Policy")
+	if err != nil {
+		return w.ServerError(safehttp.StatusInternalServerError)
+	}
 	setCSP(csps)
+
+	setCSPReportOnly, err := h.Claim("Content-Security-Policy-Report-Only")
+	if err != nil {
+		return w.ServerError(safehttp.StatusInternalServerError)
+	}
 	setCSPReportOnly(reportCsps)
 
 	return safehttp.Result{}

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -95,7 +95,7 @@ func (s StrictCSPBuilder) Build() Policy {
 			// object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-{random}'
 			b.WriteString("object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-")
 			b.WriteString(nonce)
-			b.WriteString("'")
+			b.WriteByte('\'')
 
 			if s.StrictDynamic {
 				b.WriteString(" 'strict-dynamic'")

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -65,12 +65,12 @@ func Nonce(ctx context.Context) (string, error) {
 //
 // See https://csp.withgoogle.com/docs/strict-csp.html for more info.
 type StrictCSPBuilder struct {
-	// StrictDynamic controls whether script-src should contain the 'strict-dynamic'
+	// NoStrictDynamic controls whether script-src should contain the 'strict-dynamic'
 	// value.
 	//
 	// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic
 	// for more info.
-	StrictDynamic bool
+	NoStrictDynamic bool
 	// UnsafeEval controls whether script-src should contain the 'unsafe-eval' value.
 	// If enabled, the eval() JavaScript function is allowed.
 	UnsafeEval bool
@@ -97,9 +97,10 @@ func (s StrictCSPBuilder) Build() Policy {
 			b.WriteString(nonce)
 			b.WriteByte('\'')
 
-			if s.StrictDynamic {
+			if !s.NoStrictDynamic {
 				b.WriteString(" 'strict-dynamic' https: http:")
 			}
+
 			if s.UnsafeEval {
 				b.WriteString(" 'unsafe-eval'")
 			}

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -127,15 +127,15 @@ type Interceptor struct {
 	Policies []Policy
 }
 
+// NewInterceptor creates an interceptor from the provided policies.
+func NewInterceptor(p ...Policy) Interceptor {
+	return Interceptor{Policies: p}
+}
+
 // Default creates a new CSP interceptor with a strict nonce-based policy and a
 // framing policy, both in enforcement mode.
 func Default(reportURI string) Interceptor {
-	return Interceptor{
-		Policies: []Policy{
-			StrictCSPBuilder{ReportURI: reportURI}.Build(),
-			NewFramingCSP(false),
-		},
-	}
+	return NewInterceptor(StrictCSPBuilder{ReportURI: reportURI}.Build(), NewFramingCSP(false))
 }
 
 // Before claims and sets the Content-Security-Policy header and the

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -25,7 +25,9 @@ import (
 
 var randReader = rand.Reader
 
-// nonceSize is the size of the nonces in bytes.
+// nonceSize is the size of the nonces in bytes. According to the CSP3 spec it should
+// be larger than 16 bytes. 20 bytes was picked to be future proof.
+// https://www.w3.org/TR/CSP3/#security-nonces
 const nonceSize = 20
 
 func generateNonce() string {
@@ -43,8 +45,8 @@ type Policy struct {
 	reportOnly bool
 
 	// serialize serializes this policy for use in a Content-Security-Policy header
-	// or in a Content-Security-Policy-Report-Only header. If needsNonce is true,
-	// a nonce will be provided to serialize.
+	// or in a Content-Security-Policy-Report-Only header. A nonce will be provided
+	// to serialize which can be used in 'nonce-{random-nonce}' values in directives.
 	serialize func(nonce string) string
 }
 
@@ -95,6 +97,7 @@ func (s StrictCSPBuilder) Build() Policy {
 		serialize: func(nonce string) string {
 			var b strings.Builder
 
+			// object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-{random}'
 			b.WriteString("object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-")
 			b.WriteString(nonce)
 			b.WriteString("'")

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -26,7 +26,7 @@ import (
 var randReader = rand.Reader
 
 // nonceSize is the size of the nonces in bytes.
-const nonceSize = 8
+const nonceSize = 20
 
 func generateNonce() string {
 	b := make([]byte, nonceSize)

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -92,13 +92,13 @@ func (s StrictCSPBuilder) Build() Policy {
 		serialize: func(nonce string) string {
 			var b strings.Builder
 
-			// object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-{random}'
-			b.WriteString("object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-")
+			// object-src 'none'; script-src 'unsafe-inline' 'nonce-{random}'
+			b.WriteString("object-src 'none'; script-src 'unsafe-inline' 'nonce-")
 			b.WriteString(nonce)
 			b.WriteByte('\'')
 
 			if s.StrictDynamic {
-				b.WriteString(" 'strict-dynamic'")
+				b.WriteString(" 'strict-dynamic' https: http:")
 			}
 			if s.UnsafeEval {
 				b.WriteString(" 'unsafe-eval'")

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -200,12 +200,12 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 	if err != nil {
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
-	setCSP(csps)
-
 	setCSPReportOnly, err := h.Claim("Content-Security-Policy-Report-Only")
 	if err != nil {
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
+
+	setCSP(csps)
 	setCSPReportOnly(reportCsps)
 
 	return safehttp.Result{}

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -61,15 +61,31 @@ func Nonce(ctx context.Context) string {
 }
 
 // StrictCSPBuilder can be used to build a strict, nonce-based CSP.
-// See https://csp.withgoogle.com/docs/strict-csp.html for more info.
 //
-// If BaseURI is an empty string the base-uri directive will be set to 'none'.
+// See https://csp.withgoogle.com/docs/strict-csp.html for more info.
 type StrictCSPBuilder struct {
-	ReportOnly    bool
+	// ReportOnly controls whether this policy should be set as a Content-Security-Policy
+	// header or a Content-Security-Policy-Report-Only header.
+	ReportOnly bool
+	// StrictDynamic controls whether script-src should contain the 'strict-dynamic'
+	// value.
+	//
+	// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic
+	// for more info.
 	StrictDynamic bool
-	UnsafeEval    bool
-	BaseURI       string
-	ReportURI     string
+	// UnsafeEval controls whether script-src should contain the 'unsafe-eval' value.
+	// If enabled, the eval() JavaScript function is allowed.
+	UnsafeEval bool
+	// BaseURI controls the base-uri directive. If BaseURI is an empty string the
+	// directive will be set to 'none'. The base-uri directive restricts the URLs
+	// which can be used in a document's <base> element.
+	//
+	// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri
+	// for more info.
+	BaseURI string
+	// ReportURI controls the report-uri directive. If ReportUri is empty, no report-uri
+	// directive will be set.
+	ReportURI string
 }
 
 // Build creates a Policy based on the specified options.
@@ -112,8 +128,12 @@ func (s StrictCSPBuilder) Build() Policy {
 //
 // TODO: allow relaxation on specific endpoints according to #77.
 type FramingPolicyBuilder struct {
+	// ReportOnly controls whether this policy should be set as a Content-Security-Policy
+	// header or a Content-Security-Policy-Report-Only header.
 	ReportOnly bool
-	ReportURI  string
+	// ReportURI controls the report-uri directive. If ReportUri is empty, no report-uri
+	// directive will be set.
+	ReportURI string
 }
 
 // Build creates a Policy based on the specified options.

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -110,10 +110,10 @@ func (s StrictCSPBuilder) Build() Policy {
 	}
 }
 
-// NewFramingCSP creates a new CSP policy with frame-ancestors set to 'self'.
+// FramingPolicy creates a new CSP policy with frame-ancestors set to 'self'.
 //
 // TODO: allow relaxation on specific endpoints according to #77.
-func NewFramingCSP(reportOnly bool) Policy {
+func FramingPolicy(reportOnly bool) Policy {
 	return Policy{
 		reportOnly: reportOnly,
 		serialize: func(ctx context.Context) (string, context.Context) {
@@ -135,7 +135,7 @@ func NewInterceptor(p ...Policy) Interceptor {
 // Default creates a new CSP interceptor with a strict nonce-based policy and a
 // framing policy, both in enforcement mode.
 func Default(reportURI string) Interceptor {
-	return NewInterceptor(StrictCSPBuilder{ReportURI: reportURI}.Build(), NewFramingCSP(false))
+	return NewInterceptor(StrictCSPBuilder{ReportURI: reportURI}.Build(), FramingPolicy(false))
 }
 
 // Before claims and sets the Content-Security-Policy header and the

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -1,0 +1,182 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csp
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"strings"
+
+	"github.com/google/go-safeweb/safehttp"
+)
+
+// Directive is the name of a single CSP directive.
+type Directive string
+
+const (
+	DirectiveScriptSrc Directive = "script-src"
+	DirectiveStyleSrc  Directive = "style-src"
+	DirectiveObjectSrc Directive = "object-src"
+	DirectiveBaseURI   Directive = "base-uri"
+	DirectiveReportURI Directive = "report-uri"
+)
+
+const (
+	ValueHTTPS         = "https:"
+	ValueHTTP          = "http:"
+	ValueUnsafeEval    = "'unsafe-eval'"
+	ValueUnsafeInline  = "'unsafe-inline'"
+	ValueNone          = "'none'"
+	ValueStrictDynamic = "'strict-dynamic'"
+)
+
+// PolicyDirective contains a single CSP directive.
+type PolicyDirective struct {
+	dir       Directive
+	vals      []string
+	nonces    bool
+	lastNonce string
+	// readRand is used for dependency injection in tests.
+	readRand func([]byte) (int, error)
+}
+
+// NewPolicyDirective creates a new PolicyDirective given the directive, the
+// values and whether or not a nonce directive should be added.
+func NewPolicyDirective(d Directive, values []string, nonces bool) *PolicyDirective {
+	return &PolicyDirective{
+		dir:      d,
+		vals:     values,
+		nonces:   nonces,
+		readRand: rand.Read,
+	}
+}
+
+// nonceSize is the size of the nonces in bytes.
+const nonceSize = 8
+
+func (pd *PolicyDirective) generateNonce() {
+	b := make([]byte, nonceSize)
+	_, err := pd.readRand(b)
+	if err != nil {
+		// TODO: handle this better, what should happen here?
+		panic(err)
+	}
+	pd.lastNonce = base64.StdEncoding.EncodeToString(b)
+}
+
+// Policy defines a CSP policy, containing many directives.
+type Policy struct {
+	Directives []*PolicyDirective
+}
+
+// NewPolicy creates a new strict, nonce-based CSP.
+// See https://csp.withgoogle.com/docs/strict-csp.html for more info.
+//
+// TODO: maybe reportURI should be safehttp.URL?
+func NewPolicy(reportURI string) *Policy {
+	return &Policy{
+		Directives: []*PolicyDirective{
+			NewPolicyDirective(DirectiveObjectSrc, []string{ValueNone}, false),
+			NewPolicyDirective(DirectiveScriptSrc, []string{
+				ValueUnsafeInline,
+				ValueUnsafeEval,
+				ValueStrictDynamic,
+				ValueHTTPS,
+				ValueHTTP,
+			}, true),
+			NewPolicyDirective(DirectiveBaseURI, []string{ValueNone}, false),
+			NewPolicyDirective(DirectiveReportURI, []string{reportURI}, false),
+		},
+	}
+}
+
+// Serialize serializes this policy for use in a Content-Security-Policy header
+// or in a Content-Security-Policy-Report-Only header. The nonces generated for
+// each directive is also returned.
+func (p Policy) Serialize() (csp string, nonces map[Directive]string) {
+	nonces = make(map[Directive]string)
+	b := strings.Builder{}
+
+	for i, d := range p.Directives {
+		if i != 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(string(d.dir))
+
+		if d.nonces {
+			d.generateNonce()
+			b.WriteString(" 'nonce-")
+			b.WriteString(d.lastNonce)
+			b.WriteString("'")
+			nonces[d.dir] = d.lastNonce
+		}
+
+		for _, v := range d.vals {
+			b.WriteString(" ")
+			b.WriteString(v)
+		}
+	}
+	return b.String(), nonces
+}
+
+// Interceptor intercepts requests and applies CSP policies.
+type Interceptor struct {
+	// EnforcementPolicy will be applied as the Content-Security-Policy header.
+	EnforcementPolicy *Policy
+
+	// ReportOnlyPolicy will be applied as the
+	// Content-Security-Policy-Report-Only header.
+	ReportOnlyPolicy *Policy
+}
+
+// Default creates a new CSP interceptor with a strict nonce-based policy in
+// enforcement mode.
+func Default(reportURI string) Interceptor {
+	return Interceptor{EnforcementPolicy: NewPolicy(reportURI)}
+}
+
+type ctxKey string
+
+// Before claims and sets the Content-Security-Policy header and the
+// Content-Security-Policy-Report-Only header.
+func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+	h := w.Header()
+	setCSP, err := h.Claim("Content-Security-Policy")
+	if err != nil {
+		return w.ServerError(safehttp.StatusInternalServerError)
+	}
+	if it.EnforcementPolicy != nil {
+		s, nonces := it.EnforcementPolicy.Serialize()
+		setCSP([]string{s})
+		if len(nonces) != 0 {
+			r.SetContext(context.WithValue(r.Context(), ctxKey("enforce"), nonces))
+		}
+	}
+
+	setCSPReportOnly, err := h.Claim("Content-Security-Policy-Report-Only")
+	if err != nil {
+		return w.ServerError(safehttp.StatusInternalServerError)
+	}
+	if it.ReportOnlyPolicy != nil {
+		s, nonces := it.ReportOnlyPolicy.Serialize()
+		setCSPReportOnly([]string{s})
+		if len(nonces) != 0 {
+			r.SetContext(context.WithValue(r.Context(), ctxKey("report"), nonces))
+		}
+	}
+
+	return safehttp.Result{}
+}

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 	"strings"
 
 	"github.com/google/go-safeweb/safehttp"
@@ -34,8 +35,7 @@ func generateNonce() string {
 	b := make([]byte, nonceSize)
 	_, err := randReader.Read(b)
 	if err != nil {
-		// TODO: handle this better, what should happen here?
-		panic(err)
+		panic(fmt.Errorf("failed to generate entropy using crypto/rand/RandReader: %v", err))
 	}
 	return base64.StdEncoding.EncodeToString(b)
 }

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -53,13 +54,13 @@ type Policy struct {
 type ctxKey struct{}
 
 // Nonce retrieves the nonce from the given context. If there is no nonce stored
-// in the context, an empty string is returned.
-func Nonce(ctx context.Context) string {
+// in the context, an error will be returned.
+func Nonce(ctx context.Context) (string, error) {
 	v := ctx.Value(ctxKey{})
 	if v == nil {
-		return ""
+		return "", errors.New("no nonce in context")
 	}
-	return v.(string)
+	return v.(string), nil
 }
 
 // StrictCSPBuilder can be used to build a strict, nonce-based CSP.

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -79,8 +79,13 @@ func TestSerialize(t *testing.T) {
 		},
 		{
 			name:       "FramingCSP",
-			policy:     FramingPolicy(false),
+			policy:     FramingPolicy(false, ""),
 			wantString: "frame-ancestors 'self'",
+		},
+		{
+			name:       "FramingCSP with report-uri",
+			policy:     FramingPolicy(false, "httsp://example.com/collector"),
+			wantString: "frame-ancestors 'self'; report-uri httsp://example.com/collector",
 		},
 	}
 
@@ -129,7 +134,7 @@ func TestBefore(t *testing.T) {
 			interceptor: Default("https://example.com/collector"),
 			wantEnforcementPolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
-				"frame-ancestors 'self'",
+				"frame-ancestors 'self'; report-uri https://example.com/collector",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
@@ -143,8 +148,8 @@ func TestBefore(t *testing.T) {
 		},
 		{
 			name:                 "FramingCSP reportonly",
-			interceptor:          NewInterceptor(FramingPolicy(true)),
-			wantReportOnlyPolicy: []string{"frame-ancestors 'self'"},
+			interceptor:          NewInterceptor(FramingPolicy(true, "https://example.com/collector")),
+			wantReportOnlyPolicy: []string{"frame-ancestors 'self'; report-uri https://example.com/collector"},
 		},
 	}
 

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -114,8 +114,6 @@ func TestBefore(t *testing.T) {
 		interceptor           Interceptor
 		wantEnforcementPolicy []string
 		wantReportPolicy      []string
-		wantEnforcementNonces map[Directive]string
-		wantReportNonces      map[Directive]string
 	}{
 		{
 			name:        "No policies",
@@ -129,7 +127,6 @@ func TestBefore(t *testing.T) {
 				return p
 			}(),
 			wantEnforcementPolicy: []string{"object-src 'none'; script-src 'nonce-AAECAwQFBgc=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://foo.com/collector"},
-			wantEnforcementNonces: map[Directive]string{DirectiveScriptSrc: "AAECAwQFBgc="},
 		},
 		{
 			name: "Report",
@@ -152,7 +149,6 @@ func TestBefore(t *testing.T) {
 				}(),
 			},
 			wantReportPolicy: []string{"object-src 'none'; script-src 'nonce-AAECAwQFBgc=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://foo.com/collector"},
-			wantReportNonces: map[Directive]string{DirectiveScriptSrc: "AAECAwQFBgc="},
 		},
 		{
 			name: "Report and enforce",
@@ -188,17 +184,6 @@ func TestBefore(t *testing.T) {
 
 			if diff := cmp.Diff(tt.wantReportPolicy, h.Values("Content-Security-Policy-Report-Only")); diff != "" {
 				t.Errorf("h.Values(\"Content-Security-Policy-Report-Only\") mismatch (-want +got):\n%s", diff)
-			}
-
-			ctx := req.Context()
-			en := ctx.Value(ctxKey("enforce"))
-			if diff := cmp.Diff(tt.wantEnforcementNonces, en); !(en == nil && tt.wantEnforcementNonces == nil) && diff != "" {
-				t.Errorf("ctx.Value(ctxKey(\"enforce\")) mismatch (-want +got):\n%s", diff)
-			}
-
-			rn := ctx.Value(ctxKey("report"))
-			if diff := cmp.Diff(tt.wantReportNonces, rn); !(rn == nil && tt.wantReportNonces == nil) && diff != "" {
-				t.Errorf("ctx.Value(ctxKey(\"report\")) mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -98,7 +98,7 @@ func TestBefore(t *testing.T) {
 	tests := []struct {
 		name                 string
 		interceptor          Interceptor
-		wantEnforcPolicy     []string
+		wantEnforcePolicy    []string
 		wantReportOnlyPolicy []string
 		wantNonce            string
 	}{
@@ -110,7 +110,7 @@ func TestBefore(t *testing.T) {
 		{
 			name:        "Default policies",
 			interceptor: Default(""),
-			wantEnforcPolicy: []string{
+			wantEnforcePolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'",
 				"frame-ancestors 'self'",
 			},
@@ -119,7 +119,7 @@ func TestBefore(t *testing.T) {
 		{
 			name:        "Default policies with reporting URI",
 			interceptor: Default("https://example.com/collector"),
-			wantEnforcPolicy: []string{
+			wantEnforcePolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 				"frame-ancestors 'self'; report-uri https://example.com/collector",
 			},
@@ -157,7 +157,7 @@ func TestBefore(t *testing.T) {
 			tt.interceptor.Before(rr.ResponseWriter, req)
 
 			h := rr.Header()
-			if diff := cmp.Diff(tt.wantEnforcPolicy, h.Values("Content-Security-Policy"), cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tt.wantEnforcePolicy, h.Values("Content-Security-Policy"), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("h.Values(\"Content-Security-Policy\") mismatch (-want +got):\n%s", diff)
 			}
 

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -133,12 +133,8 @@ func TestBefore(t *testing.T) {
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
-			name: "StrictCSP reportonly",
-			interceptor: Interceptor{
-				Policies: []Policy{
-					StrictCSPBuilder{ReportOnly: true, ReportURI: "https://example.com/collector"}.Build(),
-				},
-			},
+			name:        "StrictCSP reportonly",
+			interceptor: NewInterceptor(StrictCSPBuilder{ReportOnly: true, ReportURI: "https://example.com/collector"}.Build()),
 			wantReportOnlyPolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 			},
@@ -146,7 +142,7 @@ func TestBefore(t *testing.T) {
 		},
 		{
 			name:                 "FramingCSP reportonly",
-			interceptor:          Interceptor{Policies: []Policy{NewFramingCSP(true)}},
+			interceptor:          NewInterceptor(NewFramingCSP(true)),
 			wantReportOnlyPolicy: []string{"frame-ancestors 'self'"},
 		},
 	}

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -79,7 +79,7 @@ func TestSerialize(t *testing.T) {
 		},
 		{
 			name:       "FramingCSP",
-			policy:     NewFramingCSP(false),
+			policy:     FramingPolicy(false),
 			wantString: "frame-ancestors 'self'",
 		},
 	}
@@ -143,7 +143,7 @@ func TestBefore(t *testing.T) {
 		},
 		{
 			name:                 "FramingCSP reportonly",
-			interceptor:          NewInterceptor(NewFramingCSP(true)),
+			interceptor:          NewInterceptor(FramingPolicy(true)),
 			wantReportOnlyPolicy: []string{"frame-ancestors 'self'"},
 		},
 	}

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -157,13 +157,12 @@ func TestBefore(t *testing.T) {
 				t.Errorf("h.Values(\"Content-Security-Policy-Report-Only\") mismatch (-want +got):\n%s", diff)
 			}
 
-			ctx := req.Context()
-			v := ctx.Value(ctxKey{})
+			v := req.Context().Value(ctxKey{})
 			if v == nil {
-				v = ""
+				t.Fatalf("req.Context().Value(ctxKey{}) got: nil want: %q", tt.wantNonce)
 			}
 			if got := v.(string); got != tt.wantNonce {
-				t.Errorf("ctx.Value(ctxKey{}) got: %q want: %q", got, tt.wantNonce)
+				t.Errorf("v.(string) got: %q want: %q", got, tt.wantNonce)
 			}
 		})
 	}

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -222,14 +222,24 @@ func TestPanicWhileGeneratingNonce(t *testing.T) {
 
 func TestValidNonce(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxKey{}, "nonce")
-	if got, want := Nonce(ctx), "nonce"; got != want {
-		t.Errorf("Nonce(ctx) got: %v want: %v", got, want)
+	n, err := Nonce(ctx)
+	if err != nil {
+		t.Errorf("Nonce(ctx) got err: %v want: nil", err)
+	}
+
+	if want := "nonce"; n != want {
+		t.Errorf("Nonce(ctx) got nonce: %v want: %v", n, want)
 	}
 }
 
 func TestNonceEmptyContext(t *testing.T) {
 	ctx := context.Background()
-	if got, want := Nonce(ctx), ""; got != want {
-		t.Errorf("Nonce(ctx) got: %v want: %v", got, want)
+	n, err := Nonce(ctx)
+	if err == nil {
+		t.Error("Nonce(ctx) got err: nil want: error")
+	}
+
+	if want := ""; n != want {
+		t.Errorf("Nonce(ctx) got nonce: %v want: %v", n, want)
 	}
 }

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -180,7 +180,7 @@ func TestAlreadyClaimed(t *testing.T) {
 		t.Run(h, func(t *testing.T) {
 			rr := safehttptest.NewResponseRecorder()
 			if _, err := rr.ResponseWriter.Header().Claim(h); err != nil {
-				t.Fatalf("rr.ResponseWriter.Header().Claim(h) got: %v want: nil", err)
+				t.Fatalf("rr.ResponseWriter.Header().Claim(h) got err: %v want: nil", err)
 			}
 			req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
 

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -96,11 +96,11 @@ func TestSerialize(t *testing.T) {
 
 func TestBefore(t *testing.T) {
 	tests := []struct {
-		name                  string
-		interceptor           Interceptor
-		wantEnforcementPolicy []string
-		wantReportOnlyPolicy  []string
-		wantNonce             string
+		name                 string
+		interceptor          Interceptor
+		wantEnforcPolicy     []string
+		wantReportOnlyPolicy []string
+		wantNonce            string
 	}{
 		{
 			name:        "No policies",
@@ -110,7 +110,7 @@ func TestBefore(t *testing.T) {
 		{
 			name:        "Default policies",
 			interceptor: Default(""),
-			wantEnforcementPolicy: []string{
+			wantEnforcPolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'",
 				"frame-ancestors 'self'",
 			},
@@ -119,14 +119,14 @@ func TestBefore(t *testing.T) {
 		{
 			name:        "Default policies with reporting URI",
 			interceptor: Default("https://example.com/collector"),
-			wantEnforcementPolicy: []string{
+			wantEnforcPolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 				"frame-ancestors 'self'; report-uri https://example.com/collector",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
-			name:        "StrictCSP reportonly",
+			name:        "StrictCSP Report Only",
 			interceptor: NewInterceptor(StrictCSPBuilder{ReportOnly: true, ReportURI: "https://example.com/collector"}.Build()),
 			wantReportOnlyPolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
@@ -134,7 +134,7 @@ func TestBefore(t *testing.T) {
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
-			name:                 "FramingCSP reportonly",
+			name:                 "FramingCSP Report Only",
 			interceptor:          NewInterceptor(FramingPolicyBuilder{ReportOnly: true, ReportURI: "https://example.com/collector"}.Build()),
 			wantReportOnlyPolicy: []string{"frame-ancestors 'self'; report-uri https://example.com/collector"},
 			wantNonce:            "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
@@ -149,7 +149,7 @@ func TestBefore(t *testing.T) {
 			tt.interceptor.Before(rr.ResponseWriter, req)
 
 			h := rr.Header()
-			if diff := cmp.Diff(tt.wantEnforcementPolicy, h.Values("Content-Security-Policy"), cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tt.wantEnforcPolicy, h.Values("Content-Security-Policy"), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("h.Values(\"Content-Security-Policy\") mismatch (-want +got):\n%s", diff)
 			}
 
@@ -220,7 +220,7 @@ func TestPanicWhileGeneratingNonce(t *testing.T) {
 	generateNonce()
 }
 
-func TestNonce(t *testing.T) {
+func TestValidNonce(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ctxKey{}, "nonce")
 	if got, want := Nonce(ctx), "nonce"; got != want {
 		t.Errorf("Nonce(ctx) got: %v want: %v", got, want)

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/google/go-safeweb/safehttp/safehttptest"
 )
 
-type dummyReader struct{}
+type endlessAReader struct{}
 
-func (dummyReader) Read(b []byte) (int, error) {
+func (endlessAReader) Read(b []byte) (int, error) {
 	for i := range b {
 		b[i] = 41
 	}
@@ -36,7 +36,7 @@ func (dummyReader) Read(b []byte) (int, error) {
 }
 
 func TestMain(m *testing.M) {
-	randReader = dummyReader{}
+	randReader = endlessAReader{}
 	os.Exit(m.Run())
 }
 

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -16,6 +16,7 @@ package csp
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -209,4 +210,20 @@ func TestAlreadyClaimed(t *testing.T) {
 			}
 		})
 	}
+}
+
+type errorReader struct{}
+
+func (errorReader) Read(b []byte) (int, error) {
+	return 0, errors.New("bad")
+}
+
+func TestPanicWhileGeneratingNonce(t *testing.T) {
+	randReader = errorReader{}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Nonce(context.Background()) expected panic")
+		}
+	}()
+	Nonce(context.Background())
 }

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -91,8 +91,12 @@ func TestSerialize(t *testing.T) {
 				t.Errorf("tt.policy.serialize() got: %q want: %q", s, tt.wantString)
 			}
 
-			if got := Nonce(ctx); got != tt.wantNonce {
-				t.Errorf("Nonce(ctx) got: %q want: %q", got, tt.wantNonce)
+			v := ctx.Value(ctxKey{})
+			if v == nil {
+				v = ""
+			}
+			if got := v.(string); got != tt.wantNonce {
+				t.Errorf("ctx.Value(ctxKey{}) got: %q want: %q", got, tt.wantNonce)
 			}
 		})
 	}
@@ -163,8 +167,13 @@ func TestBefore(t *testing.T) {
 				t.Errorf("h.Values(\"Content-Security-Policy-Report-Only\") mismatch (-want +got):\n%s", diff)
 			}
 
-			if got := Nonce(req.Context()); got != tt.wantNonce {
-				t.Errorf("Nonce(req.Context()) got: %q want: %q", got, tt.wantNonce)
+			ctx := req.Context()
+			v := ctx.Value(ctxKey{})
+			if v == nil {
+				v = ""
+			}
+			if got := v.(string); got != tt.wantNonce {
+				t.Errorf("ctx.Value(ctxKey{}) got: %q want: %q", got, tt.wantNonce)
 			}
 		})
 	}

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -73,12 +73,12 @@ func TestSerialize(t *testing.T) {
 		},
 		{
 			name:       "FramingCSP",
-			policy:     FramingPolicy(false, ""),
+			policy:     FramingPolicyBuilder{}.Build(),
 			wantString: "frame-ancestors 'self'",
 		},
 		{
 			name:       "FramingCSP with report-uri",
-			policy:     FramingPolicy(false, "httsp://example.com/collector"),
+			policy:     FramingPolicyBuilder{ReportURI: "httsp://example.com/collector"}.Build(),
 			wantString: "frame-ancestors 'self'; report-uri httsp://example.com/collector",
 		},
 	}
@@ -135,7 +135,7 @@ func TestBefore(t *testing.T) {
 		},
 		{
 			name:                 "FramingCSP reportonly",
-			interceptor:          NewInterceptor(FramingPolicy(true, "https://example.com/collector")),
+			interceptor:          NewInterceptor(FramingPolicyBuilder{ReportOnly: true, ReportURI: "https://example.com/collector"}.Build()),
 			wantReportOnlyPolicy: []string{"frame-ancestors 'self'; report-uri https://example.com/collector"},
 			wantNonce:            "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -49,27 +49,27 @@ func TestSerialize(t *testing.T) {
 		{
 			name:       "StrictCSP",
 			policy:     StrictCSPBuilder{}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret'; base-uri 'none'",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http:; base-uri 'none'",
 		},
 		{
-			name:       "StrictCSP with strict-dynamic",
-			policy:     StrictCSPBuilder{StrictDynamic: true}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http:; base-uri 'none'",
+			name:       "StrictCSP with no strict-dynamic",
+			policy:     StrictCSPBuilder{NoStrictDynamic: true}.Build(),
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret'; base-uri 'none'",
 		},
 		{
 			name:       "StrictCSP with unsafe-eval",
 			policy:     StrictCSPBuilder{UnsafeEval: true}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'unsafe-eval'; base-uri 'none'",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http: 'unsafe-eval'; base-uri 'none'",
 		},
 		{
 			name:       "StrictCSP with set base-uri",
 			policy:     StrictCSPBuilder{BaseURI: "https://example.com"}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret'; base-uri https://example.com",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http:; base-uri https://example.com",
 		},
 		{
 			name:       "StrictCSP with report-uri",
 			policy:     StrictCSPBuilder{ReportURI: "https://example.com/collector"}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret'; base-uri 'none'; report-uri https://example.com/collector",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://example.com/collector",
 		},
 		{
 			name:       "FramingCSP",
@@ -111,7 +111,7 @@ func TestBefore(t *testing.T) {
 			name:        "Default policies",
 			interceptor: Default(""),
 			wantEnforcePolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'",
+				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'strict-dynamic' https: http:; base-uri 'none'",
 				"frame-ancestors 'self'",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
@@ -120,7 +120,7 @@ func TestBefore(t *testing.T) {
 			name:        "Default policies with reporting URI",
 			interceptor: Default("https://example.com/collector"),
 			wantEnforcePolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
+				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://example.com/collector",
 				"frame-ancestors 'self'; report-uri https://example.com/collector",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
@@ -133,7 +133,7 @@ func TestBefore(t *testing.T) {
 				},
 			},
 			wantReportOnlyPolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
+				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://example.com/collector",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -49,32 +49,32 @@ func TestSerialize(t *testing.T) {
 		{
 			name:       "StrictCSP",
 			policy:     NewStrictCSP(false, false, false, "", ""),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSk='; base-uri 'none'",
-			wantNonce:  "KSkpKSkpKSk=",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'",
+			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "StrictCSP with strict-dynamic",
 			policy:     NewStrictCSP(false, true, false, "", ""),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSk=' 'strict-dynamic'; base-uri 'none'",
-			wantNonce:  "KSkpKSkpKSk=",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'strict-dynamic'; base-uri 'none'",
+			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "StrictCSP with unsafe-eval",
 			policy:     NewStrictCSP(false, false, true, "", ""),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSk=' 'unsafe-eval'; base-uri 'none'",
-			wantNonce:  "KSkpKSkpKSk=",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'unsafe-eval'; base-uri 'none'",
+			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "StrictCSP with set base-uri",
 			policy:     NewStrictCSP(false, false, false, "https://example.com", ""),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSk='; base-uri https://example.com",
-			wantNonce:  "KSkpKSkpKSk=",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri https://example.com",
+			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "StrictCSP with report-uri",
 			policy:     NewStrictCSP(false, false, true, "", "https://example.com/collector"),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSk=' 'unsafe-eval'; base-uri 'none'; report-uri https://example.com/collector",
-			wantNonce:  "KSkpKSkpKSk=",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'unsafe-eval'; base-uri 'none'; report-uri https://example.com/collector",
+			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "FramingCSP",
@@ -114,19 +114,19 @@ func TestBefore(t *testing.T) {
 			name:        "Default policies",
 			interceptor: Default(""),
 			wantEnforcementPolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSk='; base-uri 'none'",
+				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'",
 				"frame-ancestors 'self'",
 			},
-			wantNonce: "KSkpKSkpKSk=",
+			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:        "Default policies with reporting URI",
 			interceptor: Default("https://example.com/collector"),
 			wantEnforcementPolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
+				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 				"frame-ancestors 'self'",
 			},
-			wantNonce: "KSkpKSkpKSk=",
+			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name: "StrictCSP reportonly",
@@ -136,9 +136,9 @@ func TestBefore(t *testing.T) {
 				},
 			},
 			wantReportOnlyPolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
+				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 			},
-			wantNonce: "KSkpKSkpKSk=",
+			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:                 "FramingCSP reportonly",

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -49,27 +49,27 @@ func TestSerialize(t *testing.T) {
 		{
 			name:       "StrictCSP",
 			policy:     StrictCSPBuilder{}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-super-secret'; base-uri 'none'",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret'; base-uri 'none'",
 		},
 		{
 			name:       "StrictCSP with strict-dynamic",
 			policy:     StrictCSPBuilder{StrictDynamic: true}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-super-secret' 'strict-dynamic'; base-uri 'none'",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http:; base-uri 'none'",
 		},
 		{
 			name:       "StrictCSP with unsafe-eval",
 			policy:     StrictCSPBuilder{UnsafeEval: true}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-super-secret' 'unsafe-eval'; base-uri 'none'",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'unsafe-eval'; base-uri 'none'",
 		},
 		{
 			name:       "StrictCSP with set base-uri",
 			policy:     StrictCSPBuilder{BaseURI: "https://example.com"}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-super-secret'; base-uri https://example.com",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret'; base-uri https://example.com",
 		},
 		{
 			name:       "StrictCSP with report-uri",
 			policy:     StrictCSPBuilder{ReportURI: "https://example.com/collector"}.Build(),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-super-secret'; base-uri 'none'; report-uri https://example.com/collector",
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret'; base-uri 'none'; report-uri https://example.com/collector",
 		},
 		{
 			name:       "FramingCSP",
@@ -111,7 +111,7 @@ func TestBefore(t *testing.T) {
 			name:        "Default policies",
 			interceptor: Default(""),
 			wantEnforcePolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'",
+				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'",
 				"frame-ancestors 'self'",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
@@ -120,7 +120,7 @@ func TestBefore(t *testing.T) {
 			name:        "Default policies with reporting URI",
 			interceptor: Default("https://example.com/collector"),
 			wantEnforcePolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
+				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 				"frame-ancestors 'self'; report-uri https://example.com/collector",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
@@ -133,7 +133,7 @@ func TestBefore(t *testing.T) {
 				},
 			},
 			wantReportOnlyPolicy: []string{
-				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
+				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -126,16 +126,24 @@ func TestBefore(t *testing.T) {
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
-			name:        "StrictCSP Report Only",
-			interceptor: NewInterceptor(StrictCSPBuilder{ReportOnly: true, ReportURI: "https://example.com/collector"}.Build()),
+			name: "StrictCSP Report Only",
+			interceptor: Interceptor{
+				ReportOnly: []Policy{
+					StrictCSPBuilder{ReportURI: "https://example.com/collector"}.Build(),
+				},
+			},
 			wantReportOnlyPolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
-			name:                 "FramingCSP Report Only",
-			interceptor:          NewInterceptor(FramingPolicyBuilder{ReportOnly: true, ReportURI: "https://example.com/collector"}.Build()),
+			name: "FramingCSP Report Only",
+			interceptor: Interceptor{
+				ReportOnly: []Policy{
+					FramingPolicyBuilder{ReportURI: "https://example.com/collector"}.Build(),
+				},
+			},
 			wantReportOnlyPolicy: []string{"frame-ancestors 'self'; report-uri https://example.com/collector"},
 			wantNonce:            "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -105,6 +105,7 @@ func TestBefore(t *testing.T) {
 		{
 			name:        "No policies",
 			interceptor: Interceptor{},
+			wantNonce:   "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:        "Default policies",
@@ -136,6 +137,7 @@ func TestBefore(t *testing.T) {
 			name:                 "FramingCSP reportonly",
 			interceptor:          NewInterceptor(FramingPolicy(true, "https://example.com/collector")),
 			wantReportOnlyPolicy: []string{"frame-ancestors 'self'; report-uri https://example.com/collector"},
+			wantNonce:            "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 	}
 

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -1,0 +1,251 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csp
+
+import (
+	"testing"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/safehttptest"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func readRand(b []byte) (int, error) {
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return len(b), nil
+}
+
+func (p *Policy) insertTestRandom(f func([]byte) (int, error)) {
+	if p == nil {
+		return
+	}
+	for i := range p.Directives {
+		p.Directives[i].readRand = f
+	}
+}
+
+func TestSerialize(t *testing.T) {
+	tests := []struct {
+		name       string
+		policy     *Policy
+		wantString string
+		wantNonces map[Directive]string
+	}{
+		{
+			name:       "Empty",
+			policy:     &Policy{},
+			wantString: "",
+			wantNonces: map[Directive]string{},
+		},
+		{
+			name: "Default",
+			policy: func() *Policy {
+				p := NewPolicy("https://foo.com/collector")
+				p.insertTestRandom(readRand)
+				return p
+			}(),
+			wantString: "object-src 'none'; script-src 'nonce-AAECAwQFBgc=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://foo.com/collector",
+			wantNonces: map[Directive]string{DirectiveScriptSrc: "AAECAwQFBgc="},
+		},
+		{
+			name: "Empty Directive",
+			policy: &Policy{
+				Directives: []*PolicyDirective{
+					NewPolicyDirective(DirectiveScriptSrc, nil, false),
+				},
+			},
+			wantString: "script-src",
+			wantNonces: map[Directive]string{},
+		},
+		{
+			name: "No nonces",
+			policy: &Policy{
+				Directives: []*PolicyDirective{
+					NewPolicyDirective(DirectiveScriptSrc, []string{ValueUnsafeEval}, false),
+				},
+			},
+			wantString: "script-src 'unsafe-eval'",
+			wantNonces: map[Directive]string{},
+		},
+		{
+			name: "Two nonces",
+			policy: func() *Policy {
+				p := &Policy{
+					Directives: []*PolicyDirective{
+						NewPolicyDirective(DirectiveScriptSrc, []string{ValueUnsafeEval}, true),
+						NewPolicyDirective(DirectiveStyleSrc, []string{ValueUnsafeEval}, true),
+					},
+				}
+				p.insertTestRandom(readRand)
+				return p
+			}(),
+			wantString: "script-src 'nonce-AAECAwQFBgc=' 'unsafe-eval'; style-src 'nonce-AAECAwQFBgc=' 'unsafe-eval'",
+			wantNonces: map[Directive]string{
+				DirectiveScriptSrc: "AAECAwQFBgc=",
+				DirectiveStyleSrc:  "AAECAwQFBgc=",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, nonces := tt.policy.Serialize()
+
+			if got := s; got != tt.wantString {
+				t.Errorf("tt.policy.Serialize() got: %q want: %q", got, tt.wantString)
+			}
+
+			if diff := cmp.Diff(tt.wantNonces, nonces); diff != "" {
+				t.Errorf("nonces mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBefore(t *testing.T) {
+	tests := []struct {
+		name                  string
+		interceptor           Interceptor
+		wantEnforcementPolicy []string
+		wantReportPolicy      []string
+		wantEnforcementNonces map[Directive]string
+		wantReportNonces      map[Directive]string
+	}{
+		{
+			name:        "No policies",
+			interceptor: Interceptor{},
+		},
+		{
+			name: "Default policy",
+			interceptor: func() Interceptor {
+				p := Default("https://foo.com/collector")
+				p.EnforcementPolicy.insertTestRandom(readRand)
+				p.ReportOnlyPolicy.insertTestRandom(readRand)
+				return p
+			}(),
+			wantEnforcementPolicy: []string{"object-src 'none'; script-src 'nonce-AAECAwQFBgc=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://foo.com/collector"},
+			wantEnforcementNonces: map[Directive]string{DirectiveScriptSrc: "AAECAwQFBgc="},
+		},
+		{
+			name: "Report",
+			interceptor: Interceptor{
+				ReportOnlyPolicy: &Policy{
+					Directives: []*PolicyDirective{
+						NewPolicyDirective(DirectiveScriptSrc, []string{ValueUnsafeInline}, false),
+					},
+				},
+			},
+			wantReportPolicy: []string{"script-src 'unsafe-inline'"},
+		},
+		{
+			name: "Report with nonces",
+			interceptor: Interceptor{
+				ReportOnlyPolicy: func() *Policy {
+					p := NewPolicy("https://foo.com/collector")
+					p.insertTestRandom(readRand)
+					return p
+				}(),
+			},
+			wantReportPolicy: []string{"object-src 'none'; script-src 'nonce-AAECAwQFBgc=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://foo.com/collector"},
+			wantReportNonces: map[Directive]string{DirectiveScriptSrc: "AAECAwQFBgc="},
+		},
+		{
+			name: "Report and enforce",
+			interceptor: Interceptor{
+				ReportOnlyPolicy: &Policy{
+					Directives: []*PolicyDirective{
+						NewPolicyDirective(DirectiveScriptSrc, []string{ValueUnsafeInline}, false),
+						NewPolicyDirective(DirectiveBaseURI, []string{ValueNone}, false),
+					},
+				},
+				EnforcementPolicy: &Policy{
+					Directives: []*PolicyDirective{
+						NewPolicyDirective(DirectiveScriptSrc, []string{ValueUnsafeInline}, false),
+					},
+				},
+			},
+			wantEnforcementPolicy: []string{"script-src 'unsafe-inline'"},
+			wantReportPolicy:      []string{"script-src 'unsafe-inline'; base-uri 'none'"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := safehttptest.NewResponseRecorder()
+			req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+
+			tt.interceptor.Before(rr.ResponseWriter, req)
+
+			h := rr.Header()
+			if diff := cmp.Diff(tt.wantEnforcementPolicy, h.Values("Content-Security-Policy")); diff != "" {
+				t.Errorf("h.Values(\"Content-Security-Policy\") mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.wantReportPolicy, h.Values("Content-Security-Policy-Report-Only")); diff != "" {
+				t.Errorf("h.Values(\"Content-Security-Policy-Report-Only\") mismatch (-want +got):\n%s", diff)
+			}
+
+			ctx := req.Context()
+			en := ctx.Value(ctxKey("enforce"))
+			if diff := cmp.Diff(tt.wantEnforcementNonces, en); !(en == nil && tt.wantEnforcementNonces == nil) && diff != "" {
+				t.Errorf("ctx.Value(ctxKey(\"enforce\")) mismatch (-want +got):\n%s", diff)
+			}
+
+			rn := ctx.Value(ctxKey("report"))
+			if diff := cmp.Diff(tt.wantReportNonces, rn); !(rn == nil && tt.wantReportNonces == nil) && diff != "" {
+				t.Errorf("ctx.Value(ctxKey(\"report\")) mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAlreadyClaimed(t *testing.T) {
+	headers := []string{
+		"Content-Security-Policy",
+		"Content-Security-Policy-Report-Only",
+	}
+
+	for _, h := range headers {
+		t.Run(h, func(t *testing.T) {
+			rr := safehttptest.NewResponseRecorder()
+			if _, err := rr.ResponseWriter.Header().Claim(h); err != nil {
+				t.Fatalf("rr.ResponseWriter.Header().Claim(h) got: %v want: nil", err)
+			}
+			req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+
+			it := Interceptor{}
+			it.Before(rr.ResponseWriter, req)
+
+			if got, want := rr.Status(), int(safehttp.StatusInternalServerError); got != want {
+				t.Errorf("rr.Status() got: %v want: %v", got, want)
+			}
+
+			wantHeaders := map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			}
+			if diff := cmp.Diff(wantHeaders, map[string][]string(rr.Header())); diff != "" {
+				t.Errorf("rr.Header() mismatch (-want +got):\n%s", diff)
+			}
+
+			if got, want := rr.Body(), "Internal Server Error\n"; got != want {
+				t.Errorf("rr.Body() got: %q want: %q", got, want)
+			}
+		})
+	}
+}

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -48,32 +48,32 @@ func TestSerialize(t *testing.T) {
 	}{
 		{
 			name:       "StrictCSP",
-			policy:     NewStrictCSP(false, false, false, "", ""),
+			policy:     StrictCSPBuilder{}.Build(),
 			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'",
 			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "StrictCSP with strict-dynamic",
-			policy:     NewStrictCSP(false, true, false, "", ""),
+			policy:     StrictCSPBuilder{StrictDynamic: true}.Build(),
 			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'strict-dynamic'; base-uri 'none'",
 			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "StrictCSP with unsafe-eval",
-			policy:     NewStrictCSP(false, false, true, "", ""),
+			policy:     StrictCSPBuilder{UnsafeEval: true}.Build(),
 			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'unsafe-eval'; base-uri 'none'",
 			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "StrictCSP with set base-uri",
-			policy:     NewStrictCSP(false, false, false, "https://example.com", ""),
+			policy:     StrictCSPBuilder{BaseURI: "https://example.com"}.Build(),
 			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri https://example.com",
 			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
 			name:       "StrictCSP with report-uri",
-			policy:     NewStrictCSP(false, false, true, "", "https://example.com/collector"),
-			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'unsafe-eval'; base-uri 'none'; report-uri https://example.com/collector",
+			policy:     StrictCSPBuilder{ReportURI: "https://example.com/collector"}.Build(),
+			wantString: "object-src 'none'; script-src 'unsafe-inline' https: http: 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk='; base-uri 'none'; report-uri https://example.com/collector",
 			wantNonce:  "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
 		{
@@ -136,7 +136,7 @@ func TestBefore(t *testing.T) {
 			name: "StrictCSP reportonly",
 			interceptor: Interceptor{
 				Policies: []Policy{
-					NewStrictCSP(true, false, false, "", "https://example.com/collector"),
+					StrictCSPBuilder{ReportOnly: true, ReportURI: "https://example.com/collector"}.Build(),
 				},
 			},
 			wantReportOnlyPolicy: []string{

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -60,7 +60,7 @@ func TestSerialize(t *testing.T) {
 					{Directive: DirectiveScriptSrc, Values: nil, AddNonce: false},
 				},
 			},
-			wantString: "script-src",
+			wantString: "script-src ",
 			wantNonces: map[Directive]string{},
 		},
 		{


### PR DESCRIPTION
It supports creating custom CSP policies. The interceptor contains two policies, one for enforcement and one for reporting. A default policy based on https://csp.withgoogle.com/docs/strict-csp.html is also provided.

Fixes #74 