### PR TITLE
Completed the framework's godoc

### DIFF
--- a/safehttp/cookie.go
+++ b/safehttp/cookie.go
@@ -33,8 +33,6 @@ type Cookie struct {
 //  - SameSite: Lax
 // For more info about all the options, see:
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-//
-// TODO: What if name or value is invalid?
 func NewCookie(name, value string) *Cookie {
 	return &Cookie{
 		&http.Cookie{
@@ -75,9 +73,9 @@ func (c *Cookie) SetSameSite(s SameSite) {
 
 // SetMaxAge sets the MaxAge attribute.
 //
-// MaxAge = 0 means no 'Max-Age' attribute specified.
-// MaxAge < 0 means delete cookie now, equivalently 'Max-Age: 0'
-// MaxAge > 0 means Max-Age attribute present and given in seconds
+//  MaxAge = 0 means no 'Max-Age' attribute specified.
+//  MaxAge < 0 means delete cookie now, equivalently 'Max-Age: 0'
+//  MaxAge > 0 means Max-Age attribute present and given in seconds
 func (c *Cookie) SetMaxAge(maxAge int) {
 	c.wrapped.MaxAge = maxAge
 }

--- a/safehttp/handler.go
+++ b/safehttp/handler.go
@@ -15,24 +15,16 @@
 package safehttp
 
 // Handler responds to an HTTP request.
-//
-// ServeHTTP should set headers, call one of the writing functions on the ResponseWriter
-// to write the body of the response and then return the Result received from writing
-// to the ResponseWriter.
-//
-// It is not valid to use the ResponseWriter or read from the body of the IncomingRequest
-// after or concurrently with the completion of the ServeHTTP call.
-//
-// Except for reading the body, handlers should not modify the provided Request.
-//
-// TODO: Add documentation about error handling when properly implemented.
 type Handler interface {
+	// ServeHTTP writes the response exactly once, returning the result
+	//
+	// Except for reading the body, handlers should not modify the provided Request.
+	//
+	// TODO: Add documentation about error handling when properly implemented.
 	ServeHTTP(*ResponseWriter, *IncomingRequest) Result
 }
 
-// HandlerFunc can be used to convert a function into a Handler without creating
-// a new struct. If f is a function with the appropriate signature,
-// HandlerFunc(f) is a Handler that calls f.
+// HandlerFunc is used to convert a function into a Handler.
 type HandlerFunc func(*ResponseWriter, *IncomingRequest) Result
 
 // ServeHTTP calls f(w, r).

--- a/safehttp/handler.go
+++ b/safehttp/handler.go
@@ -14,12 +14,25 @@
 
 package safehttp
 
-// Handler TODO
+// Handler responds to an HTTP request.
+//
+// ServeHTTP should set headers, call one of the writing functions on the ResponseWriter
+// to write the body of the response and then return the Result received from writing
+// to the ResponseWriter.
+//
+// It is not valid to use the ResponseWriter or read from the body of the IncomingRequest
+// after or concurrently with the completion of the ServeHTTP call.
+//
+// Except for reading the body, handlers should not modify the provided Request.
+//
+// TODO: Add documentation about error handling when properly implemented.
 type Handler interface {
 	ServeHTTP(*ResponseWriter, *IncomingRequest) Result
 }
 
-// HandlerFunc TODO
+// HandlerFunc can be used to convert a function into a Handler without creating
+// a new struct. If f is a function with the appropriate signature,
+// HandlerFunc(f) is a Handler that calls f.
 type HandlerFunc func(*ResponseWriter, *IncomingRequest) Result
 
 // ServeHTTP calls f(w, r).

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -24,18 +24,27 @@ import (
 	"sync"
 )
 
-// IncomingRequest TODO
+// IncomingRequest represents a HTTP request received by the server.
 type IncomingRequest struct {
+	// Header is the collection of headers set on the IncomingRequest.
+	//
+	// The Host header is removed from this struct and can be retrieved using Host()
+	Header Header
+	// TLS allows HTTP servers and other software to record information about the
+	// TLS connection on which the request was received. The HTTP server in the
+	// net/http package sets the field for TLS-enabled connections before invoking
+	// a handler, otherwise it leaves the field nil.
+	TLS *tls.ConnectionState
+	// URL specifies the URL that is parsed from the Request-Line. For most requests,
+	// only URL.Path() will return a non-empty result. (See RFC 7230, Section 5.3)
+	URL                *URL
 	req                *http.Request
-	Header             Header
 	postParseOnce      sync.Once
 	multipartParseOnce sync.Once
-	TLS                *tls.ConnectionState
-	URL                *URL
 }
 
 // NewIncomingRequest creates an IncomingRequest
-// from an http.Request.
+// from an underlying http.Request.
 func NewIncomingRequest(req *http.Request) *IncomingRequest {
 	return &IncomingRequest{
 		req:    req,

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -24,16 +24,14 @@ import (
 	"sync"
 )
 
-// IncomingRequest represents a HTTP request received by the server.
+// IncomingRequest represents an HTTP request received by the server.
 type IncomingRequest struct {
-	// Header is the collection of headers set on the IncomingRequest.
+	// Header is the collection of HTTP headers.
 	//
 	// The Host header is removed from this struct and can be retrieved using Host()
 	Header Header
-	// TLS allows HTTP servers and other software to record information about the
-	// TLS connection on which the request was received. The HTTP server in the
-	// net/http package sets the field for TLS-enabled connections before invoking
-	// a handler, otherwise it leaves the field nil.
+	// TLS is set just like this TLS field of the net/http.Request. For more information
+	// see https://pkg.go.dev/net/http?tab=doc#Request.
 	TLS *tls.ConnectionState
 	// URL specifies the URL that is parsed from the Request-Line. For most requests,
 	// only URL.Path() will return a non-empty result. (See RFC 7230, Section 5.3)
@@ -44,7 +42,7 @@ type IncomingRequest struct {
 }
 
 // NewIncomingRequest creates an IncomingRequest
-// from an underlying http.Request.
+// from the underlying http.Request.
 func NewIncomingRequest(req *http.Request) *IncomingRequest {
 	return &IncomingRequest{
 		req:    req,

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -36,9 +36,8 @@ const (
 //
 // When creating the multiplexer, the user needs to specify a list of allowed
 // domains. The server will only serve requests target to those domains and
-// otherwise will reply with HTTP 404 Not Found.
-// TODO(@mihalimara22, @mattiasgrenfeldt): add a link to docs/ explaining
-// why this is done.
+// otherwise will reply with HTTP 404 Not Found in order to protect agains DNS
+// rebinding and HTTP request smuggling.
 //
 // Patterns names are fixed, rooted paths, like "/favicon.ico", or rooted
 // subtrees like "/images/" (note the trailing slash). Longer patterns take

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -21,13 +21,13 @@ import "io"
 // supported by the Dispatcher.
 type Response interface{}
 
-// Template should be an implementation of a template on which data can be applied.
+// Template implements a template.
 type Template interface {
-	// Execute should apply data to the template and then write the result to
+	// Execute applies data to the template and then writes the result to
 	// the io.Writer.
 	//
-	// Execute should return an error if applying the data object to the
-	// Template fails or an error occurs while writing the result to the
+	// Execute returns an error if applying the data object to the
+	// Template fails or if an error occurs while writing the result to the
 	// io.Writer.
 	Execute(wr io.Writer, data interface{}) error
 }

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -16,11 +16,19 @@ package safehttp
 
 import "io"
 
-// Response TODO
+// Response should encapsulate the data passed to the ResponseWriter to be
+// written by the Dispatcher. Any implementation of the interface should be
+// supported by the Dispatcher.
 type Response interface{}
 
-// Template TODO
+// Template should be an implementation of a template on which data can be applied.
 type Template interface {
+	// Execute should apply data to the template and then write the result to
+	// the io.Writer.
+	//
+	// Execute should return an error if applying the data object to the
+	// Template fails or an error occurs while writing the result to the
+	// io.Writer.
 	Execute(wr io.Writer, data interface{}) error
 }
 

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -51,10 +51,9 @@ func NewResponseWriter(d Dispatcher, rw http.ResponseWriter, req *IncomingReques
 	}
 }
 
-// Result is created and returned when the ResponseWriter is written to. It should
-// be returned by Interceptor.Before and Handler.ServeHTTP. If nothing is written
-// to the ResponseWriter then an empty Result should be returned, created by
-// calling the NotWritten function.
+// Result is the result of writing an HTTP response.
+//
+// Use ResponseWriter methods to obtain it.
 type Result struct{}
 
 // NotWritten returns a Result which indicates that nothing has been written yet. It


### PR DESCRIPTION
Fixes #132 

Completed the documentation in the repository. The TODOs left in `response_writer.go` will be fixed when #147 is merged. Comments related to error handling will be refactored when we handle `ResponseWriter.Write` and `Dispatcher` panics properly.