### PR TITLE
Changed safehttptest.ResponseRecorder.Status() to return a safehttp.StatusCode instead of an int.

### DIFF
--- a/safehttp/plugins/staticheaders/staticheaders_test.go
+++ b/safehttp/plugins/staticheaders/staticheaders_test.go
@@ -30,7 +30,7 @@ func TestPlugin(t *testing.T) {
 	p := staticheaders.Plugin{}
 	p.Before(rr.ResponseWriter, req)
 
-	if got, want := rr.Status(), int(safehttp.StatusOK); got != want {
+	if got, want := rr.Status(), safehttp.StatusOK; got != want {
 		t.Errorf("rr.Status() got: %v want: %v", got, want)
 	}
 
@@ -61,7 +61,7 @@ func TestAlreadyClaimed(t *testing.T) {
 			p := staticheaders.Plugin{}
 			p.Before(rr.ResponseWriter, req)
 
-			if got, want := rr.Status(), int(safehttp.StatusInternalServerError); got != want {
+			if got, want := rr.Status(), safehttp.StatusInternalServerError; got != want {
 				t.Errorf("rr.Status() got: %v want: %v", got, want)
 			}
 

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -15,13 +15,14 @@
 package xsrf_test
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-safeweb/safehttp"
 	"github.com/google/go-safeweb/safehttp/plugins/xsrf"
 	"github.com/google/go-safeweb/safehttp/safehttptest"
 	"golang.org/x/net/xsrftoken"
-	"strings"
-	"testing"
 )
 
 type userIdentifier struct{}
@@ -36,7 +37,7 @@ func TestXSRFTokenPost(t *testing.T) {
 		host       string
 		path       string
 		userID     string
-		wantStatus int
+		wantStatus safehttp.StatusCode
 		wantHeader map[string][]string
 		wantBody   string
 	}{
@@ -45,7 +46,7 @@ func TestXSRFTokenPost(t *testing.T) {
 			userID:     "1234",
 			host:       "foo.com",
 			path:       "/pizza",
-			wantStatus: 200,
+			wantStatus: safehttp.StatusOK,
 			wantHeader: map[string][]string{},
 			wantBody:   "",
 		},
@@ -54,7 +55,7 @@ func TestXSRFTokenPost(t *testing.T) {
 			userID:     "1234",
 			host:       "bar.com",
 			path:       "/pizza",
-			wantStatus: 403,
+			wantStatus: safehttp.StatusForbidden,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -66,7 +67,7 @@ func TestXSRFTokenPost(t *testing.T) {
 			userID:     "1234",
 			host:       "foo.com",
 			path:       "spaghetti",
-			wantStatus: 403,
+			wantStatus: safehttp.StatusForbidden,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -78,7 +79,7 @@ func TestXSRFTokenPost(t *testing.T) {
 			userID:     "5678",
 			host:       "foo.com",
 			path:       "/pizza",
-			wantStatus: 403,
+			wantStatus: safehttp.StatusForbidden,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -113,7 +114,7 @@ func TestXSRFTokenMultipart(t *testing.T) {
 		host       string
 		path       string
 		userID     string
-		wantStatus int
+		wantStatus safehttp.StatusCode
 		wantHeader map[string][]string
 		wantBody   string
 	}{
@@ -122,7 +123,7 @@ func TestXSRFTokenMultipart(t *testing.T) {
 			userID:     "1234",
 			host:       "foo.com",
 			path:       "/pizza",
-			wantStatus: 200,
+			wantStatus: safehttp.StatusOK,
 			wantHeader: map[string][]string{},
 			wantBody:   "",
 		},
@@ -131,7 +132,7 @@ func TestXSRFTokenMultipart(t *testing.T) {
 			userID:     "1234",
 			host:       "bar.com",
 			path:       "/pizza",
-			wantStatus: 403,
+			wantStatus: safehttp.StatusForbidden,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -143,7 +144,7 @@ func TestXSRFTokenMultipart(t *testing.T) {
 			userID:     "1234",
 			host:       "foo.com",
 			path:       "spaghetti",
-			wantStatus: 403,
+			wantStatus: safehttp.StatusForbidden,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -155,7 +156,7 @@ func TestXSRFTokenMultipart(t *testing.T) {
 			userID:     "5678",
 			host:       "foo.com",
 			path:       "/pizza",
-			wantStatus: 403,
+			wantStatus: safehttp.StatusForbidden,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -193,7 +194,7 @@ func TestXSRFMissingToken(t *testing.T) {
 	tests := []struct {
 		name       string
 		req        *safehttp.IncomingRequest
-		wantStatus int
+		wantStatus safehttp.StatusCode
 		wantHeader map[string][]string
 		wantBody   string
 	}{
@@ -204,7 +205,7 @@ func TestXSRFMissingToken(t *testing.T) {
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req
 			}(),
-			wantStatus: 401,
+			wantStatus: safehttp.StatusUnauthorized,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -223,7 +224,7 @@ func TestXSRFMissingToken(t *testing.T) {
 				req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return req
 			}(),
-			wantStatus: 401,
+			wantStatus: safehttp.StatusUnauthorized,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},

--- a/safehttp/safehttptest/recorder.go
+++ b/safehttp/safehttptest/recorder.go
@@ -84,7 +84,7 @@ func (r *ResponseRecorder) Header() http.Header {
 
 // Status returns the recorded response status code.
 func (r *ResponseRecorder) Status() safehttp.StatusCode {
-	return safehttp.StatusCode(r.rw.status)
+	return r.rw.status
 }
 
 // Body returns the recorded response body.
@@ -97,7 +97,7 @@ func (r *ResponseRecorder) Body() string {
 type responseWriter struct {
 	header http.Header
 	writer io.Writer
-	status int
+	status safehttp.StatusCode
 }
 
 func newResponseWriter(w io.Writer) *responseWriter {
@@ -113,7 +113,7 @@ func (r *responseWriter) Header() http.Header {
 }
 
 func (r *responseWriter) WriteHeader(statusCode int) {
-	r.status = statusCode
+	r.status = safehttp.StatusCode(statusCode)
 }
 
 func (r *responseWriter) Write(data []byte) (int, error) {

--- a/safehttp/safehttptest/recorder.go
+++ b/safehttp/safehttptest/recorder.go
@@ -83,8 +83,8 @@ func (r *ResponseRecorder) Header() http.Header {
 }
 
 // Status returns the recorded response status code.
-func (r *ResponseRecorder) Status() int {
-	return r.rw.status
+func (r *ResponseRecorder) Status() safehttp.StatusCode {
+	return safehttp.StatusCode(r.rw.status)
 }
 
 // Body returns the recorded response body.


### PR DESCRIPTION
Fixes #105 

This is so that we can use the `safehttp.StatusXxxx` constants instead of number literals in tests without having to cast the constants from `safehttp.StatusCode` to `int` in every test we write that uses `safehttptest`.
