### PR TITLE
Added a safehttp.NotWritten result so that safehttp.Result{} can stop being used.

### DIFF
--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -84,7 +84,7 @@ func TestFormValidInt(t *testing.T) {
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("form.Int64:  mismatch (-want +got): \n%s", diff)
 			}
-			return safehttp.Result{}
+			return safehttp.NotWritten
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})
@@ -174,7 +174,7 @@ func TestFormInvalidInt(t *testing.T) {
 					t.Errorf("form.Err: got nil, want error")
 				}
 
-				return safehttp.Result{}
+				return safehttp.NotWritten
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -244,7 +244,7 @@ func TestFormValidUint(t *testing.T) {
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("form.Uint64:  mismatch (-want +got): \n%s", diff)
 			}
-			return safehttp.Result{}
+			return safehttp.NotWritten
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})
@@ -331,7 +331,7 @@ func TestFormInvalidUint(t *testing.T) {
 				if form.Err() == nil {
 					t.Errorf("form.Err: got nil, want error")
 				}
-				return safehttp.Result{}
+				return safehttp.NotWritten
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -413,7 +413,7 @@ func TestFormValidString(t *testing.T) {
 				if err := form.Err(); err != nil {
 					t.Errorf("form.Err: got %v, want nil", err)
 				}
-				return safehttp.Result{}
+				return safehttp.NotWritten
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -496,7 +496,7 @@ func TestFormValidFloat64(t *testing.T) {
 				if err := form.Err(); err != nil {
 					t.Errorf("form.Err: got %v, want nil", err)
 				}
-				return safehttp.Result{}
+				return safehttp.NotWritten
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -585,7 +585,7 @@ func TestFormInvalidFloat64(t *testing.T) {
 					t.Errorf("form.Err: got nil, want error")
 				}
 
-				return safehttp.Result{}
+				return safehttp.NotWritten
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -677,7 +677,7 @@ func TestFormValidBool(t *testing.T) {
 					t.Errorf("form.Err: got %v, want nil", err)
 				}
 
-				return safehttp.Result{}
+				return safehttp.NotWritten
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -758,7 +758,7 @@ func TestFormInvalidBool(t *testing.T) {
 				if form.Err() == nil {
 					t.Errorf("form.Err: got nil, want error")
 				}
-				return safehttp.Result{}
+				return safehttp.NotWritten
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -857,7 +857,7 @@ func TestFormInvalidSlice(t *testing.T) {
 					t.Errorf("form.Err: got nil, want error")
 				}
 
-				return safehttp.Result{}
+				return safehttp.NotWritten
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -950,7 +950,7 @@ func TestFormErrorHandling(t *testing.T) {
 				t.Errorf("form.Err: got nil, want error")
 			}
 
-			return safehttp.Result{}
+			return safehttp.NotWritten
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})
@@ -1032,7 +1032,7 @@ func TestFormValidSlicePost(t *testing.T) {
 				t.Errorf("form.Slice: diff (-want +got): \n%v", diff)
 			}
 
-			return safehttp.Result{}
+			return safehttp.NotWritten
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})
@@ -1133,7 +1133,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 			if diff := cmp.Diff(tc.want, tc.placeholder); diff != "" {
 				t.Errorf("form.Slice: diff (-want +got): \n%v", diff)
 			}
-			return safehttp.Result{}
+			return safehttp.NotWritten
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})

--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -84,7 +84,7 @@ func TestFormValidInt(t *testing.T) {
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("form.Int64:  mismatch (-want +got): \n%s", diff)
 			}
-			return safehttp.NotWritten
+			return safehttp.NotWritten()
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})
@@ -174,7 +174,7 @@ func TestFormInvalidInt(t *testing.T) {
 					t.Errorf("form.Err: got nil, want error")
 				}
 
-				return safehttp.NotWritten
+				return safehttp.NotWritten()
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -244,7 +244,7 @@ func TestFormValidUint(t *testing.T) {
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("form.Uint64:  mismatch (-want +got): \n%s", diff)
 			}
