### PR TITLE
Address linter comments in the safehttp package

### DIFF
--- a/safehttp/cookie.go
+++ b/safehttp/cookie.go
@@ -54,8 +54,13 @@ func NewCookie(name, value string) *Cookie {
 type SameSite int
 
 const (
+	// SameSiteLaxMode allows sending cookies with same-site requests and
+	// cross-site top-level navigations.
 	SameSiteLaxMode SameSite = iota + 1
+	// SameSiteStrictMode allows sending cookie only with same-site requests.
 	SameSiteStrictMode
+	// SameSiteNoneMode allows sending cookies with all requests, including the
+	// ones made cross-origin.
 	SameSiteNoneMode
 )
 

--- a/safehttp/doc.go
+++ b/safehttp/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package safehttp TODO(@kele, @empijei)
+package safehttp

--- a/safehttp/incoming_request_test.go
+++ b/safehttp/incoming_request_test.go
@@ -193,6 +193,8 @@ func TestRequestSetNilContext(t *testing.T) {
 			t.Errorf(`ir.SetContext(nil): expected panic`)
 		}
 	}()
+
+	// Avoids linters complaint about a nil context being passed as argument
 	var nilContext context.Context
 	ir.SetContext(nilContext)
 }

--- a/safehttp/incoming_request_test.go
+++ b/safehttp/incoming_request_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/google/go-safeweb/safehttp/safehttptest"
 )
 
+var nilContext context.Context
+
 func TestIncomingRequestCookie(t *testing.T) {
 	var tests = []struct {
 		name      string
@@ -194,7 +196,7 @@ func TestRequestSetNilContext(t *testing.T) {
 		}
 	}()
 
-	ir.SetContext(nil)
+	ir.SetContext(nilContext)
 }
 
 func TestIncomingRequestPostForm(t *testing.T) {

--- a/safehttp/incoming_request_test.go
+++ b/safehttp/incoming_request_test.go
@@ -194,7 +194,8 @@ func TestRequestSetNilContext(t *testing.T) {
 		}
 	}()
 
-	// Avoids linters complaint about a nil context being passed as argument
+	// Avoids a linter complaint about a nil context being passed as argument.
+	// In this case, we explicitly want to test that a nil context results in an error.
 	var nilContext context.Context
 	ir.SetContext(nilContext)
 }

--- a/safehttp/incoming_request_test.go
+++ b/safehttp/incoming_request_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/google/go-safeweb/safehttp/safehttptest"
 )
 
-var nilContext context.Context
-
 func TestIncomingRequestCookie(t *testing.T) {
 	var tests = []struct {
 		name      string
@@ -195,7 +193,7 @@ func TestRequestSetNilContext(t *testing.T) {
 			t.Errorf(`ir.SetContext(nil): expected panic`)
 		}
 	}()
-
+	var nilContext context.Context
 	ir.SetContext(nilContext)
 }
 

--- a/safehttp/incoming_request_test.go
+++ b/safehttp/incoming_request_test.go
@@ -379,6 +379,10 @@ func TestIncomingRequestMultipartFileUpload(t *testing.T) {
 	defer f.RemoveFiles()
 
 	file, err := fhs[0].Open()
+	if err != nil {
+		t.Fatalf("fhs[0].Open(): got err %v, want nil", err)
+	}
+
 	content := make([]byte, 12)
 	file.Read(content)
 	if want, got := "file content", string(content); want != got {
@@ -418,6 +422,10 @@ func TestIncomingRequestMultipartFormAndFileUpload(t *testing.T) {
 	defer f.RemoveFiles()
 
 	file, err := fhs[0].Open()
+	if err != nil {
+		t.Fatalf("fhs[0].Open(): got err %v, want nil", err)
+	}
+
 	content := make([]byte, 12)
 	file.Read(content)
 	if want, got := "file content", string(content); want != got {
@@ -445,6 +453,10 @@ func TestIncomingRequestFileUploadMissingContent(t *testing.T) {
 	defer f.RemoveFiles()
 
 	file, err := fhs[0].Open()
+	if err != nil {
+		t.Fatalf("fhs[0].Open(): got err %v, want nil", err)
+	}
+
 	content := make([]byte, 0)
 	file.Read(content)
 	if want, got := "", string(content); want != got {

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 )
 
+// The HTTP request methods defined by RFC.
 const (
 	MethodConnect = "CONNECT" // RFC 7231, 4.3.6
 	MethodDelete  = "DELETE"  // RFC 7231, 4.3.5

--- a/safehttp/plugins/htmlinject/htmlinject_test.go
+++ b/safehttp/plugins/htmlinject/htmlinject_test.go
@@ -15,10 +15,10 @@
 package htmlinject
 
 import (
-	"html/template"
 	"os"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -41,6 +41,7 @@ Last name:<br>
 </body>
 </html>
 `
+
 	got, err := Transform(strings.NewReader(in), CSPNoncesDefault, XSRFTokensDefault)
 	if err != nil {
 		// handle error

--- a/safehttp/plugins/htmlinject/htmlinject_test.go
+++ b/safehttp/plugins/htmlinject/htmlinject_test.go
@@ -15,10 +15,10 @@
 package htmlinject
 
 import (
+	"html/template"
 	"os"
 	"strings"
 	"testing"
-	"text/template"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/safehttp/plugins/htmlinject/htmlinject_test.go
+++ b/safehttp/plugins/htmlinject/htmlinject_test.go
@@ -41,7 +41,6 @@ Last name:<br>
 </body>
 </html>
 `
-
 	got, err := Transform(strings.NewReader(in), CSPNoncesDefault, XSRFTokensDefault)
 	if err != nil {
 		// handle error

--- a/safehttp/status.go
+++ b/safehttp/status.go
@@ -18,6 +18,7 @@ package safehttp
 // See: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 type StatusCode int
 
+// The HTTP status codes registered with IANA.
 const (
 	StatusContinue           StatusCode = 100 // RFC 7231, 6.2.1
 	StatusSwitchingProtocols StatusCode = 101 // RFC 7231, 6.2.2


### PR DESCRIPTION
The following changes have been done to address linters comments:
* Added missing documentation
* Replaced usage of `html/template` 
* ensure a `nil` context is not passed to a function directly

TODOS:
* Add godocs to `safesql/sqlwrap.go`.
* Add package level documentation in `safehttp/doc.go` to remove the TODO.
