### PR TITLE
Extended the MultipartForm type to allow accessing file uploads

### DIFF
--- a/safehttp/form.go
+++ b/safehttp/form.go
@@ -204,10 +204,10 @@ type MultipartForm struct {
 	mf *multipart.Form
 }
 
-// FileHeaders returns the file parts associated with form key param or a nil
+// File returns the file parts associated with form key param or a nil
 // slice, if none. These can be then opened individually by calling
 // FileHeader.Open.
-func (f *MultipartForm) FileHeaders(param string) []*multipart.FileHeader {
+func (f *MultipartForm) File(param string) []*multipart.FileHeader {
 	fh, ok := f.mf.File[param]
 	if !ok {
 		return nil

--- a/safehttp/form.go
+++ b/safehttp/form.go
@@ -205,7 +205,8 @@ type MultipartForm struct {
 }
 
 // FileHeaders returns the file parts associated with form key param or a nil
-// slice, if none. These can be then opened individually by calling Open.
+// slice, if none. These can be then opened individually by calling
+// FileHeader.Open.
 func (f *MultipartForm) FileHeaders(param string) []*multipart.FileHeader {
 	fh, ok := f.mf.File[param]
 	if !ok {

--- a/safehttp/form.go
+++ b/safehttp/form.go
@@ -16,6 +16,7 @@ package safehttp
 
 import (
 	"fmt"
+	"mime/multipart"
 	"strconv"
 )
 
@@ -195,9 +196,26 @@ func (f *Form) Err() error {
 	return f.err
 }
 
-// MultipartForm extends the Form structure to define a POST, PATCH or PUT
-// request that has Content-Type: multipart/form-data.
+// MultipartForm extends a parsed multipart form, part of the body of a
+// PATCH, POST or PUT request. A multipart form can include both form values and
+// file uploads, stored either in memory or on disk.
 type MultipartForm struct {
 	Form
-	// TODO(mihalimara22): add support for form files in the MultipartForm
+	mf *multipart.Form
+}
+
+// FileHeaders returns the file parts associated with form key param or a nil
+// slice, if none. These can be then opened individually by calling Open.
+func (f *MultipartForm) FileHeaders(param string) []*multipart.FileHeader {
+	fh, ok := f.mf.File[param]
+	if !ok {
+		return nil
+	}
+	return fh
+}
+
+// RemoveFiles removes any temporary files associated with a Form and returns
+// the first error that occured, if any.
+func (f *MultipartForm) RemoveFiles() error {
+	return f.mf.RemoveAll()
 }

--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -49,7 +49,6 @@ func TestFormValidInt64(t *testing.T) {
 }
 
 func TestFormInvalidInt64(t *testing.T) {
-<<<<<<< HEAD
 	tests := []struct {
 		name string
 		val  string
@@ -61,16 +60,6 @@ func TestFormInvalidInt64(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			values := map[string][]string{"a": {tt.val}}
-=======
-	tests := []string{
-		"9223372036854775810",
-		"abc",
-	}
-
-	for _, val := range tests {
-		t.Run(val, func(t *testing.T) {
-			values := map[string][]string{"a": {val}}
->>>>>>> Reformatted form_test.go to not use ServeMux but test the Form type directly
 			f := Form{values: values}
 
 			if got, want := f.Int64("a", 0), int64(0); got != want {

--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -510,9 +510,9 @@ func TestMultipartFormValidFile(t *testing.T) {
 			"foo": {fh},
 		},
 	}}
-	fhs := f.FileHeaders("foo")
+	fhs := f.File("foo")
 	if fhs == nil {
-		t.Errorf(`m.FileHeaders("foo"): got nil, want file headers`)
+		t.Errorf(`m.File("foo"): got nil, want file headers`)
 	}
 	if diff := cmp.Diff(fh, fhs[0], cmp.AllowUnexported(multipart.FileHeader{})); diff != "" {
 		t.Errorf("file headers mismatch (-want +got):\n%s", diff)
@@ -537,9 +537,9 @@ func TestMultipartFormValidFileAndVals(t *testing.T) {
 		t.Errorf(`f.Err(): got err %v`, err)
 	}
 
-	fhs := f.FileHeaders("foo")
+	fhs := f.File("foo")
 	if fhs == nil {
-		t.Errorf(`m.FileHeaders("foo"): got nil, want file headers`)
+		t.Errorf(`m.File("foo"): got nil, want file headers`)
 	}
 	if diff := cmp.Diff(fh, fhs[0], cmp.AllowUnexported(multipart.FileHeader{})); diff != "" {
 		t.Errorf("file headers mismatch (-want +got):\n%s", diff)
@@ -548,8 +548,8 @@ func TestMultipartFormValidFileAndVals(t *testing.T) {
 
 func TestMultipartFormMissingFile(t *testing.T) {
 	f := &MultipartForm{mf: &multipart.Form{}}
-	fhs := f.FileHeaders("x")
+	fhs := f.File("x")
 	if fhs != nil {
-		t.Errorf(`m.FileHeaders("x"): got file headers, want nil`)
+		t.Errorf(`m.File("x"): got file headers, want nil`)
 	}
 }

--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -49,6 +49,7 @@ func TestFormValidInt64(t *testing.T) {
 }
 
 func TestFormInvalidInt64(t *testing.T) {
+<<<<<<< HEAD
 	tests := []struct {
 		name string
 		val  string
@@ -60,6 +61,16 @@ func TestFormInvalidInt64(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			values := map[string][]string{"a": {tt.val}}
+=======
+	tests := []string{
+		"9223372036854775810",
+		"abc",
+	}
+
+	for _, val := range tests {
+		t.Run(val, func(t *testing.T) {
+			values := map[string][]string{"a": {val}}
+>>>>>>> Reformatted form_test.go to not use ServeMux but test the Form type directly
 			f := Form{values: values}
 
 			if got, want := f.Int64("a", 0), int64(0); got != want {

--- a/safehttp/form_test.go
+++ b/safehttp/form_test.go
@@ -527,7 +527,8 @@ func TestMultipartFormValidFileAndVals(t *testing.T) {
 			File: map[string][]*multipart.FileHeader{
 				"foo": {fh},
 			},
-		}}
+		},
+	}
 
 	if want, got := int64(1), f.Int64("number", 0); want != got {
 		t.Errorf(`f.Int64("number"): got %d, want %d`, got, want)

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -79,7 +79,8 @@ func (r *IncomingRequest) PostForm() (*Form, error) {
 // MultipartForm parses the form parameters provided in the body of a POST,
 // PATCH or PUT request that has Content-Type set to multipart/form-data. It
 // returns a MultipartForm object containing the parsed form parameters and
-// file uploads (if any) or the parsing error together with a nil MultipartForm // otherwise.
+// file uploads (if any) or the parsing error together with a nil MultipartForm
+// otherwise.
 //
 // If the parsed request body is larger than maxMemory, up to maxMemory bytes
 // will be stored in main memory, with the rest stored on disk in temporary

--- a/safehttp/incoming_request_test.go
+++ b/safehttp/incoming_request_test.go
@@ -372,9 +372,9 @@ func TestIncomingRequestMultipartFileUpload(t *testing.T) {
 		t.Errorf("r.MultipartForm(1024): got err %v", err)
 	}
 
-	fhs := f.FileHeaders("file")
+	fhs := f.File("file")
 	if fhs == nil {
-		t.Error(`f.FileHeaders("file"): got nil, want file header`)
+		t.Error(`f.File("file"): got nil, want file header`)
 	}
 	defer f.RemoveFiles()
 
@@ -411,9 +411,9 @@ func TestIncomingRequestMultipartFormAndFileUpload(t *testing.T) {
 		t.Errorf("f.Err(): got err %v", err)
 	}
 
-	fhs := f.FileHeaders("file")
+	fhs := f.File("file")
 	if fhs == nil {
-		t.Error(`f.FileHeaders("file"): got nil, want file header`)
+		t.Error(`f.File("file"): got nil, want file header`)
 	}
 	defer f.RemoveFiles()
 
@@ -438,9 +438,9 @@ func TestIncomingRequestFileUploadMissingContent(t *testing.T) {
 		t.Errorf("r.MultipartForm(1024): got err %v", err)
 	}
 
-	fhs := f.FileHeaders("file")
+	fhs := f.File("file")
 	if fhs == nil {
-		t.Error(`f.FileHeaders("file"): got nil, want file header`)
+		t.Error(`f.File("file"): got nil, want file header`)
 	}
 	defer f.RemoveFiles()
 


### PR DESCRIPTION
Fixes #32, #38

Extended the `MultipartForm` to support retrieving file uploads from incoming requests. This will prevent the user from directly accessing the multipart form but will still allow access to the accessor methods in `multipart` used for opening files.

Fixed the issue that was causing a multipart form to be capped at 32 MB (my misunderstanding of documentation).

This branch  is rebased on top of `grenfeldt-splitting-form-tests` branch  (#125 ).