### PR TITLE
Added the Commit phase

### DIFF
--- a/safehttp/interceptor.go
+++ b/safehttp/interceptor.go
@@ -23,4 +23,10 @@ type Interceptor interface {
 	// interceptors and the handler won't execute. If Before panics, it will be
 	// recovered and the ServeMux will respond with 500 Internal Server Error.
 	Before(w *ResponseWriter, r *IncomingRequest, cfg interface{}) Result
+
+	// Commit runs before the response is written by the Dispatcher. If an error
+	// is written to the CommitResponseWriter, then the Commit phases from the
+	// remaining interceptors won't execute and any headers set in the
+	// ResponseWriter would be removed.
+	Commit(w *CommitResponseWriter, r *IncomingRequest, resp Response, cfg interface{}) Result
 }

--- a/safehttp/interceptor.go
+++ b/safehttp/interceptor.go
@@ -25,8 +25,7 @@ type Interceptor interface {
 	Before(w *ResponseWriter, r *IncomingRequest, cfg interface{}) Result
 
 	// Commit runs before the response is written by the Dispatcher. If an error
-	// is written to the CommitResponseWriter, then the Commit phases from the
-	// remaining interceptors won't execute and any headers set in the
-	// ResponseWriter would be removed.
-	Commit(w *CommitResponseWriter, r *IncomingRequest, resp Response, cfg interface{}) Result
+	// is written to the ResponseWriter, then the Commit phases from the
+	// remaining interceptors won't execute.
+	Commit(w *ResponseWriter, r *IncomingRequest, resp Response, cfg interface{}) Result
 }

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -96,7 +96,8 @@ func NewServeMux(d Dispatcher, domains ...string) *ServeMux {
 	}
 }
 
