### PR TITLE
Added package level godocs to Collector, CORS, CSP, HSTS, staticheaders and safehttptest.

### DIFF
--- a/safehttp/plugins/collector/collector.go
+++ b/safehttp/plugins/collector/collector.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package collector provides a function for creating violation report handlers.
+// The created safehttp.Handler will be able to parse generic violation reports
+// as specified by https://w3c.github.io/reporting/ and CSP violation reports as
+// specified by https://www.w3.org/TR/CSP3/#deprecated-serialize-violation.
 package collector
 
 import (

--- a/safehttp/plugins/cors/cors.go
+++ b/safehttp/plugins/cors/cors.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package cors provides a safehttp.Interceptor that handles CORS requests.
 package cors
 
 import (
@@ -42,12 +43,13 @@ var disallowedContentTypes = map[string]bool{
 //
 // Each CORS request must contain the header "X-Cors: 1".
 //
+// The HEAD request method is disallowed.
+//
 // All of this is to prevent XSRF.
 type Interceptor struct {
 	// AllowedOrigins determines which origins should be allowed in the
 	// Access-Control-Allow-Origin header.
 	AllowedOrigins map[string]bool
-	allowedHeaders map[string]bool
 	// ExposedHeaders determines which headers should be set in the
 	// Access-Control-Expose-Headers header. This controls which headers are
 	//  accessible by JavaScript in the response.
@@ -63,7 +65,8 @@ type Interceptor struct {
 	//
 	// MaxAge=0 results in MaxAge: 5, the default used by Chromium according to
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
-	MaxAge int
+	MaxAge         int
+	allowedHeaders map[string]bool
 }
 
 // Default creates a CORS Interceptor with default settings.

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package csp provides a safehttp.Interceptor which applies Content-Security Policies
+// to responses.
+//
+// Two default policies are provided:
+//  - A strict nonce based CSP
+//  - A framing policy which sets frame-ancestors to 'self'
 package csp
 
 import (

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package hsts provides a safehttp.Interceptor which sets the Strict-Transport-Security
+// header.
 package hsts
 
 import (

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package staticheaders provides a safehttp.Interceptor which set the X-Content-Type-Options
+// and the X-XSS-Protection header.
 package staticheaders
 
 import (

--- a/safehttp/safehttptest/doc.go
+++ b/safehttp/safehttptest/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package safehttptest provides utilities for testing safehttp.Handler:s and
+// safehttp.Interceptor:s.
+package safehttptest


### PR DESCRIPTION
As part of improving the documentation of the project ( #132 ) I've added package level godocs for the following packages:

- safehttp/plugins/collector
- safehttp/plugins/cors
- safehttp/plugins/csp
- safehttp/plugins/hsts
- safehttp/plugins/staticheaders
- safehttp/safehttptest

Package level comments left to write are for:

- safehttp/plugins/xsrf
- safehttp/plugins/fetch_metadata

I'll let @maramihali write those since she wrote those packages.