### PR TITLE
Extended the Dispatcher interface to support writing JSON and retrieving the response Content-Type and created a safe default Dispatcher.

### DIFF
--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -56,9 +56,9 @@ func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
 // If the provided response is not valid JSON or writing the response fails, the
 // method will return an error.
 func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) error {
-	// TODO: XSSI protection needs to be added as this is not a safe response
-	// type yet
-	return json.NewEncoder(rw).Encode(resp.Data)
+	e := json.NewEncoder(rw)
+	e.Encode(")]}',")
+	return e.Encode(resp.Data)
 }
 
 // ExecuteTemplate applies a parsed template to the provided data object if the

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -56,9 +56,8 @@ func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
 // If the provided response is not valid JSON or writing the response fails, the
 // method will return an error.
 func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) error {
-	e := json.NewEncoder(rw)
-	e.Encode(")]}',")
-	return e.Encode(resp.Data)
+	io.WriteString(rw, ")]}',\n")
+	return json.NewEncoder(rw).Encode(resp.Data)
 }
 
 // ExecuteTemplate applies a parsed template to the provided data object if the

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -56,7 +56,7 @@ func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
 // If the provided response is not valid JSON or writing the response fails, the
 // method will return an error.
 func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) error {
-	io.WriteString(rw, ")]}',\n")
+	io.WriteString(rw, ")]}',\n") // Break parsing of JavaScript in order to prevent XSSI.
 	return json.NewEncoder(rw).Encode(resp.Data)
 }
 

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/google/safehtml"
+	"github.com/google/safehtml/template"
+	"net/http"
+)
+
+// DefaultDispatcher is responsible of writing the body of a response to an
+// Response Writer if it's of a safe type.
+type DefaultDispatcher struct{}
+
+// ContentType returns the Content-Type of a safe respons if it's of a safe-type
+// and a non-nil error otherwise.
+func (DefaultDispatcher) ContentType(resp Response) (string, error) {
+	switch resp.(type) {
+	case safehtml.HTML, *template.Template:
+		return "text/html; charset=utf-8", nil
+	case JSONResponse:
+		return "application/json; charset=utf-8", nil
+	default:
+		return "", errors.New("not a safe response")
+	}
+}
+
+// Write writes the response to the Response Writer if it's safe HTML. It
+// returns a non-nil error if the response is not safe HTML or if writing the
+// response fails.
+func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
+	x, ok := resp.(safehtml.HTML)
+	if !ok {
+		return errors.New("not a safe response type")
+	}
+	_, err := rw.Write([]byte(x.String()))
+	return err
+
+}
+
+// WriteJSON serialises and writes a JSON to the Response Writer. If the
+// provided response is not valid JSON or writing the response fails, the method
+// will return an error.
+func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) error {
+	obj, err := json.Marshal(resp.Data)
+	if err != nil {
+		return errors.New("invalid json")
+	}
+	_, err = rw.Write(obj)
+	return err
+}
+
+// ExecuteTemplate applies a parsed template to the provided data object if the
+// template is a safe HTML template, writing the output to the ResponseWriter.
+//
+// If an error occurs executing the template or writing its output,
+// execution stops, but partial results may already have been written to
+// the Response Writer.
+func (DefaultDispatcher) ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}) error {
+	x, ok := t.(*template.Template)
+	if !ok {
+		return errors.New("not a safe response type")
+	}
+	err := x.Execute(rw, data)
+	return err
+}

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"github.com/google/safehtml"
 	"github.com/google/safehtml/template"
+	"io"
 	"net/http"
 )
 
-// DefaultDispatcher is responsible of writing the body of a response to an
-// Response Writer if it's of a safe type.
+// DefaultDispatcher is responsible for writing safe responses.
 type DefaultDispatcher struct{}
 
 // ContentType returns the Content-Type of a safe response if it's of a
@@ -47,14 +47,14 @@ func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
 	if !ok {
 		return fmt.Errorf("%T is not a safe response type and it cannot be written", resp)
 	}
-	_, err := rw.Write([]byte(x.String()))
+	_, err := io.WriteString(rw, x.String())
 	return err
 
 }
 
-// WriteJSON serialises and writes a JSON to the Response Writer. If the
-// provided response is not valid JSON or writing the response fails, the method
-// will return an error.
+// WriteJSON serialises and writes a JSON to the underlying http.ResponseWriter.
+// If the provided response is not valid JSON or writing the response fails, the
+// method will return an error.
 func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) error {
 	// TODO: XSSI protection needs to be added as this is not a safe response
 	// type yet
@@ -62,7 +62,8 @@ func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) er
 }
 
 // ExecuteTemplate applies a parsed template to the provided data object if the