-			return safehttp.NotWritten
+			return safehttp.NotWritten()
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})
@@ -331,7 +331,7 @@ func TestFormInvalidUint(t *testing.T) {
 				if form.Err() == nil {
 					t.Errorf("form.Err: got nil, want error")
 				}
-				return safehttp.NotWritten
+				return safehttp.NotWritten()
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -413,7 +413,7 @@ func TestFormValidString(t *testing.T) {
 				if err := form.Err(); err != nil {
 					t.Errorf("form.Err: got %v, want nil", err)
 				}
-				return safehttp.NotWritten
+				return safehttp.NotWritten()
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -496,7 +496,7 @@ func TestFormValidFloat64(t *testing.T) {
 				if err := form.Err(); err != nil {
 					t.Errorf("form.Err: got %v, want nil", err)
 				}
-				return safehttp.NotWritten
+				return safehttp.NotWritten()
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -585,7 +585,7 @@ func TestFormInvalidFloat64(t *testing.T) {
 					t.Errorf("form.Err: got nil, want error")
 				}
 
-				return safehttp.NotWritten
+				return safehttp.NotWritten()
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -677,7 +677,7 @@ func TestFormValidBool(t *testing.T) {
 					t.Errorf("form.Err: got %v, want nil", err)
 				}
 
-				return safehttp.NotWritten
+				return safehttp.NotWritten()
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -758,7 +758,7 @@ func TestFormInvalidBool(t *testing.T) {
 				if form.Err() == nil {
 					t.Errorf("form.Err: got nil, want error")
 				}
-				return safehttp.NotWritten
+				return safehttp.NotWritten()
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -857,7 +857,7 @@ func TestFormInvalidSlice(t *testing.T) {
 					t.Errorf("form.Err: got nil, want error")
 				}
 
-				return safehttp.NotWritten
+				return safehttp.NotWritten()
 			}))
 
 			rec := newResponseRecorder(&strings.Builder{})
@@ -950,7 +950,7 @@ func TestFormErrorHandling(t *testing.T) {
 				t.Errorf("form.Err: got nil, want error")
 			}
 
-			return safehttp.NotWritten
+			return safehttp.NotWritten()
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})
@@ -1032,7 +1032,7 @@ func TestFormValidSlicePost(t *testing.T) {
 				t.Errorf("form.Slice: diff (-want +got): \n%v", diff)
 			}
 
-			return safehttp.NotWritten
+			return safehttp.NotWritten()
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})
@@ -1133,7 +1133,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 			if diff := cmp.Diff(tc.want, tc.placeholder); diff != "" {
 				t.Errorf("form.Slice: diff (-want +got): \n%v", diff)
 			}
-			return safehttp.NotWritten
+			return safehttp.NotWritten()
 		}))
 
 		rec := newResponseRecorder(&strings.Builder{})

--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -90,7 +90,7 @@ func TestFormValidInt(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, test.req)
 
