### PR TITLE
Now we use safehttp.MethodXxxx and safehttp.StatusXxxx everywhere instead of strings and ints

### DIFF
--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -90,7 +90,7 @@ func TestFormValidInt(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, test.req)
 
-		if want := 200; rec.status != want {
+		if want := safehttp.StatusOK; rec.status != want {
 			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
@@ -180,7 +180,7 @@ func TestFormInvalidInt(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := 200; rec.status != want {
+			if want := safehttp.StatusOK; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -250,7 +250,7 @@ func TestFormValidUint(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, test.req)
 
-		if want := 200; rec.status != want {
+		if want := safehttp.StatusOK; rec.status != want {
 			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
@@ -337,7 +337,7 @@ func TestFormInvalidUint(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := 200; rec.status != want {
+			if want := safehttp.StatusOK; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -419,7 +419,7 @@ func TestFormValidString(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := 200; rec.status != want {
+			if want := safehttp.StatusOK; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -502,7 +502,7 @@ func TestFormValidFloat64(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := 200; rec.status != want {
+			if want := safehttp.StatusOK; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -591,7 +591,7 @@ func TestFormInvalidFloat64(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := 200; rec.status != want {
+			if want := safehttp.StatusOK; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -683,7 +683,7 @@ func TestFormValidBool(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := 200; rec.status != want {
+			if want := safehttp.StatusOK; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -764,7 +764,7 @@ func TestFormInvalidBool(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := 200; rec.status != want {
+			if want := safehttp.StatusOK; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -863,7 +863,7 @@ func TestFormInvalidSlice(t *testing.T) {
 			rec := newResponseRecorder(&strings.Builder{})
 			mux.ServeHTTP(rec, req)
 
-			if want := 200; rec.status != want {
+			if want := safehttp.StatusOK; rec.status != want {
 				t.Errorf("response status: got %v, want %v", rec.status, want)
 			}
 		}
@@ -956,7 +956,7 @@ func TestFormErrorHandling(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, tc.req)
 
-		if want := 200; rec.status != want {
+		if want := safehttp.StatusOK; rec.status != want {
 			t.Errorf("response status: got %v, want %v", rec.status, want)
 		}
 	}
@@ -1038,7 +1038,7 @@ func TestFormValidSlicePost(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, tc.req)
 
-		if respStatus, want := rec.status, 200; respStatus != want {
+		if respStatus, want := rec.status, safehttp.StatusOK; respStatus != want {
 			t.Errorf("response status: got %v, want %v", respStatus, want)
 		}
 	}
@@ -1139,7 +1139,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 		rec := newResponseRecorder(&strings.Builder{})
 		mux.ServeHTTP(rec, tc.req)
 
-		if respStatus, want := rec.status, 200; respStatus != want {
+		if respStatus, want := rec.status, safehttp.StatusOK; respStatus != want {
 			t.Errorf("response status: got %v, want %v", respStatus, want)
 		}
 	}

--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -37,7 +37,7 @@ func TestFormValidInt(t *testing.T) {
 		{
 			name: "Valid int in POST non-multipart request",
 			req: func() *http.Request {
-				postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza="+stringMaxInt))
+				postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza="+stringMaxInt))
 				postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return postReq
 			}(),
@@ -51,7 +51,7 @@ func TestFormValidInt(t *testing.T) {
 					"\r\n" +
 					stringMaxInt + "\r\n" +
 					"--123--\r\n"
-				multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+				multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 				multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return multipartReq
 			}(),
@@ -106,7 +106,7 @@ func TestFormInvalidInt(t *testing.T) {
 			name: "Overflow integer in request",
 			reqs: []*http.Request{
 				func() *http.Request {
-					postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=9223372036854775810"))
+					postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=9223372036854775810"))
 					postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					return postReq
 				}(),
@@ -116,7 +116,7 @@ func TestFormInvalidInt(t *testing.T) {
 						"\r\n" +
 						"9223372036854775810\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					return multipartReq
 				}(),
@@ -127,7 +127,7 @@ func TestFormInvalidInt(t *testing.T) {
 			name: "Not an integer in request",
 			reqs: []*http.Request{
 				func() *http.Request {
-					postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=diavola"))
+					postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=diavola"))
 					postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					return postReq
 
@@ -138,7 +138,7 @@ func TestFormInvalidInt(t *testing.T) {
 						"\r\n" +
 						"diavola\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					return multipartReq
 				}(),
@@ -197,7 +197,7 @@ func TestFormValidUint(t *testing.T) {
 		{
 			name: "Valid unsigned integer in POST non-multipart request",
 			req: func() *http.Request {
-				postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza="+stringMaxUint))
+				postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza="+stringMaxUint))
 				postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return postReq
 			}(),
@@ -211,7 +211,7 @@ func TestFormValidUint(t *testing.T) {
 					"\r\n" +
 					stringMaxUint + "\r\n" +
 					"--123--\r\n"
-				multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+				multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 				multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return multipartReq
 			}(),
@@ -266,7 +266,7 @@ func TestFormInvalidUint(t *testing.T) {
 			name: "Not an unsigned integer",
 			reqs: []*http.Request{
 				func() *http.Request {
-					postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=-1"))
+					postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=-1"))
 					postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					return postReq
 				}(),
@@ -276,7 +276,7 @@ func TestFormInvalidUint(t *testing.T) {
 						"\r\n" +
 						"-1\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					return multipartReq
 				}(),
@@ -287,7 +287,7 @@ func TestFormInvalidUint(t *testing.T) {
 			name: "Overflow unsigned integer",
 			reqs: []*http.Request{
 				func() *http.Request {
-					postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=18446744073709551630"))
+					postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=18446744073709551630"))
 					postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					return postReq
 				}(),
@@ -297,7 +297,7 @@ func TestFormInvalidUint(t *testing.T) {
 						"\r\n" +
 						"18446744073709551630\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					return multipartReq
 				}(),
@@ -354,9 +354,9 @@ func TestFormValidString(t *testing.T) {
 			name: "Valid string in POST non-multipart request",
 			reqs: func() []*http.Request {
 				reqs := []*http.Request{
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=diavola")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=ăȚâȘî")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=\x64\x69\x61\x76\x6f\x6c\x61")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=diavola")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=ăȚâȘî")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=\x64\x69\x61\x76\x6f\x6c\x61")),
 				}
 				for _, req := range reqs {
 					req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -376,7 +376,7 @@ func TestFormValidString(t *testing.T) {
 						"\r\n" +
 						val + "\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					reqs = append(reqs, multipartReq)
 
@@ -438,8 +438,8 @@ func TestFormValidFloat64(t *testing.T) {
 			name: "Valid floats in POST non-multipart request",
 			reqs: func() []*http.Request {
 				reqs := []*http.Request{
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza="+stringMaxFloat)),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza="+stringNegativeFloat)),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza="+stringMaxFloat)),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza="+stringNegativeFloat)),
 				}
 				for _, req := range reqs {
 					req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -459,7 +459,7 @@ func TestFormValidFloat64(t *testing.T) {
 						"\r\n" +
 						val + "\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					reqs = append(reqs, multipartReq)
 
@@ -519,7 +519,7 @@ func TestFormInvalidFloat64(t *testing.T) {
 			name: "Not a float64 in request",
 			reqs: []*http.Request{
 				func() *http.Request {
-					postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=diavola"))
+					postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=diavola"))
 					postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					return postReq
 				}(),
@@ -529,7 +529,7 @@ func TestFormInvalidFloat64(t *testing.T) {
 						"\r\n" +
 						"diavola\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					return multipartReq
 				}(),
@@ -540,7 +540,7 @@ func TestFormInvalidFloat64(t *testing.T) {
 			name: "Overflow float64 in request",
 			reqs: []*http.Request{
 				func() *http.Request {
-					postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=1.797693134862315708145274237317043567981e309"))
+					postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=1.797693134862315708145274237317043567981e309"))
 					postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					return postReq
 				}(),
@@ -550,7 +550,7 @@ func TestFormInvalidFloat64(t *testing.T) {
 						"\r\n" +
 						"1.797693134862315708145274237317043567981e309\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					return multipartReq
 				}(),
@@ -608,18 +608,18 @@ func TestFormValidBool(t *testing.T) {
 			name: "Valid booleans in POST non-multipart request",
 			reqs: func() []*http.Request {
 				reqs := []*http.Request{
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=true")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=false")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=True")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=False")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=TRUE")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=FALSE")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=t")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=f")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=T")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=F")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=1")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=0")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=true")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=false")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=True")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=False")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=TRUE")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=FALSE")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=t")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=f")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=T")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=F")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=1")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=0")),
 				}
 				for _, req := range reqs {
 					req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -639,7 +639,7 @@ func TestFormValidBool(t *testing.T) {
 						"\r\n" +
 						val + "\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					reqs = append(reqs, multipartReq)
 
@@ -700,8 +700,8 @@ func TestFormInvalidBool(t *testing.T) {
 			name: "Invalid booleans in POST non-multipart request",
 			reqs: func() []*http.Request {
 				reqs := []*http.Request{
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=TruE")),
-					httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=potato")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=TruE")),
+					httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=potato")),
 				}
 				for _, req := range reqs {
 					req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -721,7 +721,7 @@ func TestFormInvalidBool(t *testing.T) {
 						"\r\n" +
 						val + "\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					reqs = append(reqs, multipartReq)
 
@@ -784,7 +784,7 @@ func TestFormInvalidSlice(t *testing.T) {
 			name: "Request with multiple types in slice",
 			reqs: []*http.Request{
 				func() *http.Request {
-					postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=true&pizza=1.3"))
+					postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=true&pizza=1.3"))
 					postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					return postReq
 				}(),
@@ -798,7 +798,7 @@ func TestFormInvalidSlice(t *testing.T) {
 						"\r\n" +
 						"1.3\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					return multipartReq
 				}(),
@@ -808,7 +808,7 @@ func TestFormInvalidSlice(t *testing.T) {
 			name: "Unsupported slice type",
 			reqs: []*http.Request{
 				func() *http.Request {
-					postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=true&pizza=1.3"))
+					postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=true&pizza=1.3"))
 					postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					return postReq
 				}(),
@@ -822,7 +822,7 @@ func TestFormInvalidSlice(t *testing.T) {
 						"\r\n" +
 						"1.3\r\n" +
 						"--123--\r\n"
-					multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+					multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 					multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 					return multipartReq
 				}(),
@@ -878,7 +878,7 @@ func TestFormErrorHandling(t *testing.T) {
 		{
 			name: "Post form errors",
 			req: func() *http.Request {
-				postReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizzaInt=diavola&pizzaBool=true&pizzaUint=-13"))
+				postReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizzaInt=diavola&pizzaBool=true&pizzaUint=-13"))
 				postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return postReq
 			}(),
@@ -899,7 +899,7 @@ func TestFormErrorHandling(t *testing.T) {
 					"\r\n" +
 					"-13\r\n" +
 					"--123--\r\n"
-				multipartReq := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(multipartReqBody))
+				multipartReq := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(multipartReqBody))
 				multipartReq.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return multipartReq
 			}(),
@@ -970,7 +970,7 @@ func TestFormValidSlicePost(t *testing.T) {
 	}{
 		{
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=-8&pizza=9&pizza=-100"))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=-8&pizza=9&pizza=-100"))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req
 			}(),
@@ -979,7 +979,7 @@ func TestFormValidSlicePost(t *testing.T) {
 		},
 		{
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=8&pizza=9&pizza=10"))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=8&pizza=9&pizza=10"))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req
 			}(),
@@ -988,7 +988,7 @@ func TestFormValidSlicePost(t *testing.T) {
 		},
 		{
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=margeritta&pizza=diavola&pizza=calzone"))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=margeritta&pizza=diavola&pizza=calzone"))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req
 			}(),
@@ -997,7 +997,7 @@ func TestFormValidSlicePost(t *testing.T) {
 		},
 		{
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=1.3&pizza=8.9&pizza=-4.1"))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=1.3&pizza=8.9&pizza=-4.1"))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req
 			}(),
@@ -1006,7 +1006,7 @@ func TestFormValidSlicePost(t *testing.T) {
 		},
 		{
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader("pizza=true&pizza=false&pizza=T"))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader("pizza=true&pizza=false&pizza=T"))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req
 			}(),
@@ -1064,7 +1064,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 			req: func() *http.Request {
 				b := &strings.Builder{}
 				multipartBody.Execute(b, []string{"-8", "9", "-100"})
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(b.String()))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(b.String()))
 				req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return req
 			}(),
@@ -1075,7 +1075,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 			req: func() *http.Request {
 				b := &strings.Builder{}
 				multipartBody.Execute(b, []string{"8", "9", "10"})
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(b.String()))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(b.String()))
 				req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return req
 			}(),
@@ -1086,7 +1086,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 			req: func() *http.Request {
 				b := &strings.Builder{}
 				multipartBody.Execute(b, []string{"margeritta", "diavola", "calzone"})
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(b.String()))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(b.String()))
 				req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return req
 			}(),
@@ -1097,7 +1097,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 			req: func() *http.Request {
 				b := &strings.Builder{}
 				multipartBody.Execute(b, []string{"1.3", "8.9", "-4.1"})
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(b.String()))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(b.String()))
 				req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return req
 			}(),
@@ -1108,7 +1108,7 @@ func TestFormValidSliceMultipart(t *testing.T) {
 			req: func() *http.Request {
 				b := &strings.Builder{}
 				multipartBody.Execute(b, []string{"true", "false", "true"})
-				req := httptest.NewRequest("POST", "http://foo.com/", strings.NewReader(b.String()))
+				req := httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", strings.NewReader(b.String()))
 				req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return req
 			}(),

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -68,8 +68,8 @@ func (r *IncomingRequest) Path() string {
 func (r *IncomingRequest) PostForm() (*Form, error) {
 	var err error
 	r.postParseOnce.Do(func() {
-		if r.req.Method != "POST" && r.req.Method != "PATCH" && r.req.Method != "PUT" {
-			err = fmt.Errorf("got request method %s, want POST/PATCH/PUT", r.req.Method)
+		if m := r.req.Method; m != MethodPost && m != MethodPatch && m != MethodPut {
+			err = fmt.Errorf("got request method %s, want POST/PATCH/PUT", m)
 			return
 		}
 
@@ -101,8 +101,8 @@ func (r *IncomingRequest) MultipartForm(maxMemory int64) (*MultipartForm, error)
 	// will be stored on disk.
 	const defaultMaxMemory = 32 << 20
 	r.multipartParseOnce.Do(func() {
-		if r.req.Method != "POST" && r.req.Method != "PATCH" && r.req.Method != "PUT" {
-			err = fmt.Errorf("got request method %s, want POST/PATCH/PUT", r.req.Method)
+		if m := r.req.Method; m != MethodPost && m != MethodPatch && m != MethodPut {
+			err = fmt.Errorf("got request method %s, want POST/PATCH/PUT", m)
 			return
 		}
 

--- a/safehttp/incoming_request_test.go
+++ b/safehttp/incoming_request_test.go
@@ -16,11 +16,12 @@ package safehttp_test
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-safeweb/safehttp"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/safehttp"
 )
 
 func TestIncomingRequestCookie(t *testing.T) {
@@ -166,7 +167,7 @@ func TestRequestSetValidContextWithValue(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		req := httptest.NewRequest("GET", "/", nil)
+		req := httptest.NewRequest(safehttp.MethodGet, "/", nil)
 		ir := safehttp.NewIncomingRequest(req)
 		ctx := context.WithValue(ir.Context(), pizzaKey("1234"), &pizza{val: "margeritta"})
 		ir.SetContext(ctx)
@@ -182,7 +183,7 @@ func TestRequestSetValidContextWithValue(t *testing.T) {
 }
 
 func TestRequestSetNilContext(t *testing.T) {
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(safehttp.MethodGet, "/", nil)
 	ir := safehttp.NewIncomingRequest(req)
 
 	defer func() {

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -29,21 +29,21 @@ func TestMuxOneHandlerOneRequest(t *testing.T) {
 	var test = []struct {
 		name       string
 		req        *http.Request
-		wantStatus int
+		wantStatus safehttp.StatusCode
 		wantHeader map[string][]string
 		wantBody   string
 	}{
 		{
 			name:       "Valid Request",
 			req:        httptest.NewRequest("GET", "http://foo.com/", nil),
-			wantStatus: 200,
+			wantStatus: safehttp.StatusOK,
 			wantHeader: map[string][]string{},
 			wantBody:   "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 		{
 			name:       "Invalid Host",
 			req:        httptest.NewRequest("GET", "http://bar.com/", nil),
-			wantStatus: 404,
+			wantStatus: safehttp.StatusNotFound,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -53,7 +53,7 @@ func TestMuxOneHandlerOneRequest(t *testing.T) {
 		{
 			name:       "Invalid Method",
 			req:        httptest.NewRequest("POST", "http://foo.com/", nil),
-			wantStatus: 405,
+			wantStatus: safehttp.StatusMethodNotAllowed,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -96,7 +96,7 @@ func TestMuxServeTwoHandlers(t *testing.T) {
 		name        string
 		req         *http.Request
 		hf          safehttp.Handler
-		wantStatus  int
+		wantStatus  safehttp.StatusCode
 		wantHeaders map[string][]string
 		wantBody    string
 	}{
@@ -106,7 +106,7 @@ func TestMuxServeTwoHandlers(t *testing.T) {
 			hf: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 				return w.Write(safehtml.HTMLEscaped("<h1>Hello World! GET</h1>"))
 			}),
-			wantStatus:  200,
+			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{},
 			wantBody:    "&lt;h1&gt;Hello World! GET&lt;/h1&gt;",
 		},
@@ -116,7 +116,7 @@ func TestMuxServeTwoHandlers(t *testing.T) {
 			hf: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 				return w.Write(safehtml.HTMLEscaped("<h1>Hello World! POST</h1>"))
 			}),
-			wantStatus:  200,
+			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{},
 			wantBody:    "&lt;h1&gt;Hello World! POST&lt;/h1&gt;",
 		},
@@ -209,7 +209,7 @@ func TestMuxInterceptors(t *testing.T) {
 	tests := []struct {
 		name        string
 		mux         *safehttp.ServeMux
-		wantStatus  int
+		wantStatus  safehttp.StatusCode
 		wantHeaders map[string][]string
 		wantBody    string
 	}{
@@ -228,7 +228,7 @@ func TestMuxInterceptors(t *testing.T) {
 				mux.Handle("/bar", safehttp.MethodGet, registeredHandler)
 				return mux
 			}(),
-			wantStatus:  200,
+			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{"Foo": {"bar"}},
 			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
@@ -248,7 +248,7 @@ func TestMuxInterceptors(t *testing.T) {
 				})
 				return mux
 			}(),
-			wantStatus:  200,
+			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{"Foo": {"bar"}},
 			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
@@ -265,7 +265,7 @@ func TestMuxInterceptors(t *testing.T) {
 
 				return mux
 			}(),
-			wantStatus: 500,
+			wantStatus: safehttp.StatusInternalServerError,
 			wantHeaders: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},
@@ -287,7 +287,7 @@ func TestMuxInterceptors(t *testing.T) {
 
 				return mux
 			}(),
-			wantStatus:  200,
+			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{"Foo": {"bar"}},
 			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -35,14 +35,14 @@ func TestMuxOneHandlerOneRequest(t *testing.T) {
 	}{
 		{
 			name:       "Valid Request",
-			req:        httptest.NewRequest("GET", "http://foo.com/", nil),
+			req:        httptest.NewRequest(safehttp.MethodGet, "http://foo.com/", nil),
 			wantStatus: safehttp.StatusOK,
 			wantHeader: map[string][]string{},
 			wantBody:   "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 		{
 			name:       "Invalid Host",
-			req:        httptest.NewRequest("GET", "http://bar.com/", nil),
+			req:        httptest.NewRequest(safehttp.MethodGet, "http://bar.com/", nil),
 			wantStatus: safehttp.StatusNotFound,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
@@ -52,7 +52,7 @@ func TestMuxOneHandlerOneRequest(t *testing.T) {
 		},
 		{
 			name:       "Invalid Method",
-			req:        httptest.NewRequest("POST", "http://foo.com/", nil),
+			req:        httptest.NewRequest(safehttp.MethodPost, "http://foo.com/", nil),
 			wantStatus: safehttp.StatusMethodNotAllowed,
 			wantHeader: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
@@ -102,7 +102,7 @@ func TestMuxServeTwoHandlers(t *testing.T) {
 	}{
 		{
 			name: "GET Handler",
-			req:  httptest.NewRequest("GET", "http://foo.com/bar", nil),
+			req:  httptest.NewRequest(safehttp.MethodGet, "http://foo.com/bar", nil),
 			hf: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 				return w.Write(safehtml.HTMLEscaped("<h1>Hello World! GET</h1>"))
 			}),
@@ -112,7 +112,7 @@ func TestMuxServeTwoHandlers(t *testing.T) {
 		},
 		{
 			name: "POST Handler",
-			req:  httptest.NewRequest("POST", "http://foo.com/bar", nil),
+			req:  httptest.NewRequest(safehttp.MethodPost, "http://foo.com/bar", nil),
 			hf: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 				return w.Write(safehtml.HTMLEscaped("<h1>Hello World! POST</h1>"))
 			}),
@@ -318,7 +318,7 @@ func TestMuxInterceptors(t *testing.T) {
 			b := &strings.Builder{}
 			rw := newResponseRecorder(b)
 
-			req := httptest.NewRequest("GET", "http://foo.com/bar", nil)
+			req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/bar", nil)
 
 			tt.mux.ServeHTTP(rw, req)
 

--- a/safehttp/plugins/hsts/hsts_test.go
+++ b/safehttp/plugins/hsts/hsts_test.go
@@ -112,7 +112,7 @@ func TestHSTS(t *testing.T) {
 			name:        "Negative maxage",
 			interceptor: hsts.Interceptor{MaxAge: -1 * time.Second},
 			req:         safehttptest.NewRequest("GET", "https://localhost/", nil),
-			wantStatus:  500,
+			wantStatus:  safehttp.StatusInternalServerError,
 			wantHeaders: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
 				"X-Content-Type-Options": {"nosniff"},

--- a/safehttp/plugins/hsts/hsts_test.go
+++ b/safehttp/plugins/hsts/hsts_test.go
@@ -36,7 +36,7 @@ func TestHSTS(t *testing.T) {
 		{
 			name:        "HTTPS",
 			interceptor: hsts.Default(),
-			req:         safehttptest.NewRequest("GET", "https://localhost/", nil),
+			req:         safehttptest.NewRequest(safehttp.MethodGet, "https://localhost/", nil),
 			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{
 				"Strict-Transport-Security": {"max-age=63072000; includeSubDomains"}, // 63072000 seconds is two years
@@ -46,7 +46,7 @@ func TestHSTS(t *testing.T) {
 		{
 			name:        "HTTP",
 			interceptor: hsts.Default(),
-			req:         safehttptest.NewRequest("GET", "http://localhost/", nil),
+			req:         safehttptest.NewRequest(safehttp.MethodGet, "http://localhost/", nil),
 			wantStatus:  safehttp.StatusMovedPermanently,
 			wantHeaders: map[string][]string{
 				"Content-Type": {"text/html; charset=utf-8"},
@@ -57,7 +57,7 @@ func TestHSTS(t *testing.T) {
 		{
 			name:        "HTTP behind proxy",
 			interceptor: hsts.Interceptor{BehindProxy: true},
-			req:         safehttptest.NewRequest("GET", "http://localhost/", nil),
+			req:         safehttptest.NewRequest(safehttp.MethodGet, "http://localhost/", nil),
 			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{
 				// max-age=0 tells the browser to expire the HSTS protection.
@@ -68,7 +68,7 @@ func TestHSTS(t *testing.T) {
 		{
 			name:        "Preload",
 			interceptor: hsts.Interceptor{Preload: true, DisableIncludeSubDomains: true},
-			req:         safehttptest.NewRequest("GET", "https://localhost/", nil),
+			req:         safehttptest.NewRequest(safehttp.MethodGet, "https://localhost/", nil),
 			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{
 				// max-age=0 tells the browser to expire the HSTS protection.
@@ -79,7 +79,7 @@ func TestHSTS(t *testing.T) {
 		{
 			name:        "Preload and IncludeSubDomains",
 			interceptor: hsts.Interceptor{Preload: true},
-			req:         safehttptest.NewRequest("GET", "https://localhost/", nil),
+			req:         safehttptest.NewRequest(safehttp.MethodGet, "https://localhost/", nil),
 			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{
 				// max-age=0 tells the browser to expire the HSTS protection.
@@ -90,7 +90,7 @@ func TestHSTS(t *testing.T) {
 		{
 			name:        "No preload and no includeSubDomains",
 			interceptor: hsts.Interceptor{DisableIncludeSubDomains: true},
-			req:         safehttptest.NewRequest("GET", "https://localhost/", nil),
+			req:         safehttptest.NewRequest(safehttp.MethodGet, "https://localhost/", nil),
 			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{
 				// max-age=0 tells the browser to expire the HSTS protection.
@@ -101,7 +101,7 @@ func TestHSTS(t *testing.T) {
 		{
 			name:        "Custom maxage",
 			interceptor: hsts.Interceptor{MaxAge: 3600 * time.Second},
-			req:         safehttptest.NewRequest("GET", "https://localhost/", nil),
+			req:         safehttptest.NewRequest(safehttp.MethodGet, "https://localhost/", nil),
 			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{
 				"Strict-Transport-Security": {"max-age=3600; includeSubDomains"}, // 3600 seconds is 1 hour
@@ -111,7 +111,7 @@ func TestHSTS(t *testing.T) {
 		{
 			name:        "Negative maxage",
 			interceptor: hsts.Interceptor{MaxAge: -1 * time.Second},
-			req:         safehttptest.NewRequest("GET", "https://localhost/", nil),
+			req:         safehttptest.NewRequest(safehttp.MethodGet, "https://localhost/", nil),
 			wantStatus:  safehttp.StatusInternalServerError,
 			wantHeaders: map[string][]string{
 				"Content-Type":           {"text/plain; charset=utf-8"},
@@ -145,7 +145,7 @@ func TestHSTS(t *testing.T) {
 func TestStrictTransportSecurityAlreadyImmutable(t *testing.T) {
 	p := hsts.Default()
 
-	req := safehttptest.NewRequest("GET", "https://localhost/", nil)
+	req := safehttptest.NewRequest(safehttp.MethodGet, "https://localhost/", nil)
 
 	rr := safehttptest.NewResponseRecorder()
 	rr.ResponseWriter.Header().Claim("Strict-Transport-Security")

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -90,7 +90,7 @@ func TestXSRFTokenPost(t *testing.T) {
 	for _, test := range tests {
 		i := xsrf.Interceptor{AppKey: "xsrf", Identifier: userIdentifier{}}
 		tok := xsrftoken.Generate("xsrf", test.userID, test.host+test.path)
-		req := safehttptest.NewRequest("POST", "http://foo.com/pizza", strings.NewReader(xsrf.TokenKey+"="+tok))
+		req := safehttptest.NewRequest(safehttp.MethodPost, "http://foo.com/pizza", strings.NewReader(xsrf.TokenKey+"="+tok))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		rec := safehttptest.NewResponseRecorder()
@@ -172,7 +172,7 @@ func TestXSRFTokenMultipart(t *testing.T) {
 			"\r\n" +
 			tok + "\r\n" +
 			"--123--\r\n"
-		req := safehttptest.NewRequest("POST", "http://foo.com/pizza", strings.NewReader(b))
+		req := safehttptest.NewRequest(safehttp.MethodPost, "http://foo.com/pizza", strings.NewReader(b))
 		req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 
 		rec := safehttptest.NewResponseRecorder()
@@ -201,7 +201,7 @@ func TestXSRFMissingToken(t *testing.T) {
 		{
 			name: "Missing token in POST request",
 			req: func() *safehttp.IncomingRequest {
-				req := safehttptest.NewRequest("POST", "/", strings.NewReader("foo=bar"))
+				req := safehttptest.NewRequest(safehttp.MethodPost, "/", strings.NewReader("foo=bar"))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req
 			}(),
@@ -220,7 +220,7 @@ func TestXSRFMissingToken(t *testing.T) {
 					"\r\n" +
 					"bar\r\n" +
 					"--123--\r\n"
-				req := safehttptest.NewRequest("POST", "/", strings.NewReader(b))
+				req := safehttptest.NewRequest(safehttp.MethodPost, "/", strings.NewReader(b))
 				req.Header.Set("Content-Type", `multipart/form-data; boundary="123"`)
 				return req
 			}(),

--- a/safehttp/recorder_dispatcher_test.go
+++ b/safehttp/recorder_dispatcher_test.go
@@ -51,7 +51,7 @@ func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Templat
 type responseRecorder struct {
 	header http.Header
 	writer io.Writer
-	status int
+	status safehttp.StatusCode
 }
 
 func newResponseRecorder(w io.Writer) *responseRecorder {
@@ -67,7 +67,7 @@ func (r *responseRecorder) Header() http.Header {
 }
 
 func (r *responseRecorder) WriteHeader(statusCode int) {
-	r.status = statusCode
+	r.status = safehttp.StatusCode(statusCode)
 }
 
 func (r *responseRecorder) Write(data []byte) (int, error) {

--- a/tests/integration/header/header_test.go
+++ b/tests/integration/header/header_test.go
@@ -95,7 +95,7 @@ func TestChangingResponseHeaders(t *testing.T) {
 		return rw.Write(safehtml.HTMLEscaped("hello"))
 	}))
 
-	req := httptest.NewRequest("GET", "http://foo.com/", nil)
+	req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/", nil)
 
 	b := &strings.Builder{}
 	rw := newResponseRecorder(b)

--- a/tests/integration/header/header_test.go
+++ b/tests/integration/header/header_test.go
@@ -46,7 +46,7 @@ func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Templat
 type responseRecorder struct {
 	header http.Header
 	writer io.Writer
-	status int
+	status safehttp.StatusCode
 }
 
 func newResponseRecorder(w io.Writer) *responseRecorder {
@@ -58,7 +58,7 @@ func (r *responseRecorder) Header() http.Header {
 }
 
 func (r *responseRecorder) WriteHeader(statusCode int) {
-	r.status = statusCode
+	r.status = safehttp.StatusCode(statusCode)
 }
 
 func (r *responseRecorder) Write(data []byte) (int, error) {

--- a/tests/integration/hsts/hsts_test.go
+++ b/tests/integration/hsts/hsts_test.go
@@ -46,7 +46,7 @@ func (dispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, d
 type responseRecorder struct {
 	header http.Header
 	writer io.Writer
-	status int
+	status safehttp.StatusCode
 }
 
 func newResponseRecorder(w io.Writer) *responseRecorder {
@@ -58,7 +58,7 @@ func (r *responseRecorder) Header() http.Header {
 }
 
 func (r *responseRecorder) WriteHeader(statusCode int) {
-	r.status = statusCode
+	r.status = safehttp.StatusCode(statusCode)
 }
 
 func (r *responseRecorder) Write(data []byte) (int, error) {
@@ -82,7 +82,7 @@ func TestHSTSServeMuxInstall(t *testing.T) {
 
 	mux.ServeHTTP(rr, req)
 
-	if want := 200; rr.status != want {
+	if want := safehttp.StatusOK; rr.status != want {
 		t.Errorf("rr.status got: %v want: %v", rr.status, want)
 	}
 

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -75,7 +75,7 @@ func TestHandleRequestWrite(t *testing.T) {
 		return rw.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
 	}))
 
-	req := httptest.NewRequest("GET", "http://foo.com/", nil)
+	req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/", nil)
 
 	b := &strings.Builder{}
 	rw := newResponseRecorder(b)
@@ -95,7 +95,7 @@ func TestHandleRequestWriteTemplate(t *testing.T) {
 		return rw.WriteTemplate(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 	}))
 
-	req := httptest.NewRequest("GET", "http://foo.com/", nil)
+	req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/", nil)
 
 	b := &strings.Builder{}
 	rw := newResponseRecorder(b)

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -50,7 +50,7 @@ func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Templat
 type responseRecorder struct {
 	header http.Header
 	writer io.Writer
-	status int
+	status safehttp.StatusCode
 }
 
 func newResponseRecorder(w io.Writer) *responseRecorder {
@@ -62,7 +62,7 @@ func (r *responseRecorder) Header() http.Header {
 }
 
 func (r *responseRecorder) WriteHeader(statusCode int) {
-	r.status = statusCode
+	r.status = safehttp.StatusCode(statusCode)
 }
 
 func (r *responseRecorder) Write(data []byte) (int, error) {

--- a/tests/integration/staticheaders/staticheaders_test.go
+++ b/tests/integration/staticheaders/staticheaders_test.go
@@ -52,7 +52,7 @@ func (dispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, d
 type responseRecorder struct {
 	header http.Header
 	writer io.Writer
-	status int
+	status safehttp.StatusCode
 }
 
 func newResponseRecorder(w io.Writer) *responseRecorder {
@@ -64,7 +64,7 @@ func (r *responseRecorder) Header() http.Header {
 }
 
 func (r *responseRecorder) WriteHeader(statusCode int) {
-	r.status = statusCode
+	r.status = safehttp.StatusCode(statusCode)
 }
 
 func (r *responseRecorder) Write(data []byte) (int, error) {
@@ -88,7 +88,7 @@ func TestServeMuxInstallStaticHeaders(t *testing.T) {
 
 	mux.ServeHTTP(rr, req)
 
-	if want := int(safehttp.StatusOK); rr.status != want {
+	if want := safehttp.StatusOK; rr.status != want {
 		t.Errorf("rr.status got: %v want: %v", rr.status, want)
 	}
 


### PR DESCRIPTION
Fixes #121 