-// template is a safe HTML template, writing the output to the ResponseWriter.
+// template is a safe HTML template, writing the output to the  http.
+// ResponseWriter.
 //
 // If an error occurs executing the template or writing its output,
 // execution stops, but partial results may already have been written to

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -58,7 +58,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				}{Field: "myField"}
 				return d.WriteJSON(w, safehttp.JSONResponse{Data: data})
 			},
-			wantBody: "{\"field\":\"myField\"}\n",
+			wantBody: ")]}',\n{\"field\":\"myField\"}\n",
 		},
 	}
 	for _, tt := range tests {

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -83,6 +83,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 	tests := []struct {
 		name  string
 		write func(w http.ResponseWriter) error
+		want  string
 	}{
 		{
 			name: "Unsafe HTML Response",
@@ -90,6 +91,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 				d := &safehttp.DefaultDispatcher{}
 				return d.Write(w, "<h1>Hello World!</h1>")
 			},
+			want: "",
 		},
 		{
 			name: "Unsafe Template Response",
@@ -97,6 +99,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 				d := &safehttp.DefaultDispatcher{}
 				return d.ExecuteTemplate(w, template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 			},
+			want: "",
 		},
 		{
 			name: "Invalid JSON Response",
@@ -104,6 +107,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 				d := &safehttp.DefaultDispatcher{}
 				return d.WriteJSON(w, safehttp.JSONResponse{Data: math.Inf(1)})
 			},
+			want: ")]}',\n",
 		},
 	}
 	for _, tt := range tests {
@@ -115,7 +119,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 				t.Error("tt.write(rw): got nil, want error")
 			}
 
-			if want, got := "", b.String(); want != got {
+			if want, got := tt.want, b.String(); want != got {
 				t.Errorf("response body: got %q, want %q", got, want)
 			}
 		})

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -58,7 +58,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				}{Field: "myField"}
 				return d.WriteJSON(w, safehttp.JSONResponse{Data: data})
 			},
-			wantBody: `{"field":"myField"}`,
+			wantBody: "{\"field\":\"myField\"}\n",
 		},
 	}
 	for _, tt := range tests {
@@ -91,7 +91,6 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 				return d.Write(w, "<h1>Hello World!</h1>")
 			},
 		},
