### PR TITLE
Per handler interceptor configurations

### DIFF
--- a/safehttp/config.go
+++ b/safehttp/config.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp
+
+// Config provide additional configurations to Interceptors when needed.
+type Config interface {
+	// Apply applies the configurations to an Interceptor if it's of the
+	// appropriate type. The bool indicates whether the configuration took
+	// effect. If that's the case, the modified interceptor should be returned
+	// and otherwise Apply should return a nil Interceptor.
+	Apply(Interceptor) (Interceptor, bool)
+}

--- a/safehttp/config.go
+++ b/safehttp/config.go
@@ -16,9 +16,7 @@ package safehttp
 
 // Config provide additional configurations to Interceptors when needed.
 type Config interface {
-	// Apply applies the configurations to an Interceptor, if it's of the
-	// appropriate type. The bool indicates whether the configuration took
-	// effect, in which case, the modified interceptor will be returned.
-	// Otherwise, Apply returns the unmodified Interceptor.
-	Apply(Interceptor) (Interceptor, bool)
+	// Match checks whether this Config is meant to be used with the provided
+	// Interceptor.
+	Match(Interceptor) bool
 }

--- a/safehttp/config.go
+++ b/safehttp/config.go
@@ -16,9 +16,9 @@ package safehttp
 
 // Config provide additional configurations to Interceptors when needed.
 type Config interface {
-	// Apply applies the configurations to an Interceptor if it's of the
+	// Apply applies the configurations to an Interceptor, if it's of the
 	// appropriate type. The bool indicates whether the configuration took
-	// effect. If that's the case, the modified interceptor should be returned
-	// and otherwise Apply should return a nil Interceptor.
+	// effect, in which case, the modified interceptor will be returned.
+	// Otherwise, Apply returns the unmodified Interceptor.
 	Apply(Interceptor) (Interceptor, bool)
 }