-type appliedInterceptor struct {
+// AppliedInterceptor TODO
+type AppliedInterceptor struct {
 	it  Interceptor
 	cfg Config
 }
@@ -109,7 +110,7 @@ type appliedInterceptor struct {
 // Interceptor was not installed will produce no effect. If multiple Configs are
 // passed for the same Interceptor, only the first one will take effect.
 func (m *ServeMux) Handle(pattern string, method string, h Handler, cfgs ...Config) {
-	var interceps []appliedInterceptor
+	var interceps []AppliedInterceptor
 	for _, it := range m.interceps {
 		var cfg Config
 		for _, c := range cfgs {
@@ -118,7 +119,7 @@ func (m *ServeMux) Handle(pattern string, method string, h Handler, cfgs ...Conf
 				break
 			}
 		}
-		interceps = append(interceps, appliedInterceptor{it: it, cfg: cfg})
+		interceps = append(interceps, AppliedInterceptor{it: it, cfg: cfg})
 	}
 	hi := handlerWithInterceptors{
 		handler:   h,
@@ -183,21 +184,17 @@ func (m methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // interceptors.
 type handlerWithInterceptors struct {
 	handler   Handler
-	interceps []appliedInterceptor
+	interceps []AppliedInterceptor
 	disp      Dispatcher
 }
 
 // ServeHTTP calls the Before method of all the interceptors and then calls the
-// underlying handler.
+// underlying handler. Any panics that occur during the Before phase, during handler
+// execution or during the Commit phase are recovered here and a 500 Internal Server
+// Error response is sent.
 func (h handlerWithInterceptors) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ir := NewIncomingRequest(r)
-	cp := &CommitPhase{
-		Req:            ir,
-		Interceps:      h.interceps,
-		Configs:        h.configs,
-		IntercepsOrder: h.intercepsOrder,
-	}
-	rw := NewResponseWriter(h.disp, w, h.interceps, cp)
+	rw := NewResponseWriter(h.disp, w, ir, h.interceps)
 
 	// The `net/http` package recovers handler panics, but we cannot rely on that behavior here.
 	// The reason is, we might need to run After/Commit stages of the interceptors before we
@@ -218,26 +215,5 @@ func (h handlerWithInterceptors) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	h.handler.ServeHTTP(rw, ir)
 	if !rw.written {
 		rw.NoContent()
-	}
-}
-
-// CommitPhase contains the configured interceptors that are associated with
-// handler and the incoming request.
-type CommitPhase struct {
-	Req            *IncomingRequest
-	Configs        map[string]Config
-	Interceps      map[string]Interceptor
-	IntercepsOrder []string
-}
-
-func (c *CommitPhase) commit(w *CommitResponseWriter, resp Response) {
-	for i := len(c.IntercepsOrder) - 1; i >= 0; i-- {
-		key := c.IntercepsOrder[i]
-		it := c.Interceps[key]
-		cfg := c.Configs[key]
-		it.Commit(w, c.Req, resp, cfg)
-		if w.rw.written {
-			return
-		}
 	}
 }

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -96,8 +96,7 @@ func NewServeMux(d Dispatcher, domains ...string) *ServeMux {
 	}
 }
 
-// AppliedInterceptor TODO
-type AppliedInterceptor struct {
+type appliedInterceptor struct {
 	it  Interceptor
 	cfg Config
 }
@@ -110,7 +109,7 @@ type AppliedInterceptor struct {
 // Interceptor was not installed will produce no effect. If multiple Configs are
 // passed for the same Interceptor, only the first one will take effect.
 func (m *ServeMux) Handle(pattern string, method string, h Handler, cfgs ...Config) {
-	var interceps []AppliedInterceptor
+	var interceps []appliedInterceptor
 	for _, it := range m.interceps {
 		var cfg Config
 		for _, c := range cfgs {
@@ -119,7 +118,7 @@ func (m *ServeMux) Handle(pattern string, method string, h Handler, cfgs ...Conf
 				break
 			}
 		}
-		interceps = append(interceps, AppliedInterceptor{it: it, cfg: cfg})
+		interceps = append(interceps, appliedInterceptor{it: it, cfg: cfg})
 	}
 	hi := handlerWithInterceptors{
 		handler:   h,
@@ -184,7 +183,7 @@ func (m methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // interceptors.
 type handlerWithInterceptors struct {
 	handler   Handler
-	interceps []AppliedInterceptor
+	interceps []appliedInterceptor
 	disp      Dispatcher
 }
 

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -174,7 +174,7 @@ func (p setHeaderInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.Inc
 	return safehttp.NotWritten()
 }
 
-func (p setHeaderInterceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (p setHeaderInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return safehttp.NotWritten()
 }
 
@@ -184,7 +184,7 @@ func (internalErrorInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.I
 	return w.WriteError(safehttp.StatusInternalServerError)
 }
 
-func (internalErrorInterceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (internalErrorInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	w.Header().Set("Foo", "this should not be reached")
 	return safehttp.NotWritten()
 }
@@ -201,7 +201,7 @@ func (p *claimHeaderInterceptor) Before(w *safehttp.ResponseWriter, r *safehttp.
 	return safehttp.NotWritten()
 }
 
-func (p *claimHeaderInterceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (p *claimHeaderInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return safehttp.NotWritten()
 }
 
@@ -216,7 +216,7 @@ func (panickingInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.Incom
 	panic("bad")
 }
 
-func (panickingInterceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (panickingInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return safehttp.NotWritten()
 }
 
@@ -226,7 +226,7 @@ func (committerInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.Incom
 	return safehttp.NotWritten()
 }
 
-func (committerInterceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (committerInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	w.Header().Set("foo", "bar")
 	return safehttp.NotWritten()
 }
@@ -238,7 +238,7 @@ func (commitErroringInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.
 	return safehttp.NotWritten()
 }
 
-func (commitErroringInterceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (commitErroringInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return w.WriteError(safehttp.StatusInternalServerError)
 }
 
@@ -331,7 +331,7 @@ func TestMuxInterceptors(t *testing.T) {
 			name: "Commit phase sets header",
 			mux: func() *safehttp.ServeMux {
 				mux := safehttp.NewServeMux(testDispatcher{}, "foo.com")
-				mux.Install("commiter", committerInterceptor{})
+				mux.Install(committerInterceptor{})
 
 				registeredHandler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 					return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
@@ -343,26 +343,6 @@ func TestMuxInterceptors(t *testing.T) {
 			wantStatus:  safehttp.StatusOK,
 			wantHeaders: map[string][]string{"Foo": {"bar"}},
 			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
-		},
-		{
-			name: "Commit error clears headers set by Before",
-			mux: func() *safehttp.ServeMux {
-				mux := safehttp.NewServeMux(testDispatcher{}, "foo.com")
-				mux.Install("test", commitErroringInterceptor{})
-
-				registeredHandler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-					return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
-				})
-				mux.Handle("/bar", safehttp.MethodGet, registeredHandler)
-
-				return mux
-			}(),
-			wantStatus: safehttp.StatusInternalServerError,
-			wantHeaders: map[string][]string{
-				"Content-Type":           {"text/plain; charset=utf-8"},
-				"X-Content-Type-Options": {"nosniff"},
-			},
-			wantBody: "Internal Server Error\n",
 		},
 	}
 
@@ -411,7 +391,7 @@ func (p setHeaderConfigInterceptor) Before(w *safehttp.ResponseWriter, _ *safeht
 	return safehttp.Result{}
 }
 
-func (p setHeaderConfigInterceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (p setHeaderConfigInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	value := "Fusili"
 	if c, ok := cfg.(setHeaderConfig); ok {
 		value = c.pastaValue
@@ -495,7 +475,7 @@ func (interceptorOne) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	return safehttp.NotWritten()
 }
 
-func (interceptorOne) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (interceptorOne) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	if w.Header().Get("Bar") != "1" {
 		w.WriteError(safehttp.StatusInternalServerError)
 	}
@@ -513,7 +493,7 @@ func (interceptorTwo) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	return safehttp.NotWritten()
 }
 
-func (interceptorTwo) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (interceptorTwo) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	if w.Header().Get("Bar") != "0" {
 		w.WriteError(safehttp.StatusInternalServerError)
 	}
@@ -531,7 +511,7 @@ func (interceptorThree) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingR
 	return safehttp.NotWritten()
 }
 
-func (interceptorThree) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (interceptorThree) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	if w.Header().Get("Foo") != "2" {
 		w.WriteError(safehttp.StatusInternalServerError)
 	}

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -383,20 +383,14 @@ func (setHeaderConfig) Match(i safehttp.Interceptor) bool {
 type setHeaderConfigInterceptor struct{}
 
 func (p setHeaderConfigInterceptor) Before(w *safehttp.ResponseWriter, _ *safehttp.IncomingRequest, cfg interface{}) safehttp.Result {
-	value := "Hawaii"
-	if c, ok := cfg.(setHeaderConfig); ok {
-		value = c.pizzaValue
-	}
-	w.Header().Set("Pizza", value)
+	c := cfg.(setHeaderConfig)
+	w.Header().Set("Pizza", c.pizzaValue)
 	return safehttp.Result{}
 }
 
 func (p setHeaderConfigInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	value := "Fusili"
-	if c, ok := cfg.(setHeaderConfig); ok {
-		value = c.pastaValue
-	}
-	w.Header().Set("Pasta", value)
+	c := cfg.(setHeaderConfig)
+	w.Header().Set("Pasta", c.pastaValue)
 	return safehttp.NotWritten()
 }
 
@@ -427,12 +421,12 @@ func TestMuxInterceptorConfigs(t *testing.T) {
 		{
 			name:       "SetHeaderInterceptor with mismatching config",
 			config:     noInterceptorConfig{},
-			wantStatus: safehttp.StatusOK,
+			wantStatus: safehttp.StatusInternalServerError,
 			wantHeaders: map[string][]string{
-				"Pizza": {"Hawaii"},
-				"Pasta": {"Fusili"},
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
 			},
-			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+			wantBody: "Internal Server Error\n",
 		},
 	}
 

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -207,6 +207,6 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	return safehttp.Result{}
 }
 
-func (it Interceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -206,3 +206,7 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 
 	return safehttp.Result{}
 }
+
+func (it Interceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+	return safehttp.Result{}
+}

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -164,6 +164,6 @@ func (p *Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest)
 	return safehttp.Result{}
 }
 
-func (p *Plugin) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (p *Plugin) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -163,3 +163,7 @@ func (p *Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest)
 
 	return safehttp.Result{}
 }
+
+func (p *Plugin) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+	return safehttp.Result{}
+}

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -93,6 +93,6 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	return safehttp.NotWritten()
 }
 
-func (it Interceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -92,3 +92,7 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	set([]string{value.String()})
 	return safehttp.NotWritten()
 }
+
+func (it Interceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+	return safehttp.Result{}
+}

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -34,6 +34,6 @@ func (Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cf
 	return safehttp.NotWritten()
 }
 
-func (Plugin) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (Plugin) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return safehttp.Result{}
 }

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -33,3 +33,7 @@ func (Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cf
 	setXXP([]string{"0"})
 	return safehttp.NotWritten()
 }
+
+func (Plugin) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+	return safehttp.Result{}
+}

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -131,3 +131,7 @@ func (i *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	r.SetContext(context.WithValue(r.Context(), tokenCtxKey{}, tok))
 	return safehttp.NotWritten()
 }
+
+func (i *Interceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+	return safehttp.Result{}
+}

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -132,6 +132,6 @@ func (i *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	return safehttp.NotWritten()
 }
 
-func (i *Interceptor) Commit(w *safehttp.CommitResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
+func (i *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	return safehttp.Result{}
 }

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -23,3 +23,9 @@ type Response interface{}
 type Template interface {
 	Execute(wr io.Writer, data interface{}) error
 }
+
+// DataTemplate TODO
+type DataTemplate struct {
+	Template *Template
+	Data     *interface{}
+}

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -24,8 +24,8 @@ type Template interface {
 	Execute(wr io.Writer, data interface{}) error
 }
 
-// DataTemplate TODO
-type DataTemplate struct {
+// TemplateResponse TODO
+type TemplateResponse struct {
 	Template *Template
 	Data     *interface{}
 }

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -24,11 +24,14 @@ type Template interface {
 	Execute(wr io.Writer, data interface{}) error
 }
 
-// TemplateResponse TODO
+// TemplateResponse bundles a Template with its data to be passed together to the
+// commit phase. This will be passed when the commit phase is initiated from
+// ResponseWriter.WriteTemplate.
 type TemplateResponse struct {
 	Template *Template
 	Data     *interface{}
 }
 
-// NoContentResponse TODO
+// NoContentResponse is sent to the commit phase when it's initiated from
+// ResponseWriter.NoContent.
 type NoContentResponse struct{}

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -29,3 +29,6 @@ type TemplateResponse struct {
 	Template *Template
 	Data     *interface{}
 }
+
+// NoContentResponse TODO
+type NoContentResponse struct{}

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -85,10 +85,10 @@ func (w *ResponseWriter) Write(resp Response) Result {
 	if w.written {
 		return Result{}
 	}
+	w.markWritten()
 	if err := w.d.Write(w.rw, resp); err != nil {
 		panic("error")
 	}
-	w.markWritten()
 	return Result{}
 }
 
@@ -101,15 +101,22 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	if w.written {
 		return Result{}
 	}
+	w.markWritten()
 	if err := w.d.ExecuteTemplate(w.rw, t, data); err != nil {
 		panic("error")
 	}
-	w.markWritten()
 	return Result{}
 }
 
 // NoContent responds with a 204 No Content response.
 func (w *ResponseWriter) NoContent() Result {
+	if w.written {
+		panic("ResponseWriter was already written to")
+	}
+	w.commitPhase(NoContentResponse{})
+	if w.written {
+		return Result{}
+	}
 	w.markWritten()
 	w.rw.WriteHeader(int(StatusNoContent))
 	return Result{}

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -35,6 +35,7 @@ type ResponseWriter struct {
 // http.ResponseWriter and a reference to the current IncomingRequest being served.
 // The IncomingRequest will only be used by the commit phase, which only runs when
 // the ServeMux is used, and can be passed as nil in tests.
+// TODO: remove the IncomingRequest parameter.
 func NewResponseWriter(d Dispatcher, rw http.ResponseWriter, req *IncomingRequest) *ResponseWriter {
 	header := newHeader(rw.Header())
 	return &ResponseWriter{

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -32,7 +32,9 @@ type ResponseWriter struct {
 }
 
 // NewResponseWriter creates a ResponseWriter from a safehttp.Dispatcher, an
-// http.ResponseWriter and a list of interceptors associated with a ServeMux.
+// http.ResponseWriter and a reference to the current IncomingRequest being served.
+// The IncomingRequest will only be used by the commit phase, which only runs when
+// the ServeMux is used, and can be passed as nil in tests.
 func NewResponseWriter(d Dispatcher, rw http.ResponseWriter, req *IncomingRequest) *ResponseWriter {
 	header := newHeader(rw.Header())
 	return &ResponseWriter{
@@ -103,7 +105,7 @@ func (w *ResponseWriter) NoContent() Result {
 }
 
 // WriteError writes an error response (400-599) according to the provided status
-// code. Any headers previously set will be removed.
+// code.
 func (w *ResponseWriter) WriteError(code StatusCode) Result {
 	w.markWritten()
 	http.Error(w.rw, http.StatusText(int(code)), int(code))

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -27,11 +27,7 @@ import (
 
 func TestResponseWriterSetCookie(t *testing.T) {
 	rr := newResponseRecorder(&strings.Builder{})
-<<<<<<< HEAD
-	rw := safehttp.NewResponseWriter(testDispatcher{}, rr)
-=======
 	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil, nil)
->>>>>>> Added the Commit phase.
 
 	c := safehttp.NewCookie("foo", "bar")
 	err := rw.SetCookie(c)

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -27,7 +27,11 @@ import (
 
 func TestResponseWriterSetCookie(t *testing.T) {
 	rr := newResponseRecorder(&strings.Builder{})
+<<<<<<< HEAD
 	rw := safehttp.NewResponseWriter(testDispatcher{}, rr)
+=======
+	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil, nil)
+>>>>>>> Added the Commit phase.
 
 	c := safehttp.NewCookie("foo", "bar")
 	err := rw.SetCookie(c)
@@ -45,7 +49,7 @@ func TestResponseWriterSetCookie(t *testing.T) {
 
 func TestResponseWriterSetInvalidCookie(t *testing.T) {
 	rr := newResponseRecorder(&strings.Builder{})
-	rw := safehttp.NewResponseWriter(testDispatcher{}, rr)
+	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil, nil)
 
 	c := safehttp.NewCookie("f=oo", "bar")
 	err := rw.SetCookie(c)
@@ -99,7 +103,7 @@ func TestResponseWriterWriteTwicePanic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := safehttp.NewResponseWriter(testDispatcher{}, newResponseRecorder(&strings.Builder{}))
+			w := safehttp.NewResponseWriter(testDispatcher{}, newResponseRecorder(&strings.Builder{}), nil, nil)
 			defer func() {
 				if r := recover(); r == nil {
 					t.Errorf("tt.write(w) expected panic")

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestResponseWriterSetCookie(t *testing.T) {
 	rr := newResponseRecorder(&strings.Builder{})
-	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil, nil)
+	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil)
 
 	c := safehttp.NewCookie("foo", "bar")
 	err := rw.SetCookie(c)
@@ -45,7 +45,7 @@ func TestResponseWriterSetCookie(t *testing.T) {
 
 func TestResponseWriterSetInvalidCookie(t *testing.T) {
 	rr := newResponseRecorder(&strings.Builder{})
-	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil, nil)
+	rw := safehttp.NewResponseWriter(testDispatcher{}, rr, nil)
 
 	c := safehttp.NewCookie("f=oo", "bar")
 	err := rw.SetCookie(c)
@@ -99,7 +99,7 @@ func TestResponseWriterWriteTwicePanic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := safehttp.NewResponseWriter(testDispatcher{}, newResponseRecorder(&strings.Builder{}), nil, nil)
+			w := safehttp.NewResponseWriter(testDispatcher{}, newResponseRecorder(&strings.Builder{}), nil)
 			defer func() {
 				if r := recover(); r == nil {
 					t.Errorf("tt.write(w) expected panic")

--- a/safehttp/safehttptest/recorder.go
+++ b/safehttp/safehttptest/recorder.go
@@ -61,7 +61,7 @@ func NewResponseRecorder() *ResponseRecorder {
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
-		ResponseWriter: safehttp.NewResponseWriter(testDispatcher{}, rw, nil, nil),
+		ResponseWriter: safehttp.NewResponseWriter(testDispatcher{}, rw, nil),
 	}
 }
 
@@ -73,7 +73,7 @@ func NewResponseRecorderFromDispatcher(d safehttp.Dispatcher) *ResponseRecorder 
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
-		ResponseWriter: safehttp.NewResponseWriter(d, rw, nil, nil),
+		ResponseWriter: safehttp.NewResponseWriter(d, rw, nil),
 	}
 }
 

--- a/safehttp/safehttptest/recorder.go
+++ b/safehttp/safehttptest/recorder.go
@@ -61,7 +61,7 @@ func NewResponseRecorder() *ResponseRecorder {
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
-		ResponseWriter: safehttp.NewResponseWriter(testDispatcher{}, rw),
+		ResponseWriter: safehttp.NewResponseWriter(testDispatcher{}, rw, nil, nil),
 	}
 }
 
@@ -73,7 +73,7 @@ func NewResponseRecorderFromDispatcher(d safehttp.Dispatcher) *ResponseRecorder 
 	return &ResponseRecorder{
 		rw:             rw,
 		b:              &b,
-		ResponseWriter: safehttp.NewResponseWriter(d, rw),
+		ResponseWriter: safehttp.NewResponseWriter(d, rw, nil, nil),
 	}
 }
 


### PR DESCRIPTION
Fixes #145

Added the `Commit` phase to the Interceptor interface. This will be called by the `safehttp.ResponseWriter` before a response is written to the underlying `http.ResponseWriter`, for all interceptors that were installed on the handler. If a response  is written in any of the `Commit` phases,  then the `Commit` phases of the remaining interceptor won't execute.

As the `Commit` phase takes a `safehttp.Response` as argument (e.g. for injecting nonces), we also created a `safehttp.TemplateResponse` interface that encapsulates a safe template and the data that is applied to it.

Co-authored-by: Mihali Mara <maramihali@google.com>
