### PR TITLE
Added token generation to the XSRF plugin.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -47,6 +47,7 @@ func NewIncomingRequest(req *http.Request) *IncomingRequest {
 // Method specifies the HTTP method of an IncomingRequest.
 func (r *IncomingRequest) Method() string {
 	return r.req.Method
+<<<<<<< HEAD
 }
 
 // Host returns the host the request is targeted to.
@@ -61,6 +62,8 @@ func (r *IncomingRequest) Host() string {
 // implemented.
 func (r *IncomingRequest) Path() string {
 	return r.req.URL.Path
+=======
+>>>>>>> Added token generation functionality to the XSRF plugin. The generated token will be added to each of the safehttp.IncomingRequest contexts and subsequently injected as a hidden input in form by the htmlinject plugin
 }
 
 // PostForm parses the form parameters provided in the body of a POST, PATCH or

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -47,23 +47,6 @@ func NewIncomingRequest(req *http.Request) *IncomingRequest {
 // Method specifies the HTTP method of an IncomingRequest.
 func (r *IncomingRequest) Method() string {
 	return r.req.Method
-<<<<<<< HEAD
-}
-
-// Host returns the host the request is targeted to.
-// TODO(@mihalimara22): Remove this after the safehttp.URL type has been implemented
-func (r *IncomingRequest) Host() string {
-	return r.req.Host
-}
-
-// Path returns the relative path of the URL in decoded format (e.g. %47%6f%2f
-// becomes /Go/).
-// TODO(@mihalimara22): Remove this after the safehttp.URL type has been
-// implemented.
-func (r *IncomingRequest) Path() string {
-	return r.req.URL.Path
-=======
->>>>>>> Added token generation functionality to the XSRF plugin. The generated token will be added to each of the safehttp.IncomingRequest contexts and subsequently injected as a hidden input in form by the htmlinject plugin
 }
 
 // PostForm parses the form parameters provided in the body of a POST, PATCH or

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -44,10 +44,10 @@ type UserIdentifier interface {
 // Interceptor implements XSRF protection.
 type Interceptor struct {
 	// AppKey uniquely identifies each registered service and should have high
-	// entropy as it is use in generating the XSRF token.
+	// entropy as it is used for generating the XSRF token.
 	AppKey string
-	// Identifier supports retrieving the user ID of application's user based on
-	// incoming requests. This is needed in generating the XSRF token.
+	// Identifier supports retrieving the user ID based on the incoming
+	// request. This is needed for generating the XSRF token.
 	Identifier UserIdentifier
 }
 
@@ -84,6 +84,9 @@ func (i *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	if needsValidation {
 		f, err := r.PostForm()
 		if err != nil {
+			// We fallback to checking whether the form is multipart. Both types
+			// are valid in an incoming request as long as the XSRF token is
+			// present.
 			mf, err := r.MultipartForm(32 << 20)
 			if err != nil {
 				return w.ClientError(safehttp.StatusBadRequest)

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -43,9 +43,9 @@ type UserIdentifier interface {
 
 // Interceptor implements XSRF protection.
 type Interceptor struct {
-	// AppKey uniquely identifies each registered service and should have high
+	// SecretAppKey uniquely identifies each registered service and should have high
 	// entropy as it is used for generating the XSRF token.
-	AppKey string
+	SecretAppKey string
 	// Identifier supports retrieving the user ID based on the incoming
 	// request. This is needed for generating the XSRF token.
 	Identifier UserIdentifier
@@ -99,12 +99,12 @@ func (i *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 			return w.ClientError(safehttp.StatusUnauthorized)
 		}
 
-		if ok := xsrftoken.Valid(tok, i.AppKey, userID, actionID); !ok {
+		if ok := xsrftoken.Valid(tok, i.SecretAppKey, userID, actionID); !ok {
 			return w.ClientError(safehttp.StatusForbidden)
 		}
 	}
 
-	tok := xsrftoken.Generate(i.AppKey, userID, actionID)
+	tok := xsrftoken.Generate(i.SecretAppKey, userID, actionID)
 	r.SetContext(context.WithValue(r.Context(), tokenCtxKey{}, tok))
 
 	return safehttp.Result{}

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -35,10 +35,10 @@ type UserIdentifier interface {
 }
 
 // Interceptor implements XSRF protection. It requires an application key and a
-// storage service. The appKey uniquely identifies each registered service and
+// storage service. The AppKey uniquely identifies each registered service and
 // should have high entropy. The storage service supports retrieving ID's of the
-// application's users. Both the appKey and user ID are used in the XSRF
-// token generation algorithm.
+// application's users. Both the AppKey and user ID are used in the XSRF
+// token generation and verification algorithm.
 type Interceptor struct {
 	AppKey     string
 	Identifier UserIdentifier
@@ -61,8 +61,7 @@ func Token(r *safehttp.IncomingRequest) string {
 // Forgery. In case of state changing methods, it checks for the
 // presence of an xsrf-token in the request body and validates it based on the
 // userID associated with the request. It also adds a cryptographically safe
-// XSRF token to the safehttp.IncomingRequest context that will be subsequently
-// injected in HTML as hidden input to forms.
+// XSRF token to the safehttp.IncomingRequest context.
 func (i *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cfg interface{}) safehttp.Result {
 	userID, err := i.Identifier.UserID(r)
 	if err != nil {

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -73,11 +73,11 @@ func TestTokenPost(t *testing.T) {
 	for _, test := range formTokenTests {
 		t.Run(test.name, func(t *testing.T) {
 			rec := safehttptest.NewResponseRecorder()
-			tok := xsrftoken.Generate("testAppKey", test.userID, test.actionID)
+			tok := xsrftoken.Generate("testSecretAppKey", test.userID, test.actionID)
 			req := safehttptest.NewRequest(safehttp.MethodPost, "https://foo.com/pizza", strings.NewReader(TokenKey+"="+tok))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-			i := Interceptor{AppKey: "testAppKey", Identifier: userIdentifier{}}
+			i := Interceptor{SecretAppKey: "testSecretAppKey", Identifier: userIdentifier{}}
 			i.Before(rec.ResponseWriter, req, nil)
 
 			if got := rec.Status(); got != test.wantStatus {
@@ -97,7 +97,7 @@ func TestTokenMultipart(t *testing.T) {
 	for _, test := range formTokenTests {
 		t.Run(test.name, func(t *testing.T) {
 			rec := safehttptest.NewResponseRecorder()
-			tok := xsrftoken.Generate("testAppKey", test.userID, test.actionID)
+			tok := xsrftoken.Generate("testSecretAppKey", test.userID, test.actionID)
 			b := "--123\r\n" +
 				"Content-Disposition: form-data; name=\"xsrf-token\"\r\n" +
 				"\r\n" +
@@ -106,7 +106,7 @@ func TestTokenMultipart(t *testing.T) {
 			req := safehttptest.NewRequest(safehttp.MethodPost, "https://foo.com/pizza", strings.NewReader(b))
 			req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 
-			i := Interceptor{AppKey: "testAppKey", Identifier: userIdentifier{}}
+			i := Interceptor{SecretAppKey: "testSecretAppKey", Identifier: userIdentifier{}}
 			i.Before(rec.ResponseWriter, req, nil)
 
 			if got := rec.Status(); got != test.wantStatus {
@@ -173,7 +173,7 @@ func TestMissingTokenInBody(t *testing.T) {
 	for _, test := range tests {
 		rec := safehttptest.NewResponseRecorder()
 
-		i := Interceptor{AppKey: "testAppKey", Identifier: userIdentifier{}}
+		i := Interceptor{SecretAppKey: "testSecretAppKey", Identifier: userIdentifier{}}
 		i.Before(rec.ResponseWriter, test.req, nil)
 
 		if want, got := safehttp.StatusUnauthorized, rec.Status(); got != want {
@@ -196,7 +196,7 @@ func TestBeforeTokenInRequestContext(t *testing.T) {
 	rec := safehttptest.NewResponseRecorder()
 	req := safehttptest.NewRequest(safehttp.MethodGet, "https://foo.com/pizza", nil)
 
-	i := Interceptor{AppKey: "testAppKey", Identifier: userIdentifier{}}
+	i := Interceptor{SecretAppKey: "testSecretAppKey", Identifier: userIdentifier{}}
 	i.Before(rec.ResponseWriter, req, nil)
 
 	tok, err := Token(req)

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -46,7 +46,7 @@ var (
 			wantBody:   "",
 		},
 		{
-			name:       "Token mismatch for invalid actionID",
+			name:       "Invalid actionID in token generation",
 			userID:     "1234",
 			actionID:   "http://bar.com/pizza",
 			wantStatus: safehttp.StatusForbidden,
@@ -57,7 +57,7 @@ var (
 			wantBody: "Forbidden\n",
 		},
 		{
-			name:       "Token mismatch for invalid userID",
+			name:       "Invalid userID in token generation",
 			userID:     "5678",
 			actionID:   "http://foo.com/pizza",
 			wantStatus: safehttp.StatusForbidden,

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -73,11 +73,11 @@ func TestTokenPost(t *testing.T) {
 	for _, test := range formTokenTests {
 		t.Run(test.name, func(t *testing.T) {
 			rec := safehttptest.NewResponseRecorder()
-			tok := xsrftoken.Generate("xsrf", test.userID, test.actionID)
+			tok := xsrftoken.Generate("testAppKey", test.userID, test.actionID)
 			req := safehttptest.NewRequest(safehttp.MethodPost, "https://foo.com/pizza", strings.NewReader(TokenKey+"="+tok))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-			i := Interceptor{AppKey: "xsrf", Identifier: userIdentifier{}}
+			i := Interceptor{AppKey: "testAppKey", Identifier: userIdentifier{}}
 			i.Before(rec.ResponseWriter, req, nil)
 
 			if got := rec.Status(); got != test.wantStatus {
@@ -97,7 +97,7 @@ func TestTokenMultipart(t *testing.T) {
 	for _, test := range formTokenTests {
 		t.Run(test.name, func(t *testing.T) {
 			rec := safehttptest.NewResponseRecorder()
-			tok := xsrftoken.Generate("xsrf", test.userID, test.actionID)
+			tok := xsrftoken.Generate("testAppKey", test.userID, test.actionID)
 			b := "--123\r\n" +
 				"Content-Disposition: form-data; name=\"xsrf-token\"\r\n" +
 				"\r\n" +
@@ -106,7 +106,7 @@ func TestTokenMultipart(t *testing.T) {
 			req := safehttptest.NewRequest(safehttp.MethodPost, "https://foo.com/pizza", strings.NewReader(b))
 			req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 
-			i := Interceptor{AppKey: "xsrf", Identifier: userIdentifier{}}
+			i := Interceptor{AppKey: "testAppKey", Identifier: userIdentifier{}}
 			i.Before(rec.ResponseWriter, req, nil)
 
 			if got := rec.Status(); got != test.wantStatus {
@@ -173,7 +173,7 @@ func TestMissingTokenInBody(t *testing.T) {
 	for _, test := range tests {
 		rec := safehttptest.NewResponseRecorder()
 
-		i := Interceptor{AppKey: "xsrf", Identifier: userIdentifier{}}
+		i := Interceptor{AppKey: "testAppKey", Identifier: userIdentifier{}}
 		i.Before(rec.ResponseWriter, test.req, nil)
 
 		if want, got := safehttp.StatusUnauthorized, rec.Status(); got != want {
@@ -196,7 +196,7 @@ func TestBeforeTokenInRequestContext(t *testing.T) {
 	rec := safehttptest.NewResponseRecorder()
 	req := safehttptest.NewRequest(safehttp.MethodGet, "https://foo.com/pizza", nil)
 
-	i := Interceptor{AppKey: "xsrf", Identifier: userIdentifier{}}
+	i := Interceptor{AppKey: "testAppKey", Identifier: userIdentifier{}}
 	i.Before(rec.ResponseWriter, req, nil)
 
 	tok, err := Token(req)


### PR DESCRIPTION
Fixes #122 

Extended the XSRF plugin to support token generation in the `xsrf.Before()` function. This will then be added to the context of a `safehttp.IncomingRequest` and can be retrieved using the `xsrf.Token()` getter.