-
 		{
 			name: "Unsafe Template Response",
 			write: func(w http.ResponseWriter) error {

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -1,0 +1,124 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp_test
+
+import (
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+	safetemplate "github.com/google/safehtml/template"
+	"html/template"
+	"math"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestDefaultDispatcherValidResponse(t *testing.T) {
+	tests := []struct {
+		name        string
+		write       func(w http.ResponseWriter) error
+		wantStatus  safehttp.StatusCode
+		wantHeaders map[string][]string
+		wantBody    string
+	}{
+		{
+			name: "Safe HTML Response",
+			write: func(w http.ResponseWriter) error {
+				d := &safehttp.DefaultDispatcher{}
+				return d.Write(w, safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+			},
+			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+		},
+		{
+			name: "Safe HTML Template Response",
+			write: func(w http.ResponseWriter) error {
+				d := &safehttp.DefaultDispatcher{}
+				return d.ExecuteTemplate(w, safetemplate.Must(safetemplate.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+			},
+			wantBody: "<h1>This is an actual heading, though.</h1>",
+		},
+		{
+			name: "Valid JSON Response",
+			write: func(w http.ResponseWriter) error {
+				d := &safehttp.DefaultDispatcher{}
+				data := struct {
+					Field string `json:"field"`
+				}{Field: "myField"}
+				return d.WriteJSON(w, safehttp.JSONResponse{Data: data})
+			},
+			wantBody: `{"field":"myField"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &strings.Builder{}
+			rw := newResponseRecorder(b)
+
+			err := tt.write(rw)
+
+			if err != nil {
+				t.Errorf("tt.write(rw): got error %v, want nil", err)
+			}
+
+			if gotBody := b.String(); tt.wantBody != gotBody {
+				t.Errorf("response body: got %q, want %q", gotBody, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestDefaultDispatcherInvalidResponse(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(w http.ResponseWriter) error
+	}{
+		{
+			name: "Unsafe HTML Response",
+			write: func(w http.ResponseWriter) error {
+				d := &safehttp.DefaultDispatcher{}
+				return d.Write(w, "<h1>Hello World!</h1>")
+			},
+		},
+
+		{
+			name: "Unsafe Template Response",
+			write: func(w http.ResponseWriter) error {
+				d := &safehttp.DefaultDispatcher{}
+				return d.ExecuteTemplate(w, template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+			},
+		},
+		{
+			name: "Invalid JSON Response",
+			write: func(w http.ResponseWriter) error {
+				d := &safehttp.DefaultDispatcher{}
+				return d.WriteJSON(w, safehttp.JSONResponse{Data: math.Inf(1)})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &strings.Builder{}
+			rw := newResponseRecorder(b)
+
+			if err := tt.write(rw); err == nil {
+				t.Error("tt.write(rw): got nil, want error")
+			}
+
+			if want, got := "", b.String(); want != got {
+				t.Errorf("response body: got %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -80,8 +80,13 @@ type ServeMux struct {
 	interceps []Interceptor
 }
 
-// NewServeMux allocates and returns a new ServeMux
+// NewServeMux allocates and returns a new ServeMux. Passing a nil Dispatcher
+// will cause the method to panic.
 func NewServeMux(d Dispatcher, domains ...string) *ServeMux {
+	if d == nil {
+		panic("dispatcher cannot be nil")
+	}
+
 	// TODO(@mattiasgrenfeldt, @mihalimara22): make domains a variadic of string **literals**.
 	dm := map[string]bool{}
 	for _, host := range domains {

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -84,7 +84,7 @@ type ServeMux struct {
 // will cause the method to panic.
 func NewServeMux(d Dispatcher, domains ...string) *ServeMux {
 	if d == nil {
-		panic("dispatcher cannot be nil")
+		d = DefaultDispatcher{}
 	}
 
 	// TODO(@mattiasgrenfeldt, @mihalimara22): make domains a variadic of string **literals**.

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -38,8 +38,10 @@ func TestMuxOneHandlerOneRequest(t *testing.T) {
 			name:       "Valid Request",
 			req:        httptest.NewRequest(safehttp.MethodGet, "http://foo.com/", nil),
 			wantStatus: safehttp.StatusOK,
-			wantHeader: map[string][]string{},
-			wantBody:   "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+			wantHeader: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+			},
+			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 		{
 			name:       "Invalid Host",
@@ -107,9 +109,11 @@ func TestMuxServeTwoHandlers(t *testing.T) {
 			hf: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 				return w.Write(safehtml.HTMLEscaped("<h1>Hello World! GET</h1>"))
 			}),
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{},
-			wantBody:    "&lt;h1&gt;Hello World! GET&lt;/h1&gt;",
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+			},
+			wantBody: "&lt;h1&gt;Hello World! GET&lt;/h1&gt;",
 		},
 		{
 			name: "POST Handler",
@@ -117,9 +121,11 @@ func TestMuxServeTwoHandlers(t *testing.T) {
 			hf: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 				return w.Write(safehtml.HTMLEscaped("<h1>Hello World! POST</h1>"))
 			}),
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{},
-			wantBody:    "&lt;h1&gt;Hello World! POST&lt;/h1&gt;",
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+			},
+			wantBody: "&lt;h1&gt;Hello World! POST&lt;/h1&gt;",
 		},
 	}
 
@@ -265,9 +271,12 @@ func TestMuxInterceptors(t *testing.T) {
 				mux.Handle("/bar", safehttp.MethodGet, registeredHandler)
 				return mux
 			}(),
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{"Foo": {"bar"}},
-			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+				"Foo":          {"bar"},
+			},
+			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 		{
 			name: "Install Interrupting Interceptor",
@@ -303,9 +312,12 @@ func TestMuxInterceptors(t *testing.T) {
 
 				return mux
 			}(),
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{"Foo": {"bar"}},
-			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+				"Foo":          {"bar"},
+			},
+			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 		{
 			name: "Panicking interceptor recovered by ServeMux",
@@ -419,18 +431,23 @@ func TestMuxInterceptorConfigs(t *testing.T) {
 		wantBody    string
 	}{
 		{
-			name:        "SetHeaderInterceptor with config",
-			config:      setHeaderConfig{name: "Foo", value: "Bar"},
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{"Foo": {"Bar"}, "Commit-Foo": {"Bar"}},
-			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+			name:       "SetHeaderInterceptor with config",
+			config:     setHeaderConfig{name: "Foo", value: "Bar"},
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+				"Foo":          {"Bar"}},
+			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 		{
-			name:        "SetHeaderInterceptor with mismatching config",
-			config:      noInterceptorConfig{},
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{"Pizza": {"Hawaii"}, "Commit-Pizza": {"Hawaii"}},
-			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+			name:       "SetHeaderInterceptor with mismatching config",
+			config:     noInterceptorConfig{},
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+				"Pizza":        {"Hawaii"},
+			},
+			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 	}
 
@@ -539,12 +556,13 @@ func TestMuxDeterministicInterceptorOrder(t *testing.T) {
 		t.Errorf("rw.status: got %v want %v", rw.status, want)
 	}
 	wantHeaders := map[string][]string{
-		"Dessert":   {"tiramisu"},
-		"Pizza":     {"diavola"},
-		"Spaghetti": {"bolognese"},
-		"Commit1":   {"a"},
-		"Commit2":   {"b"},
-		"Commit3":   {"c"},
+		"Dessert":      {"tiramisu"},
+		"Pizza":        {"diavola"},
+		"Spaghetti":    {"bolognese"},
+		"Commit1":      {"a"},
+		"Commit2":      {"b"},
+		"Commit3":      {"c"},
+		"Content-Type": {"text/html; charset=utf-8"},
 	}
 	if diff := cmp.Diff(wantHeaders, map[string][]string(rw.header)); diff != "" {
 		t.Errorf("rw.header mismatch (-want +got):\n%s", diff)
@@ -576,4 +594,13 @@ func TestMuxHandlerReturnsNotWritten(t *testing.T) {
 	if got := b.String(); got != "" {
 		t.Errorf(`response body got: %q want: ""`, got)
 	}
+}
+
+func TestMuxNilDispatcher(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf(`mux.NewServeMux(nil): expected panic`)
+		}
+	}()
+	_ = safehttp.NewServeMux(nil)
 }

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package safehttp
+package safehttp_test
 
 import (
 	"context"
@@ -352,9 +352,12 @@ func TestMuxInterceptors(t *testing.T) {
 
 				return mux
 			}(),
-			wantStatus:  safehttp.StatusOK,
-			wantHeaders: map[string][]string{"Foo": {"bar"}},
-			wantBody:    "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Foo":          {"bar"},
+				"Content-Type": {"text/html; charset=utf-8"},
+			},
+			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 	}
 
@@ -436,7 +439,9 @@ func TestMuxInterceptorConfigs(t *testing.T) {
 			wantStatus: safehttp.StatusOK,
 			wantHeaders: map[string][]string{
 				"Content-Type": {"text/html; charset=utf-8"},
-				"Foo":          {"Bar"}},
+				"Commit-Foo":   {"Bar"},
+				"Foo":          {"Bar"},
+			},
 			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
 		{
@@ -446,6 +451,7 @@ func TestMuxInterceptorConfigs(t *testing.T) {
 			wantHeaders: map[string][]string{
 				"Content-Type": {"text/html; charset=utf-8"},
 				"Pizza":        {"Hawaii"},
+				"Commit-Pizza": {"Hawaii"},
 			},
 			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
 		},
@@ -594,9 +600,4 @@ func TestMuxHandlerReturnsNotWritten(t *testing.T) {
 	if got := b.String(); got != "" {
 		t.Errorf(`response body got: %q want: ""`, got)
 	}
-}
-
-func TestMuxNilDispatcher(t *testing.T) {
-	mux := safehttp.NewServeMux(nil)
-	d, ok := mux.dis
 }

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package safehttp_test
+package safehttp
 
 import (
 	"context"
@@ -597,10 +597,6 @@ func TestMuxHandlerReturnsNotWritten(t *testing.T) {
 }
 
 func TestMuxNilDispatcher(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf(`mux.NewServeMux(nil): expected panic`)
-		}
-	}()
-	safehttp.NewServeMux(nil)
+	mux := safehttp.NewServeMux(nil)
+	d, ok := mux.dis
 }

--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -602,5 +602,5 @@ func TestMuxNilDispatcher(t *testing.T) {
 			t.Errorf(`mux.NewServeMux(nil): expected panic`)
 		}
 	}()
-	_ = safehttp.NewServeMux(nil)
+	safehttp.NewServeMux(nil)
 }

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -21,6 +21,12 @@ import "io"
 // supported by the Dispatcher.
 type Response interface{}
 
+// JSONResponse encapsulate a JSON response that will be passed as an argument
+// to ResponseWriter.WriteJSON>
+type JSONResponse struct {
+	Data interface{}
+}
+
 // Template implements a template.
 type Template interface {
 	// Execute applies data to the template and then writes the result to

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -21,8 +21,8 @@ import "io"
 // supported by the Dispatcher.
 type Response interface{}
 
-// JSONResponse encapsulate a JSON response that will be passed as an argument
-// to ResponseWriter.WriteJSON>
+// JSONResponse should encapsulate a valid JSON object that will be serialised
+// and written to the http.ResponseWriter using a JSON encoder.
 type JSONResponse struct {
 	Data interface{}
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -240,11 +240,11 @@ type Dispatcher interface {
 	// Content-Type returns the Content-Type of the provided response if it is
 	// of a type supported by the Dispatcher and should return an error
 	// otherwise.
-
+	//
 	// Sending a response to the http.ResponseWriter without properly setting
-	// the is bug-prone and could introduce vulnerabilities. Therefore, this
+	// CT is error-prone and could introduce vulnerabilities. Therefore, this
 	// method should be used to set the Content-Type header before calling any
 	// of the writing methods in the Dispatcher. Writing should not proceed
-	// ContentType returns an error.
+	// if ContentType returns an error.
 	ContentType(resp Response) (string, error)
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -66,7 +66,13 @@ func NotWritten() Result {
 	return Result{}
 }
 
-// Write TODO
+// Write dispatches the response to the Dispatcher, setting the Content-Type to
+// text/html; charset=utf-8 and response status to 200 OK if resp is a safe
+// response. The Dispatcher will then write the response to the underlying
+// Response Writer.
+//
+// TODO: replace panics with proper error handling when getting the response
+// Content-Type or writing the response fails.
 func (w *ResponseWriter) Write(resp Response) Result {
 	if w.written {
 		panic("ResponseWriter was already written to")
@@ -76,13 +82,49 @@ func (w *ResponseWriter) Write(resp Response) Result {
 		return Result{}
 	}
 	w.markWritten()
-	if err := w.d.Write(w.rw, resp); err != nil {
-		panic("error")
+	ct, err := w.d.ContentType(resp)
+	if err != nil {
+		panic(err)
 	}
+	w.rw.WriteHeader(int(StatusOK))
+	w.rw.Header().Set("Content-Type", ct)
+	if err := w.d.Write(w.rw, resp); err != nil {
+		panic(err)
+	}
+	w.markWritten()
 	return Result{}
 }
 
-// WriteTemplate TODO
+// WriteJSON encapsulates data into a JSON response and dispatches it to the
+// Dispatcher, to be serialised and written to the ResponseWriter. It will also
+// set the Content-Type to application/json; charset=utf-8 and the response
+// status to 200 OK.
+//
+// TODO: replace panics with proper error handling when getting the response
+// Content-Type or writing the response fails.
+func (w *ResponseWriter) WriteJSON(data interface{}) Result {
+	resp := JSONResponse{Data: data}
+	ct, err := w.d.ContentType(resp)
+	if err != nil {
+		panic(err)
+	}
+	w.rw.WriteHeader(int(StatusOK))
+	w.rw.Header().Set("Content-Type", ct)
+	if err := w.d.WriteJSON(w.rw, resp); err != nil {
+		panic(err)
+	}
+	w.markWritten()
+	return Result{}
+}
+
+// WriteTemplate dispatches a parsed template and a data object to the
+// Dispatcher to be executed and written to the underlying Response Writer, in
+// case the template is a safe HTML template. If t is a safe HTML Template, the
+// Content-Type will also be set to text/html; charset=utf-8 and the response
+// status to 200 OK.
+//
+// TODO: replace panics with proper error handling when getting the response
+// Content-Type or writing the response fails.
 func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	if w.written {
 		panic("ResponseWriter was already written to")
@@ -91,10 +133,16 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	if w.written {
 		return Result{}
 	}
-	w.markWritten()
-	if err := w.d.ExecuteTemplate(w.rw, t, data); err != nil {
-		panic("error")
+	ct, err := w.d.ContentType(t)
+	if err != nil {
+		panic(err)
 	}
+	w.rw.WriteHeader(int(StatusOK))
+	w.rw.Header().Set("Content-Type", ct)
+	if err := w.d.ExecuteTemplate(w.rw, t, data); err != nil {
+		panic(err)
+	}
+	w.markWritten()
 	return Result{}
 }
 
@@ -162,5 +210,7 @@ func (w *ResponseWriter) SetCookie(c *Cookie) error {
 // Dispatcher TODO
 type Dispatcher interface {
 	Write(rw http.ResponseWriter, resp Response) error
+	WriteJSON(rw http.ResponseWriter, resp JSONResponse) error
 	ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}) error
+	ContentType(resp Response) (string, error)
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -139,6 +139,7 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	if w.written {
 		return Result{}
 	}
+	w.markWritten()
 	ct, err := w.d.ContentType(t)
 	if err != nil {
 		panic(err)

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -207,10 +207,39 @@ func (w *ResponseWriter) SetCookie(c *Cookie) error {
 	return w.header.addCookie(c)
 }
 
-// Dispatcher TODO
+// Dispatcher is responsible for writing a response received from the
+// ResponseWriter to the underlying http.ResponseWriter.
+//
+// The implementation of a custom Dispatcher should be thoroughly reviewed by
+// the security team to avoid introducing vulnerabilities. Moreover/
 type Dispatcher interface {
+	// Write writes a Response to the http.ResponseWriter.
+	//
+	// It should return an error if the writing operation fails or if the
+	// provided Response should not be written to the http.ResponseWriter
 	Write(rw http.ResponseWriter, resp Response) error
+
+	// WriteJSON serialises and writes a JSON object to the http.ResponseWriter.
+	//
+	// This should return an error if the provided response is not a valid
+	// JSONResponse  or if writing the object to the http.ResponseWriter fails.
 	WriteJSON(rw http.ResponseWriter, resp JSONResponse) error
+
+	// ExecuteTemplate applies a parsed template to the provided data object
+	// and writes the output to the http.ResponseWriter.
+	//
+	// This should return an error if the provided Template response is not a
+	// valid template or if an error occurs executing or writing the template.
 	ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}) error
+
+	// Content-Type returns the Content-Type of the provided response if it is
+	// of a type supported by the Dispatcher and should return an error
+	// otherwise.
+
+	// Sending a response to the http.ResponseWriter without properly setting
+	// the is bug-prone and could introduce vulnerabilities. Therefore, this
+	// method should be used to set the Content-Type header before calling any
+	// of the writing methods in the Dispatcher. Writing should not proceed
+	// ContentType returns an error.
 	ContentType(resp Response) (string, error)
 }

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -66,10 +66,9 @@ func NotWritten() Result {
 	return Result{}
 }
 
-// Write dispatches the response to the Dispatcher, setting the Content-Type to
-// text/html; charset=utf-8 and response status to 200 OK if resp is a safe
-// response. The Dispatcher will then write the response to the underlying
-// Response Writer.
+// Write dispatches the response to the Dispatcher, setting the Content-Type and
+// response status if the provided response is a safe response. The
+// Dispatcher will then write the response to the underlying Response Writer.
 //
 // TODO: replace panics with proper error handling when getting the response
 // Content-Type or writing the response fails.
@@ -96,8 +95,7 @@ func (w *ResponseWriter) Write(resp Response) Result {
 
 // WriteJSON encapsulates data into a JSON response and dispatches it to the
 // Dispatcher, to be serialised and written to the ResponseWriter. It will also
-// set the Content-Type to application/json; charset=utf-8 and the response
-// status to 200 OK.
+// set the Content-Type and response status will be set.
 //
 // TODO: replace panics with proper error handling when getting the response
 // Content-Type or writing the response fails.
@@ -125,9 +123,8 @@ func (w *ResponseWriter) WriteJSON(data interface{}) Result {
 
 // WriteTemplate dispatches a parsed template and a data object to the
 // Dispatcher to be executed and written to the underlying Response Writer, in
-// case the template is a safe HTML template. If t is a safe HTML Template, the
-// Content-Type will also be set to text/html; charset=utf-8 and the response
-// status to 200 OK.
+// case the template is a safe HTML template. If it is a safe HTML Template, the
+// Content-Type  and response status will also be set.
 //
 // TODO: replace panics with proper error handling when getting the response
 // Content-Type or writing the response fails.
@@ -217,7 +214,7 @@ func (w *ResponseWriter) SetCookie(c *Cookie) error {
 // ResponseWriter to the underlying http.ResponseWriter.
 //
 // The implementation of a custom Dispatcher should be thoroughly reviewed by
-// the security team to avoid introducing vulnerabilities. Moreover/
+// the security team to avoid introducing vulnerabilities.
 type Dispatcher interface {
 	// Write writes a Response to the http.ResponseWriter.
 	//

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -15,7 +15,6 @@
 package safehttp_test
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 	"text/template"
@@ -70,13 +69,9 @@ func TestResponseWriterWriteTwicePanic(t *testing.T) {
 		{
 			name: "Call WriteJSON twice",
 			write: func(w *safehttp.ResponseWriter) {
-				data := struct{ Field string }{Field: "myField"}
-				jsonObj, err := json.Marshal(data)
-				if err != nil {
-					t.Fatalf("invalid json object")
-				}
-				w.WriteJSON(jsonObj)
-				w.WriteJSON(jsonObj)
+				obj := struct{ Field string }{Field: "myField"}
+				w.WriteJSON(obj)
+				w.WriteJSON(obj)
 			},
 		},
 		{

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -15,6 +15,7 @@
 package safehttp_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"text/template"
@@ -64,6 +65,18 @@ func TestResponseWriterWriteTwicePanic(t *testing.T) {
 			write: func(w *safehttp.ResponseWriter) {
 				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
 				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
+			},
+		},
+		{
+			name: "Call WriteJSON twice",
+			write: func(w *safehttp.ResponseWriter) {
+				data := struct{ Field string }{Field: "myField"}
+				jsonObj, err := json.Marshal(data)
+				if err != nil {
+					t.Fatalf("invalid json object")
+				}
+				w.WriteJSON(jsonObj)
+				w.WriteJSON(jsonObj)
 			},
 		},
 		{

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -75,6 +75,14 @@ func TestResponseWriterWriteTwicePanic(t *testing.T) {
 			},
 		},
 		{
+			name: "Call Write then WriteJSON",
+			write: func(w *safehttp.ResponseWriter) {
+				obj := struct{ Field string }{Field: "myField"}
+				w.Write(obj)
+				w.WriteJSON(obj)
+			},
+		},
+		{
 			name: "Call WriteTemplate twice",
 			write: func(w *safehttp.ResponseWriter) {
 				w.WriteTemplate(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")

--- a/tests/integration/hsts/hsts_test.go
+++ b/tests/integration/hsts/hsts_test.go
@@ -15,6 +15,9 @@
 package hsts_test
 
 import (
+	"encoding/json"
+	"errors"
+	"github.com/google/safehtml/template"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -29,6 +32,17 @@ import (
 
 type dispatcher struct{}
 
+func (dispatcher) ContentType(resp safehttp.Response) (string, error) {
+	switch resp.(type) {
+	case safehtml.HTML, *template.Template:
+		return "text/html; charset=utf-8", nil
+	case safehttp.JSONResponse:
+		return "application/json; charset=utf-8", nil
+	default:
+		return "", errors.New("not a safe response")
+	}
+}
+
 func (dispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
@@ -37,6 +51,15 @@ func (dispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
 	default:
 		panic("not a safe response type")
 	}
+}
+
+func (dispatcher) WriteJSON(rw http.ResponseWriter, resp safehttp.JSONResponse) error {
+	obj, err := json.Marshal(resp.Data)
+	if err != nil {
+		panic("invalid json")
+	}
+	_, err = rw.Write(obj)
+	return err
 }
 
 func (dispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {
@@ -86,6 +109,7 @@ func TestHSTSServeMuxInstall(t *testing.T) {
 	}
 
 	wantHeaders := map[string][]string{
+		"Content-Type":              {"text/html; charset=utf-8"},
 		"Strict-Transport-Security": {"max-age=63072000; includeSubDomains"},
 	}
 	if diff := cmp.Diff(wantHeaders, map[string][]string(rr.header)); diff != "" {

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -146,7 +146,7 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 			wantHeaders: map[string][]string{
 				"Content-Type": {"application/json; charset=utf-8"},
 			},
-			wantBody: `{"field":"myField"}`,
+			wantBody: "{\"field\":\"myField\"}\n",
 		},
 		{
 			name: "Invalid JSON Response",
@@ -184,7 +184,7 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 			}
 
 			if gotBody := b.String(); tt.wantBody != gotBody {
-				t.Errorf("response body: got %q, want %q", gotBody, tt.wantBody)
+				t.Errorf("response body: got %v, want %v", gotBody, tt.wantBody)
 			}
 		})
 	}

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -1,0 +1,191 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safemux_test
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+	safetemplate "github.com/google/safehtml/template"
+	"html/template"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type responseRecorder struct {
+	headers http.Header
+	writer  io.Writer
+	status  safehttp.StatusCode
+}
+
+func newResponseRecorder(w io.Writer) *responseRecorder {
+	return &responseRecorder{headers: http.Header{}, writer: w}
+}
+
+func (r *responseRecorder) Header() http.Header {
+	return r.headers
+}
+
+func (r *responseRecorder) WriteHeader(statusCode int) {
+	r.status = safehttp.StatusCode(statusCode)
+}
+
+func (r *responseRecorder) Write(data []byte) (int, error) {
+	return r.writer.Write(data)
+}
+
+func TestMuxDefaultDispatcher(t *testing.T) {
+	tests := []struct {
+		name        string
+		mux         *safehttp.ServeMux
+		wantStatus  safehttp.StatusCode
+		wantHeaders map[string][]string
+		wantBody    string
+	}{
+		{
+			name: "Safe HTML Response",
+			mux: func() *safehttp.ServeMux {
+				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+
+				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+					return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+				})
+				mux.Handle("/pizza", safehttp.MethodGet, h)
+				return mux
+			}(),
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+			},
+			wantBody: "&lt;h1&gt;Hello World!&lt;/h1&gt;",
+		},
+		{
+			name: "Unsafe HTML Response",
+			mux: func() *safehttp.ServeMux {
+				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+
+				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+					return w.Write("<h1>Hello World!</h1>")
+				})
+				mux.Handle("/pizza", safehttp.MethodGet, h)
+				return mux
+			}(),
+			wantStatus: safehttp.StatusInternalServerError,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Internal Server Error\n",
+		},
+		{
+			name: "Safe HTML Template Response",
+			mux: func() *safehttp.ServeMux {
+				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+
+				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+					return w.WriteTemplate(safetemplate.Must(safetemplate.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+				})
+				mux.Handle("/pizza", safehttp.MethodGet, h)
+				return mux
+			}(),
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+			},
+			wantBody: "<h1>This is an actual heading, though.</h1>",
+		},
+		{
+			name: "Unsafe Template Response",
+			mux: func() *safehttp.ServeMux {
+				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+
+				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+					return w.WriteTemplate(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+				})
+				mux.Handle("/pizza", safehttp.MethodGet, h)
+				return mux
+			}(),
+			wantStatus: safehttp.StatusInternalServerError,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Internal Server Error\n",
+		},
+		{
+			name: "Valid JSON Response",
+			mux: func() *safehttp.ServeMux {
+				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+
+				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+					data := struct {
+						Field string `json:"field"`
+					}{Field: "myField"}
+					return w.WriteJSON(data)
+				})
+				mux.Handle("/pizza", safehttp.MethodGet, h)
+				return mux
+			}(),
+			wantStatus: safehttp.StatusOK,
+			wantHeaders: map[string][]string{
+				"Content-Type": {"application/json; charset=utf-8"},
+			},
+			wantBody: `{"field":"myField"}`,
+		},
+		{
+			name: "Invalid JSON Response",
+			mux: func() *safehttp.ServeMux {
+				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+
+				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+					return w.WriteJSON(math.Inf(1))
+				})
+				mux.Handle("/pizza", safehttp.MethodGet, h)
+				return mux
+			}(),
+			wantStatus: safehttp.StatusInternalServerError,
+			wantHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Internal Server Error\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/pizza", nil)
+			b := &strings.Builder{}
+			rw := newResponseRecorder(b)
+
+			tt.mux.ServeHTTP(rw, req)
+
+			if rw.status != tt.wantStatus {
+				t.Errorf("rw.status: got %v want %v", rw.status, tt.wantStatus)
+			}
+
+			if diff := cmp.Diff(tt.wantHeaders, map[string][]string(rw.headers)); diff != "" {
+				t.Errorf("rw.header mismatch (-want +got):\n%s", diff)
+			}
+
+			if gotBody := b.String(); tt.wantBody != gotBody {
+				t.Errorf("response body: got %q, want %q", gotBody, tt.wantBody)
+			}
+		})
+	}
+}

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -15,6 +15,8 @@
 package safehtml_test
 
 import (
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +30,17 @@ import (
 
 type testDispatcher struct{}
 
+func (testDispatcher) ContentType(resp safehttp.Response) (string, error) {
+	switch resp.(type) {
+	case safehtml.HTML, *template.Template:
+		return "text/html; charset=utf-8", nil
+	case safehttp.JSONResponse:
+		return "application/json; charset=utf-8", nil
+	default:
+		return "", errors.New("not a safe response")
+	}
+}
+
 func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) error {
 	switch x := resp.(type) {
 	case safehtml.HTML:
@@ -36,6 +49,15 @@ func (testDispatcher) Write(rw http.ResponseWriter, resp safehttp.Response) erro
 	default:
 		panic("not a safe response type")
 	}
+}
+
+func (testDispatcher) WriteJSON(rw http.ResponseWriter, resp safehttp.JSONResponse) error {
+	obj, err := json.Marshal(resp.Data)
+	if err != nil {
+		panic("invalid json")
+	}
+	_, err = rw.Write(obj)
+	return err
 }
 
 func (testDispatcher) ExecuteTemplate(rw http.ResponseWriter, t safehttp.Template, data interface{}) error {


### PR DESCRIPTION
Fixes #60, #133

Extended the Dispatcher interface to support writing JSON safe responses and retrieving the Content-Type of safe response and added a . This way the ResponseWriter can query the Dispatcher to retrieve and set the Content-Type of a safe response before writing the response. Implemented and write tests for a default safe dispatcher.