--- a/safehttp/interceptor.go
+++ b/safehttp/interceptor.go
@@ -22,5 +22,5 @@ type Interceptor interface {
 	// response is written to the ResponseWriter, then the remaining
 	// interceptors and the handler won't execute. If Before panics, it will be
 	// recovered and the ServeMux will respond with 500 Internal Server Error.
-	Before(*ResponseWriter, *IncomingRequest) Result
+	Before(w *ResponseWriter, r *IncomingRequest, cfg interface{}) Result
 }

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -106,11 +106,11 @@ func NewServeMux(d Dispatcher, domains ...string) *ServeMux {
 // interceptors on a registered handler. Passing a Config whose corresponding
 // Interceptor was not installed will produce no effect.
 func (m *ServeMux) Handle(pattern string, method string, h Handler, configs ...Config) {
-	var changed bool
 	interceps := map[string]Interceptor{}
 	for k, i := range m.interceps {
 		interceps[k] = i
 	}
+	var changed bool
 	for _, c := range configs {
 		for k, i := range interceps {
 			if i, ok := c.Apply(i); ok {

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -323,10 +323,8 @@ type setHeaderConfig struct {
 }
 
 func (setHeaderConfig) Match(i safehttp.Interceptor) bool {
-	if _, ok := i.(setHeaderConfigInterceptor); !ok {
-		return false
-	}
-	return true
+	_, ok := i.(setHeaderConfigInterceptor)
+	return ok
 }
 
 type setHeaderConfigInterceptor struct{}

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -404,8 +404,7 @@ func TestMuxInterceptorConfigs(t *testing.T) {
 	}
 }
 
-type interceptorOne struct {
-}
+type interceptorOne struct {}
 
 func (interceptorOne) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cfg interface{}) safehttp.Result {
 	w.Header().Set("pizza", "diavola")

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -322,7 +322,7 @@ type setHeaderConfig struct{}
 func (setHeaderConfig) Apply(i safehttp.Interceptor) (safehttp.Interceptor, bool) {
 	p, ok := i.(setHeaderInterceptor)
 	if !ok {
-		return nil, false
+		return p, false
 	}
 	p.name = "Foo"
 	p.value = "Bar"
@@ -332,7 +332,7 @@ func (setHeaderConfig) Apply(i safehttp.Interceptor) (safehttp.Interceptor, bool
 type noInterceptorConfig struct{}
 
 func (noInterceptorConfig) Apply(i safehttp.Interceptor) (safehttp.Interceptor, bool) {
-	return nil, false
+	return i, false
 }
 
 func TestMuxInterceptorConfigs(t *testing.T) {

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -65,7 +65,7 @@ func Default() Interceptor {
 // The function redirects HTTP requests to HTTPS. When HTTPS traffic
 // is received the Strict-Transport-Security header is applied to the
 // response.
-func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cfgs interface{}) safehttp.Result {
 	if it.MaxAge < 0 {
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}

--- a/safehttp/plugins/hsts/hsts_test.go
+++ b/safehttp/plugins/hsts/hsts_test.go
@@ -125,7 +125,7 @@ func TestHSTS(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := safehttptest.NewResponseRecorder()
 
-			tt.interceptor.Before(rr.ResponseWriter, tt.req)
+			tt.interceptor.Before(rr.ResponseWriter, tt.req, nil)
 
 			if rr.Status() != tt.wantStatus {
 				t.Errorf("status code got: %v want: %v", rr.Status(), tt.wantStatus)
@@ -150,7 +150,7 @@ func TestStrictTransportSecurityAlreadyImmutable(t *testing.T) {
 	rr := safehttptest.NewResponseRecorder()
 	rr.ResponseWriter.Header().Claim("Strict-Transport-Security")
 
-	p.Before(rr.ResponseWriter, req)
+	p.Before(rr.ResponseWriter, req, nil)
 
 	if want := safehttp.StatusInternalServerError; rr.Status() != want {
 		t.Errorf("status code got: %v want: %v", rr.Status(), want)

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -24,7 +24,7 @@ type Plugin struct{}
 // Before claims and sets the following headers:
 //  - X-Content-Type-Options: nosniff
 //  - X-XSS-Protection: 0
-func (Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+func (Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cfg interface{}) safehttp.Result {
 	h := w.Header()
 	setXCTO, err := h.Claim("X-Content-Type-Options")
 	if err != nil {

--- a/safehttp/plugins/staticheaders/staticheaders_test.go
+++ b/safehttp/plugins/staticheaders/staticheaders_test.go
@@ -28,7 +28,7 @@ func TestPlugin(t *testing.T) {
 	rr := safehttptest.NewResponseRecorder()
 
 	p := staticheaders.Plugin{}
-	p.Before(rr.ResponseWriter, req)
+	p.Before(rr.ResponseWriter, req, nil)
 
 	if got, want := rr.Status(), safehttp.StatusOK; got != want {
 		t.Errorf("rr.Status() got: %v want: %v", got, want)
@@ -59,7 +59,7 @@ func TestAlreadyClaimed(t *testing.T) {
 			}
 
 			p := staticheaders.Plugin{}
-			p.Before(rr.ResponseWriter, req)
+			p.Before(rr.ResponseWriter, req, nil)
 
 			if got, want := rr.Status(), safehttp.StatusInternalServerError; got != want {
 				t.Errorf("rr.Status() got: %v want: %v", got, want)

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -47,7 +47,7 @@ type Interceptor struct {
 // the handler to ensure it is not part of the Cross Site Request
 // Forgery. It checks for the presence of an xsrf-token in the request body and
 // validates it based on the userID associated with the request.
-func (p *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+func (p *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cfg interface{}) safehttp.Result {
 	userID, err := p.Identifier.UserID(r)
 	if err != nil {
 		return w.ClientError(safehttp.StatusUnauthorized)

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -94,7 +94,7 @@ func TestXSRFTokenPost(t *testing.T) {
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		rec := safehttptest.NewResponseRecorder()
-		i.Before(rec.ResponseWriter, req)
+		i.Before(rec.ResponseWriter, req, nil)
 
 		if rec.Status() != test.wantStatus {
 			t.Errorf("response status: got %v, want %v", rec.Status(), test.wantStatus)
@@ -176,7 +176,7 @@ func TestXSRFTokenMultipart(t *testing.T) {
 		req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 
 		rec := safehttptest.NewResponseRecorder()
-		i.Before(rec.ResponseWriter, req)
+		i.Before(rec.ResponseWriter, req, nil)
 
 		if rec.Status() != test.wantStatus {
 			t.Errorf("response status: got %v, want %v", rec.Status(), test.wantStatus)
@@ -235,7 +235,7 @@ func TestXSRFMissingToken(t *testing.T) {
 	for _, test := range tests {
 		i := xsrf.Interceptor{AppKey: "xsrf", Identifier: userIdentifier{}}
 		rec := safehttptest.NewResponseRecorder()
-		i.Before(rec.ResponseWriter, test.req)
+		i.Before(rec.ResponseWriter, test.req, nil)
 
 		if rec.Status() != test.wantStatus {
 			t.Errorf("response status: got %v, want %v", rec.Status(), test.wantStatus)

--- a/tests/integration/hsts/hsts_test.go
+++ b/tests/integration/hsts/hsts_test.go
@@ -68,12 +68,11 @@ func (r *responseRecorder) Write(data []byte) (int, error) {
 func TestHSTSServeMuxInstall(t *testing.T) {
 	mux := safehttp.NewServeMux(&dispatcher{}, "foo.com")
 
+	mux.Install("hsts", hsts.Default())
 	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 	})
 	mux.Handle("/asdf", safehttp.MethodGet, handler)
-
-	mux.Install("hsts", hsts.Default())
 
 	b := strings.Builder{}
 	rr := newResponseRecorder(&b)

--- a/tests/integration/staticheaders/staticheaders_test.go
+++ b/tests/integration/staticheaders/staticheaders_test.go
@@ -74,12 +74,11 @@ func (r *responseRecorder) Write(data []byte) (int, error) {
 func TestServeMuxInstallStaticHeaders(t *testing.T) {
 	mux := safehttp.NewServeMux(dispatcher{}, "foo.com")
 
+	mux.Install("staticheaders", staticheaders.Plugin{})
 	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 	})
 	mux.Handle("/asdf", safehttp.MethodGet, handler)
-
-	mux.Install("staticheaders", staticheaders.Plugin{})
 
 	b := strings.Builder{}
 	rr := newResponseRecorder(&b)


### PR DESCRIPTION
Fixes #87 

Added interceptor configurations that enable the user to modify the behaviour of interceptors per handler. Interceptors need to be installed before registering handlers otherwise the interceptor won't take effect. The configuration type is expected to be implemented for every interceptor that is configurable.