### PR TITLE
Added set of hashes to CSP plugin

### DIFF
--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -84,6 +84,12 @@ type StrictCSPBuilder struct {
 	// ReportURI controls the report-uri directive. If ReportUri is empty, no report-uri
 	// directive will be set.
 	ReportURI string
+	// Hashes adds a set of hashes to script-src. An example of a hash would be:
+	//  sha256-CihokcEcBW4atb/CW/XWsvWwbTjqwQlE9nj9ii5ww5M=
+	// which is the SHA256 hash for the script "console.log(1)".
+	//
+	// For more info, see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
+	Hashes []string
 }
 
 // Build creates a Policy based on the specified options.
@@ -103,6 +109,12 @@ func (s StrictCSPBuilder) Build() Policy {
 
 			if s.UnsafeEval {
 				b.WriteString(" 'unsafe-eval'")
+			}
+
+			for _, h := range s.Hashes {
+				b.WriteString(" '")
+				b.WriteString(h)
+				b.WriteByte('\'')
 			}
 
 			b.WriteString("; base-uri ")

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -72,6 +72,21 @@ func TestSerialize(t *testing.T) {
 			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://example.com/collector",
 		},
 		{
+			name: "StrictCSP with one hash",
+			policy: StrictCSPBuilder{Hashes: []string{
+				"sha256-CihokcEcBW4atb/CW/XWsvWwbTjqwQlE9nj9ii5ww5M=",
+			}}.Build(),
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http: 'sha256-CihokcEcBW4atb/CW/XWsvWwbTjqwQlE9nj9ii5ww5M='; base-uri 'none'",
+		},
+		{
+			name: "StrictCSP with multiple hashes",
+			policy: StrictCSPBuilder{Hashes: []string{
+				"sha256-CihokcEcBW4atb/CW/XWsvWwbTjqwQlE9nj9ii5ww5M=",
+				"sha256-CihokcEcBW4atb/CW/XWsvWwbTjqwQlE9nj9ii5ww5M=",
+			}}.Build(),
+			wantString: "object-src 'none'; script-src 'unsafe-inline' 'nonce-super-secret' 'strict-dynamic' https: http: 'sha256-CihokcEcBW4atb/CW/XWsvWwbTjqwQlE9nj9ii5ww5M=' 'sha256-CihokcEcBW4atb/CW/XWsvWwbTjqwQlE9nj9ii5ww5M='; base-uri 'none'",
+		},
+		{
 			name:       "FramingCSP",
 			policy:     FramingPolicyBuilder{}.Build(),
 			wantString: "frame-ancestors 'self'",


### PR DESCRIPTION
Fixes #111 

You can now specify a set of hashes in the CSP plugin. An example of such a hash is `sha256-CihokcEcBW4atb/CW/XWsvWwbTjqwQlE9nj9ii5ww5M=`