### PR TITLE
Removed casting in CSP tests that is breaking master

### DIFF
--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -193,7 +193,7 @@ func TestAlreadyClaimed(t *testing.T) {
 			it := Interceptor{}
 			it.Before(rr.ResponseWriter, req)
 
-			if got, want := rr.Status(), int(safehttp.StatusInternalServerError); got != want {
+			if got, want := rr.Status(), safehttp.StatusInternalServerError; got != want {
 				t.Errorf("rr.Status() got: %v want: %v", got, want)
 			}
 


### PR DESCRIPTION
Fixed commit #5c6aabe that is causing `go vet` and `go test` to fail because of a type mismatich (`int` to `safehttp.StatusCode` comparison in the CSP tests).  