### PR TITLE
Removed Interceptor keys from ServeMux, now interceptors and their configs are stored in a slice.

### DIFF
--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -202,8 +202,8 @@ func (h handlerWithInterceptors) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		}
 	}()
 
-	for _, ai := range h.interceps {
-		ai.it.Before(rw, ir, ai.cfg)
+	for _, interceptor := range h.interceps {
+		interceptor.it.Before(rw, ir, interceptor.cfg)
 		if rw.written {
 			return
 		}

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -25,30 +25,19 @@ type ResponseWriter struct {
 
 	// Having this field unexported is essential for security. Otherwise one can
 	// easily overwrite the struct bypassing all our safety guarantees.
-	header       Header
-	muxInterceps map[string]Interceptor
-	written      bool
+	header  Header
+	written bool
 }
 
 // NewResponseWriter creates a ResponseWriter from a safehttp.Dispatcher, an
 // http.ResponseWriter and a list of interceptors associated with a ServeMux.
-func NewResponseWriter(d Dispatcher, rw http.ResponseWriter, muxInterceps map[string]Interceptor) *ResponseWriter {
+func NewResponseWriter(d Dispatcher, rw http.ResponseWriter) *ResponseWriter {
 	header := newHeader(rw.Header())
 	return &ResponseWriter{
-		d:            d,
-		rw:           rw,
-		header:       header,
-		muxInterceps: muxInterceps,
+		d:      d,
+		rw:     rw,
+		header: header,
 	}
-}
-
-// Interceptor returns the interceptor associated with the given key.
-func (w *ResponseWriter) Interceptor(key string) Interceptor {
-	mp, ok := w.muxInterceps[key]
-	if !ok {
-		return nil
-	}
-	return mp
 }
 
 // Result TODO

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestResponseWriterSetCookie(t *testing.T) {
 	rr := newResponseRecorder(&strings.Builder{})
-	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil)
+	rw := safehttp.NewResponseWriter(testDispatcher{}, rr)
 
 	c := safehttp.NewCookie("foo", "bar")
 	err := rw.SetCookie(c)
@@ -45,7 +45,7 @@ func TestResponseWriterSetCookie(t *testing.T) {
 
 func TestResponseWriterSetInvalidCookie(t *testing.T) {
 	rr := newResponseRecorder(&strings.Builder{})
-	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil)
+	rw := safehttp.NewResponseWriter(testDispatcher{}, rr)
 
 	c := safehttp.NewCookie("f=oo", "bar")
 	err := rw.SetCookie(c)
@@ -99,7 +99,7 @@ func TestResponseWriterWriteTwicePanic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := safehttp.NewResponseWriter(testDispatcher{}, newResponseRecorder(&strings.Builder{}), nil)
+			w := safehttp.NewResponseWriter(testDispatcher{}, newResponseRecorder(&strings.Builder{}))
 			defer func() {
 				if r := recover(); r == nil {
 					t.Errorf("tt.write(w) expected panic")

--- a/safehttp/safehttptest/recorder.go
+++ b/safehttp/safehttptest/recorder.go
@@ -61,7 +61,7 @@ func NewResponseRecorder() *ResponseRecorder {
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
-		ResponseWriter: safehttp.NewResponseWriter(testDispatcher{}, rw, nil),
+		ResponseWriter: safehttp.NewResponseWriter(testDispatcher{}, rw),
 	}
 }
 
@@ -73,7 +73,7 @@ func NewResponseRecorderFromDispatcher(d safehttp.Dispatcher) *ResponseRecorder 
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
-		ResponseWriter: safehttp.NewResponseWriter(d, rw, nil),
+		ResponseWriter: safehttp.NewResponseWriter(d, rw),
 	}
 }
 

--- a/tests/integration/hsts/hsts_test.go
+++ b/tests/integration/hsts/hsts_test.go
@@ -68,7 +68,7 @@ func (r *responseRecorder) Write(data []byte) (int, error) {
 func TestHSTSServeMuxInstall(t *testing.T) {
 	mux := safehttp.NewServeMux(&dispatcher{}, "foo.com")
 
-	mux.Install("hsts", hsts.Default())
+	mux.Install(hsts.Default())
 	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 	})

--- a/tests/integration/staticheaders/staticheaders_test.go
+++ b/tests/integration/staticheaders/staticheaders_test.go
@@ -74,7 +74,7 @@ func (r *responseRecorder) Write(data []byte) (int, error) {
 func TestServeMuxInstallStaticHeaders(t *testing.T) {
 	mux := safehttp.NewServeMux(dispatcher{}, "foo.com")
 
-	mux.Install("staticheaders", staticheaders.Plugin{})
+	mux.Install(staticheaders.Plugin{})
 	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 	})


### PR DESCRIPTION
Now Interceptors are stored together with their configs in slices instead of maps. To interact with an interceptor from the handler that interceptor needs to implement package level functions which take ResponseWriters and IncomingRequests and do things. State can be stored in the context of the request.

Fixes #143 