-		if want := safehttp.StatusOK; rec.status != want {
+		if want := safehttp.StatusNoContent; rec.status != want {
 			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
@@ -180,7 +180,7 @@ func TestFormInvalidInt(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := safehttp.StatusOK; rec.status != want {
+			if want := safehttp.StatusNoContent; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -250,7 +250,7 @@ func TestFormValidUint(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, test.req)
 
-		if want := safehttp.StatusOK; rec.status != want {
+		if want := safehttp.StatusNoContent; rec.status != want {
 			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
@@ -337,7 +337,7 @@ func TestFormInvalidUint(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := safehttp.StatusOK; rec.status != want {
+			if want := safehttp.StatusNoContent; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -419,7 +419,7 @@ func TestFormValidString(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := safehttp.StatusOK; rec.status != want {
+			if want := safehttp.StatusNoContent; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -502,7 +502,7 @@ func TestFormValidFloat64(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := safehttp.StatusOK; rec.status != want {
+			if want := safehttp.StatusNoContent; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -591,7 +591,7 @@ func TestFormInvalidFloat64(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := safehttp.StatusOK; rec.status != want {
+			if want := safehttp.StatusNoContent; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -683,7 +683,7 @@ func TestFormValidBool(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := safehttp.StatusOK; rec.status != want {
+			if want := safehttp.StatusNoContent; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -764,7 +764,7 @@ func TestFormInvalidBool(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := safehttp.StatusOK; rec.status != want {
+			if want := safehttp.StatusNoContent; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -863,7 +863,7 @@ func TestFormInvalidSlice(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := safehttp.StatusOK; rec.status != want {
+			if want := safehttp.StatusNoContent; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -956,7 +956,7 @@ func TestFormErrorHandling(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, tc.req)
 
-		if want := safehttp.StatusOK; rec.status != want {
+		if want := safehttp.StatusNoContent; rec.status != want {
 			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
@@ -1038,7 +1038,7 @@ func TestFormValidSlicePost(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, tc.req)
 
-		if respStatus, want := rec.status, safehttp.StatusOK; respStatus != want {
+		if respStatus, want := rec.status, safehttp.StatusNoContent; respStatus != want {
 			t.Errorf("response status: got %v, want %v", respStatus, want)
 		}
 	}
@@ -1139,7 +1139,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, tc.req)
 
-		if respStatus, want := rec.status, safehttp.StatusOK; respStatus != want {
+		if respStatus, want := rec.status, safehttp.StatusNoContent; respStatus != want {
 			t.Errorf("response status: got %v, want %v", respStatus, want)
 		}
 	}

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -218,4 +218,7 @@ func (h handlerWithInterceptors) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	h.handler.ServeHTTP(rw, ir)
+	if !rw.written {
+		rw.NoContent()
+	}
 }

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -172,7 +172,7 @@ func (p setHeaderInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.Inc
 	if err := w.Header().Set(p.name, p.value); err != nil {
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
-	return safehttp.NotWritten
+	return safehttp.NotWritten()
 }
 
 type internalErrorInterceptor struct{}
@@ -192,7 +192,7 @@ func (p *claimHeaderInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	p.setValue = f
-	return safehttp.NotWritten
+	return safehttp.NotWritten()
 }
 
 func (p *claimHeaderInterceptor) SetHeader(value string) {
@@ -470,7 +470,7 @@ func TestMuxDeterministicInterceptorOrder(t *testing.T) {
 func TestMuxHandlerReturnsNotWritten(t *testing.T) {
 	mux := safehttp.NewServeMux(testDispatcher{}, "foo.com")
 	h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-		return safehttp.NotWritten
+		return safehttp.NotWritten()
 	})
 	mux.Handle("/bar", safehttp.MethodGet, h)
 	req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/bar", nil)

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -172,7 +172,7 @@ func (p setHeaderInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.Inc
 	if err := w.Header().Set(p.name, p.value); err != nil {
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
-	return safehttp.Result{}
+	return safehttp.NotWritten
 }
 
 type internalErrorInterceptor struct{}
@@ -192,7 +192,7 @@ func (p *claimHeaderInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	p.setValue = f
-	return safehttp.Result{}
+	return safehttp.NotWritten
 }
 
 func (p *claimHeaderInterceptor) SetHeader(value string) {

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -93,5 +93,5 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	set([]string{value.String()})
-	return safehttp.NotWritten
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -93,5 +93,5 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	set([]string{value.String()})
-	return safehttp.Result{}
+	return safehttp.NotWritten
 }

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -37,5 +37,5 @@ func (Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cf
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	setXXP([]string{"0"})
-	return safehttp.NotWritten
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -37,5 +37,5 @@ func (Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cf
 		return w.ServerError(safehttp.StatusInternalServerError)
 	}
 	setXXP([]string{"0"})
-	return safehttp.Result{}
+	return safehttp.NotWritten
 }

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -70,5 +70,5 @@ func (p *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 		return w.ClientError(safehttp.StatusForbidden)
 	}
 
-	return safehttp.NotWritten
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -70,5 +70,5 @@ func (p *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 		return w.ClientError(safehttp.StatusForbidden)
 	}
 
-	return safehttp.Result{}
+	return safehttp.NotWritten
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -54,13 +54,15 @@ func (w *ResponseWriter) Interceptor(key string) Interceptor {
 // Result TODO
 type Result struct{}
 
-// NotWritten is a Result which indicates that nothing has been written yet. It
+// NotWritten returns a Result which indicates that nothing has been written yet. It
 // can be used in all functions that return a Result, such as in the ServeHTTP method
 // of a Handler or in the Before method of an Interceptor. When returned, NotWritten
 // indicates that the writing of the response should take place later. When this
 // is returned by the Before method in Interceptors the next Interceptor in line
 // is run. When this is returned by a Handler, a 204 No Content response is written.
-var NotWritten Result
+func NotWritten() Result {
+	return Result{}
+}
 
 // Write TODO
 func (w *ResponseWriter) Write(resp Response) Result {

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -54,6 +54,14 @@ func (w *ResponseWriter) Interceptor(key string) Interceptor {
 // Result TODO
 type Result struct{}
 
+// NotWritten is a Result which indicates that nothing has been written yet. It
+// can be used in all functions that return a Result, such as in the ServeHTTP method
+// of a Handler or in the Before method of an Interceptor. When returned, NotWritten
+// indicates that the writing of the response should take place later. When this
+// is returned by the Before method in Interceptors the next Interceptor in line
+// is run. When this is returned by a Handler, a 204 No Content response is written.
+var NotWritten Result
+
 // Write TODO
 func (w *ResponseWriter) Write(resp Response) Result {
 	w.markWritten()
@@ -69,6 +77,13 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	if err := w.d.ExecuteTemplate(w.rw, t, data); err != nil {
 		panic("error")
 	}
+	return Result{}
+}
+
+// NoContent writes a 204 No Content response.
+func (w *ResponseWriter) NoContent() Result {
+	w.markWritten()
+	w.rw.WriteHeader(int(StatusNoContent))
 	return Result{}
 }
 

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -74,6 +74,13 @@ func TestResponseWriterWriteTwicePanic(t *testing.T) {
 			},
 		},
 		{
+			name: "Call NoContent twice",
+			write: func(w *safehttp.ResponseWriter) {
+				w.NoContent()
+				w.NoContent()
+			},
+		},
+		{
 			name: "Call ClientError twice",
 			write: func(w *safehttp.ResponseWriter) {
 				w.ClientError(safehttp.StatusBadRequest)


### PR DESCRIPTION
Fixes #109 

I added a `safehttp.NotWritten` variable which we can use everywhere instead of `safehttp.Result{}`. If a `Handler` returns `NotWritten` then a `204 No Content` response is automatically set by the ServeMux.