### PR TITLE
Implemented the Commit phase in the CSP and XSRF plugins

### DIFF
--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -62,7 +62,7 @@ func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) er
 
 // ExecuteTemplate applies the parsed template to the provided data object, if
 // the template is a safe HTML template, writing the output to the  http.
-// ResponseWriter. If the funcMap is non-nil, its elements can override the
+// ResponseWriter. If the funcMap is non-nil, its elements override the
 // existing names to functions mappings in the template. An attempt to define a
 // new name to function mapping that is not already in the template will result
 // in a panic. The template, data object and funcMap are contained in the

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -65,8 +65,7 @@ func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) er
 // ResponseWriter. If the funcMap is non-nil, its elements override the
 // existing names to functions mappings in the template. An attempt to define a
 // new name to function mapping that is not already in the template will result
-// in a panic. The template, data object and funcMap are contained in the
-// TemplateResponse.
+// in a panic.
 //
 // If an error occurs executing the template or writing its output,
 // execution stops, but partial results may already have been written to

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -60,27 +60,29 @@ func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) er
 	return json.NewEncoder(rw).Encode(resp.Data)
 }
 
-// ExecuteTemplate applies a parsed template to the provided data object, if the
-// template is a safe HTML template, writing the output to the  http.
+// ExecuteTemplate applies the parsed template to the provided data object, if
+// the template is a safe HTML template, writing the output to the  http.
 // ResponseWriter. If the funcMap is non-nil, its elements can override the
 // existing names to functions mappings in the template. An attempt to define a
 // new name to function mapping that is not already in the template will result
-// in a panic.
+// in a panic. The template, data object and funcMap are contained in the
+// TemplateResponse.
 //
 // If an error occurs executing the template or writing its output,
 // execution stops, but partial results may already have been written to
 // the Response Writer.
-func (DefaultDispatcher) ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}, funcMap map[string]interface{}) error {
+func (DefaultDispatcher) ExecuteTemplate(rw http.ResponseWriter, resp TemplateResponse) error {
+	t := *resp.Template
 	x, ok := t.(*template.Template)
 	if !ok {
-		return fmt.Errorf("%T is not a safe template and it cannot be parsed and written", t)
+		return fmt.Errorf("%T is not a safe template and it cannot be parsed and written", resp.Template)
 	}
-	if len(funcMap) == 0 {
-		return x.Execute(rw, data)
+	if len(resp.FuncMap) == 0 {
+		return x.Execute(rw, resp.Data)
 	}
 	cloned, err := x.Clone()
 	if err != nil {
 		return err
 	}
-	return cloned.Funcs(funcMap).Execute(rw, data)
+	return cloned.Funcs(resp.FuncMap).Execute(rw, resp.Data)
 }

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -60,9 +60,12 @@ func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) er
 	return json.NewEncoder(rw).Encode(resp.Data)
 }
 
-// ExecuteTemplate applies a parsed template to the provided data object if the
+// ExecuteTemplate applies a parsed template to the provided data object, if the
 // template is a safe HTML template, writing the output to the  http.
-// ResponseWriter.
+// ResponseWriter. If the funcMap is non-nil, its elements can override the
+// existing names to functions mappings in the template. An attempt to define a
+// new name to function mapping that is not already in the template will result
+// in a panic.
 //
 // If an error occurs executing the template or writing its output,
 // execution stops, but partial results may already have been written to

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -67,10 +67,17 @@ func (DefaultDispatcher) WriteJSON(rw http.ResponseWriter, resp JSONResponse) er
 // If an error occurs executing the template or writing its output,
 // execution stops, but partial results may already have been written to
 // the Response Writer.
-func (DefaultDispatcher) ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}) error {
+func (DefaultDispatcher) ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}, funcMap map[string]interface{}) error {
 	x, ok := t.(*template.Template)
 	if !ok {
 		return fmt.Errorf("%T is not a safe template and it cannot be parsed and written", t)
 	}
-	return x.Execute(rw, data)
+	if len(funcMap) == 0 {
+		return x.Execute(rw, data)
+	}
+	cloned, err := x.Clone()
+	if err != nil {
+		return err
+	}
+	return cloned.Funcs(funcMap).Execute(rw, data)
 }

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -46,13 +46,14 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 			name: "Safe HTML Template Response",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				t := safehttp.Template(safetemplate.Must(safetemplate.New("name").Parse("<h1>{{ . }}</h1>")))
+				t := safehttp.Template(safetemplate.
+					Must(safetemplate.New("name").
+						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
 				resp := safehttp.TemplateResponse{
 					Template: &t,
 					Data:     &data,
-					FuncMap:  map[string]interface{}{},
 				}
 				return d.ExecuteTemplate(w, resp)
 			},
@@ -62,8 +63,11 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 			name: "Safe HTML Template Response with Token",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				noop := func() string { panic("this function should never be called") }
-				t := safehttp.Template(safetemplate.Must(safetemplate.New("name").Funcs(map[string]interface{}{"Token": noop}).Parse(`<form><input type="hidden" name="token" value="{{Token}}">{{.}}</form>`)))
+				defaultFunc := func() string { panic("this function should never be called") }
+				t := safehttp.Template(safetemplate.
+					Must(safetemplate.New("name").
+						Funcs(map[string]interface{}{"Token": defaultFunc}).
+						Parse(`<form><input type="hidden" name="token" value="{{Token}}">{{.}}</form>`)))
 				var data interface{}
 				data = "Content"
 				fm := map[string]interface{}{
@@ -83,8 +87,11 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 			name: "Safe HTML Template Response with  Nonce",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				noop := func() string { panic("this function should never be called") }
-				t := safehttp.Template(safetemplate.Must(safetemplate.New("name").Funcs(map[string]interface{}{"Nonce": noop}).Parse(`<script nonce="{{Nonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`)))
+				defaultFunc := func() string { panic("this function should never be called") }
+				t := safehttp.Template(safetemplate.
+					Must(safetemplate.New("name").
+						Funcs(map[string]interface{}{"Nonce": defaultFunc}).
+						Parse(`<script nonce="{{Nonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`)))
 				var data interface{}
 				data = "Content"
 				fm := map[string]interface{}{
@@ -148,13 +155,14 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 			name: "Unsafe Template Response",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				t := safehttp.Template(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")))
+				t := safehttp.Template(template.
+					Must(template.New("name").
+						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
 				resp := safehttp.TemplateResponse{
 					Template: &t,
 					Data:     &data,
-					FuncMap:  map[string]interface{}{},
 				}
 				return d.ExecuteTemplate(w, resp)
 			},

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -46,7 +46,15 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 			name: "Safe HTML Template Response",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				return d.ExecuteTemplate(w, safetemplate.Must(safetemplate.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", map[string]interface{}{})
+				t := safehttp.Template(safetemplate.Must(safetemplate.New("name").Parse("<h1>{{ . }}</h1>")))
+				var data interface{}
+				data = "This is an actual heading, though."
+				resp := safehttp.TemplateResponse{
+					Template: &t,
+					Data:     &data,
+					FuncMap:  map[string]interface{}{},
+				}
+				return d.ExecuteTemplate(w, resp)
 			},
 			wantBody: "<h1>This is an actual heading, though.</h1>",
 		},
@@ -55,12 +63,19 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
 				noop := func() string { panic("this function should never be called") }
-				t := safetemplate.Must(safetemplate.New("name").Funcs(map[string]interface{}{"Token": noop}).Parse(`<form><input type="hidden" name="token" value="{{Token}}">{{.}}</form>`))
+				t := safehttp.Template(safetemplate.Must(safetemplate.New("name").Funcs(map[string]interface{}{"Token": noop}).Parse(`<form><input type="hidden" name="token" value="{{Token}}">{{.}}</form>`)))
+				var data interface{}
+				data = "Content"
 				fm := map[string]interface{}{
 					"Token": func() string { return "Token-secret" },
 				}
+				resp := safehttp.TemplateResponse{
+					Template: &t,
+					Data:     &data,
+					FuncMap:  fm,
+				}
 
-				return d.ExecuteTemplate(w, t, "Content", fm)
+				return d.ExecuteTemplate(w, resp)
 			},
 			wantBody: `<form><input type="hidden" name="token" value="Token-secret">Content</form>`,
 		},
@@ -69,12 +84,19 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
 				noop := func() string { panic("this function should never be called") }
-				t := safetemplate.Must(safetemplate.New("name").Funcs(map[string]interface{}{"Nonce": noop}).Parse(`<script nonce="{{Nonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`))
+				t := safehttp.Template(safetemplate.Must(safetemplate.New("name").Funcs(map[string]interface{}{"Nonce": noop}).Parse(`<script nonce="{{Nonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`)))
+				var data interface{}
+				data = "Content"
 				fm := map[string]interface{}{
 					"Nonce": func() string { return "Nonce-secret" },
 				}
+				resp := safehttp.TemplateResponse{
+					Template: &t,
+					Data:     &data,
+					FuncMap:  fm,
+				}
 
-				return d.ExecuteTemplate(w, t, "Content", fm)
+				return d.ExecuteTemplate(w, resp)
 			},
 			wantBody: `<script nonce="Nonce-secret" type="application/javascript">alert("script")</script><h1>Content</h1>`,
 		},
@@ -126,7 +148,15 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 			name: "Unsafe Template Response",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				return d.ExecuteTemplate(w, template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", map[string]interface{}{})
+				t := safehttp.Template(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")))
+				var data interface{}
+				data = "This is an actual heading, though."
+				resp := safehttp.TemplateResponse{
+					Template: &t,
+					Data:     &data,
+					FuncMap:  map[string]interface{}{},
+				}
+				return d.ExecuteTemplate(w, resp)
 			},
 			want: "",
 		},

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -231,7 +231,10 @@ func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 		return w.WriteError(safehttp.StatusInternalServerError)
 	}
 
-	// TODO(maramihali@): Change the key when function names are exported by htmlinject
+	// TODO(maramihali@): Change the key when function names are exported by
+	// htmlinject
+	// TODO: What should happen if the CSPNonce is not present in the
+	// tr.FuncMap?
 	tmplResp.FuncMap["CSPNonce"] = func() string { return nonce }
 	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -221,7 +221,7 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	tempResp, ok := resp.(safehttp.TemplateResponse)
 	if !ok {
-		return safehttp.Result{}
+		return safehttp.NotWritten()
 	}
 
 	nonce, err := Nonce(r.Context())
@@ -233,5 +233,5 @@ func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 
 	// TODO(maramihali@): Change the key when function names are exported by htmlinject
 	tempResp.FuncMap["CSPNonce"] = func() string { return nonce }
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -219,7 +219,7 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 // injected as the value of the nonce attribute in <script> and <link> tags. The
 // nonce is going to be unique for each safehttp.IncomingRequest.
 func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	tempResp, ok := resp.(safehttp.TemplateResponse)
+	tmplResp, ok := resp.(safehttp.TemplateResponse)
 	if !ok {
 		return safehttp.NotWritten()
 	}
@@ -232,6 +232,6 @@ func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	}
 
 	// TODO(maramihali@): Change the key when function names are exported by htmlinject
-	tempResp.FuncMap["CSPNonce"] = func() string { return nonce }
+	tmplResp.FuncMap["CSPNonce"] = func() string { return nonce }
 	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -319,34 +319,3 @@ func TestCommitNotTemplateResponse(t *testing.T) {
 	}
 
 }
-
-func TestBeforeCommit(t *testing.T) {
-	rec := safehttptest.NewResponseRecorder()
-	req := safehttptest.NewRequest(safehttp.MethodGet, "https://foo.com/pizza", nil)
-
-	it := Default("")
-	tr := safehttp.TemplateResponse{FuncMap: map[string]interface{}{}}
-	it.Before(rec.ResponseWriter, req, nil)
-	it.Commit(rec.ResponseWriter, req, tr, nil)
-
-	nonce, ok := tr.FuncMap["CSPNonce"]
-	if !ok {
-		t.Fatal(`tr.FuncMap["CSPNonce"] not found`)
-	}
-
-	fn, ok := nonce.(func() string)
-	if !ok {
-		t.Fatalf(`tr.FuncMap["CSPNonce"]: got %T, want "func() string"`, fn)
-	}
-	if got := fn(); got == "" {
-		t.Errorf(`tr.FuncMap["CSPNonce"](): got %q, want nonce`, got)
-	}
-
-	if got, want := rec.Status(), safehttp.StatusOK; want != got {
-		t.Errorf("rec.Status(): got %v, want %v", got, want)
-	}
-	if got, want := rec.Body(), ""; got != want {
-		t.Errorf("rec.Body(): got %q want %q", got, want)
-	}
-
-}

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -154,7 +154,10 @@ func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 		return w.WriteError(safehttp.StatusInternalServerError)
 	}
 
-	// TODO(maramihali@): Change the key when function names are exported by htmlinject
+	// TODO(maramihali@): Change the key when function names are exported by
+	// htmlinject
+	// TODO: what should happen if the XSRFToken key is not present in the
+	// tr.FuncMap?
 	tmplResp.FuncMap["XSRFToken"] = func() string { return tok }
 	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -144,7 +144,7 @@ func (it *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
 	tempResp, ok := resp.(safehttp.TemplateResponse)
 	if !ok {
-		return safehttp.Result{}
+		return safehttp.NotWritten()
 	}
 
 	tok, err := Token(r)
@@ -156,5 +156,5 @@ func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 
 	// TODO(maramihali@): Change the key when function names are exported by htmlinject
 	tempResp.FuncMap["XSRFToken"] = func() string { return tok }
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -138,11 +138,11 @@ func (it *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 	return safehttp.NotWritten()
 }
 
-// Commit adds the XSRF token corresponding to the correct user to the
-// safehttp.TemplateResponse to be subsequently injected in HTML forms as a
-// hidden form field.
+// Commit adds the XSRF token corresponding to the safehttp.TemplateResponse
+// with key "XSRFToken". The token corresponds to the user information found in
+// the request.
 func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	tempResp, ok := resp.(safehttp.TemplateResponse)
+	tmplResp, ok := resp.(safehttp.TemplateResponse)
 	if !ok {
 		return safehttp.NotWritten()
 	}
@@ -155,6 +155,6 @@ func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 	}
 
 	// TODO(maramihali@): Change the key when function names are exported by htmlinject
-	tempResp.FuncMap["XSRFToken"] = func() string { return tok }
+	tmplResp.FuncMap["XSRFToken"] = func() string { return tok }
 	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -138,11 +138,6 @@ func (it *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 	return safehttp.NotWritten()
 }
 
-<<<<<<< HEAD
-// Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
-func (i *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	return safehttp.NotWritten()
-=======
 // Commit adds the XSRF token corresponding to the correct user to the
 // safehttp.TemplateResponse to be subsequently injected in HTML forms as a
 // hidden form field.
@@ -162,5 +157,4 @@ func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 	// TODO(maramihali@): Change the key when function names are exported by htmlinject
 	tempResp.FuncMap["XSRFToken"] = func() string { return tok }
 	return safehttp.Result{}
->>>>>>> Implemented the Commit phase of the XSRF plugin
 }

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -109,7 +109,7 @@ func TestTokenMultipart(t *testing.T) {
 				t.Errorf("rec.Status(): got %v, want %v", got, test.wantStatus)
 			}
 			if diff := cmp.Diff(test.wantHeader, map[string][]string(rec.Header())); diff != "" {
-				t.Errorf("rw.header mismatch (-want +got):\n%s", diff)
+				t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
 			}
 			if got := rec.Body(); got != test.wantBody {
 				t.Errorf("rec.Body(): got %q want %q", got, test.wantBody)
@@ -135,7 +135,7 @@ func TestMalformedForm(t *testing.T) {
 		"X-Content-Type-Options": {"nosniff"},
 	}
 	if diff := cmp.Diff(wantHeaders, map[string][]string(rec.Header())); diff != "" {
-		t.Errorf("rw.header mismatch (-want +got):\n%s", diff)
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
 	}
 	if want, got := "Bad Request\n", rec.Body(); got != want {
 		t.Errorf("rec.Body(): got %q want %q", got, want)
@@ -208,7 +208,7 @@ func TestMissingTokenInBody(t *testing.T) {
 			"X-Content-Type-Options": {"nosniff"},
 		}
 		if diff := cmp.Diff(wantHeaders, map[string][]string(rec.Header())); diff != "" {
-			t.Errorf("rw.header mismatch (-want +got):\n%s", diff)
+			t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
 		}
 		if want, got := "Unauthorized\n", rec.Body(); got != want {
 			t.Errorf("rec.Body(): got %q want %q", got, want)
@@ -309,9 +309,125 @@ func TestMissingCookiePostRequest(t *testing.T) {
 		"X-Content-Type-Options": {"nosniff"},
 	}
 	if diff := cmp.Diff(wantHeaders, map[string][]string(rec.Header())); diff != "" {
-		t.Errorf("rw.header mismatch (-want +got):\n%s", diff)
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
 	}
 	if want, got := "Forbidden\n", rec.Body(); got != want {
 		t.Errorf("rec.Body(): got %q want %q", got, want)
 	}
+}
+
+func TestCommitToken(t *testing.T) {
+	rec := safehttptest.NewResponseRecorder()
+	req := safehttptest.NewRequest(safehttp.MethodGet, "https://foo.com/pizza", nil)
+	req.SetContext(context.WithValue(req.Context(), tokenCtxKey{}, "pizza"))
+
+	i := Interceptor{SecretAppKey: "testSecretAppKey"}
+	tr := safehttp.TemplateResponse{FuncMap: map[string]interface{}{}}
+	i.Commit(rec.ResponseWriter, req, tr, nil)
+
+	tok, ok := tr.FuncMap["XSRFToken"]
+	if !ok {
+		t.Error(`tr.FuncMap["XSRFToken"]: got nil, want tok`)
+	}
+
+	fn, ok := tok.(func() string)
+	if !ok {
+		t.Errorf(`tr.FuncMap["XSRFToken"]: got %T, want "func() string"`, fn)
+	}
+	if want, got := "pizza", fn(); want != got {
+		t.Errorf(`tr.FuncMap["XSRFToken"](): got %s, want %s`, got, want)
+	}
+
+	if want, got := safehttp.StatusOK, rec.Status(); want != got {
+		t.Errorf("rec.Status(): got %v, want %v", got, want)
+	}
+	if diff := cmp.Diff(map[string][]string{}, map[string][]string(rec.Header())); diff != "" {
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+	}
+
+	if want, got := "", rec.Body(); got != want {
+		t.Errorf("rec.Body(): got %q want %q", got, want)
+	}
+}
+
+func TestCommitMissingToken(t *testing.T) {
+	rec := safehttptest.NewResponseRecorder()
+	req := safehttptest.NewRequest(safehttp.MethodGet, "https://foo.com/pizza", nil)
+	req.SetContext(context.Background())
+
+	i := Interceptor{SecretAppKey: "testSecretAppKey"}
+	tr := safehttp.TemplateResponse{FuncMap: map[string]interface{}{}}
+	i.Commit(rec.ResponseWriter, req, tr, nil)
+
+	wantFuncMap := map[string]interface{}{}
+	if diff := cmp.Diff(wantFuncMap, tr.FuncMap); diff != "" {
+		t.Errorf("tr.FuncMap: mismatch (-want +got):\n%s", diff)
+	}
+
+	if want, got := safehttp.StatusInternalServerError, rec.Status(); got != want {
+		t.Errorf("rec.Status(): got %v, want %v", got, want)
+	}
+	wantHeaders := map[string][]string{
+		"Content-Type":           {"text/plain; charset=utf-8"},
+		"X-Content-Type-Options": {"nosniff"},
+	}
+
+	if diff := cmp.Diff(wantHeaders, map[string][]string(rec.Header())); diff != "" {
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+	}
+
+	if want, got := "Internal Server Error\n", rec.Body(); got != want {
+		t.Errorf("rec.Body(): got %q want %q", got, want)
+	}
+}
+
+func TestCommitNotTemplateResponse(t *testing.T) {
+	rec := safehttptest.NewResponseRecorder()
+	req := safehttptest.NewRequest(safehttp.MethodGet, "https://foo.com/pizza", nil)
+
+	i := Interceptor{SecretAppKey: "testSecretAppKey"}
+	i.Commit(rec.ResponseWriter, req, safehttp.NoContentResponse{}, nil)
+
+	if want, got := safehttp.StatusOK, rec.Status(); want != got {
+		t.Errorf("rec.Status(): got %v, want %v", got, want)
+	}
+
+	if diff := cmp.Diff(map[string][]string{}, map[string][]string(rec.Header())); diff != "" {
+		t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+	}
+
+	if want, got := "", rec.Body(); got != want {
+		t.Errorf("rec.Body(): got %q want %q", got, want)
+	}
+}
+
+func TestBeforeCommit(t *testing.T) {
+	rec := safehttptest.NewResponseRecorder()
+	req := safehttptest.NewRequest(safehttp.MethodGet, "https://foo.com/pizza", nil)
+
+	i := Interceptor{SecretAppKey: "testSecretAppKey"}
+	tr := safehttp.TemplateResponse{FuncMap: map[string]interface{}{}}
+	i.Before(rec.ResponseWriter, req, nil)
+	i.Commit(rec.ResponseWriter, req, tr, nil)
+
+	tok, ok := tr.FuncMap["XSRFToken"]
+	if !ok {
+		t.Error(`tr.FuncMap["XSRFToken"]: got nil, want token`)
+	}
+
+	fn, ok := tok.(func() string)
+	if !ok {
+		t.Errorf(`tr.FuncMap["XSRFToken"]: got %T, want "func() string"`, fn)
+	}
+	if got := fn(); got == "" {
+		t.Errorf(`tr.FuncMap["XSRFToken"](): got %s, want token`, got)
+	}
+
+	if want, got := safehttp.StatusOK, rec.Status(); want != got {
+		t.Errorf("rec.Status(): got %v, want %v", got, want)
+	}
+	if want, got := "", rec.Body(); got != want {
+		t.Errorf("rec.Body(): got %q want %q", got, want)
+	}
+
 }

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -400,34 +400,3 @@ func TestCommitNotTemplateResponse(t *testing.T) {
 		t.Errorf("rec.Body(): got %q want %q", got, want)
 	}
 }
-
-func TestBeforeCommit(t *testing.T) {
-	rec := safehttptest.NewResponseRecorder()
-	req := safehttptest.NewRequest(safehttp.MethodGet, "https://foo.com/pizza", nil)
-
-	i := Interceptor{SecretAppKey: "testSecretAppKey"}
-	tr := safehttp.TemplateResponse{FuncMap: map[string]interface{}{}}
-	i.Before(rec.ResponseWriter, req, nil)
-	i.Commit(rec.ResponseWriter, req, tr, nil)
-
-	tok, ok := tr.FuncMap["XSRFToken"]
-	if !ok {
-		t.Fatal(`tr.FuncMap["XSRFToken"] not found`)
-	}
-
-	fn, ok := tok.(func() string)
-	if !ok {
-		t.Errorf(`tr.FuncMap["XSRFToken"]: got %T, want "func() string"`, fn)
-	}
-	if got := fn(); got == "" {
-		t.Errorf(`tr.FuncMap["XSRFToken"](): got %q, want token`, got)
-	}
-
-	if want, got := safehttp.StatusOK, rec.Status(); want != got {
-		t.Errorf("rec.Status(): got %v, want %v", got, want)
-	}
-	if want, got := "", rec.Body(); got != want {
-		t.Errorf("rec.Body(): got %q want %q", got, want)
-	}
-
-}

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -327,7 +327,7 @@ func TestCommitToken(t *testing.T) {
 
 	tok, ok := tr.FuncMap["XSRFToken"]
 	if !ok {
-		t.Error(`tr.FuncMap["XSRFToken"]: got nil, want tok`)
+		t.Fatal(`tr.FuncMap["XSRFToken"] not found`)
 	}
 
 	fn, ok := tok.(func() string)
@@ -335,7 +335,7 @@ func TestCommitToken(t *testing.T) {
 		t.Errorf(`tr.FuncMap["XSRFToken"]: got %T, want "func() string"`, fn)
 	}
 	if want, got := "pizza", fn(); want != got {
-		t.Errorf(`tr.FuncMap["XSRFToken"](): got %s, want %s`, got, want)
+		t.Errorf(`tr.FuncMap["XSRFToken"](): got %q, want %q`, got, want)
 	}
 
 	if want, got := safehttp.StatusOK, rec.Status(); want != got {
@@ -412,7 +412,7 @@ func TestBeforeCommit(t *testing.T) {
 
 	tok, ok := tr.FuncMap["XSRFToken"]
 	if !ok {
-		t.Error(`tr.FuncMap["XSRFToken"]: got nil, want token`)
+		t.Fatal(`tr.FuncMap["XSRFToken"] not found`)
 	}
 
 	fn, ok := tok.(func() string)
@@ -420,7 +420,7 @@ func TestBeforeCommit(t *testing.T) {
 		t.Errorf(`tr.FuncMap["XSRFToken"]: got %T, want "func() string"`, fn)
 	}
 	if got := fn(); got == "" {
-		t.Errorf(`tr.FuncMap["XSRFToken"](): got %s, want token`, got)
+		t.Errorf(`tr.FuncMap["XSRFToken"](): got %q, want token`, got)
 	}
 
 	if want, got := safehttp.StatusOK, rec.Status(); want != got {

--- a/safehttp/plugins/xsrf/xsrf_test.go
+++ b/safehttp/plugins/xsrf/xsrf_test.go
@@ -332,7 +332,7 @@ func TestCommitToken(t *testing.T) {
 
 	fn, ok := tok.(func() string)
 	if !ok {
-		t.Errorf(`tr.FuncMap["XSRFToken"]: got %T, want "func() string"`, fn)
+		t.Fatalf(`tr.FuncMap["XSRFToken"]: got %T, want "func() string"`, fn)
 	}
 	if want, got := "pizza", fn(); want != got {
 		t.Errorf(`tr.FuncMap["XSRFToken"](): got %q, want %q`, got, want)

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -38,9 +38,9 @@ type Template interface {
 	Execute(wr io.Writer, data interface{}) error
 }
 
-// TemplateResponse bundles a Template with its data to be passed together to the
-// commit phase. This will be passed when the commit phase is initiated from
-// ResponseWriter.WriteTemplate.
+// TemplateResponse bundles a Template with its data and names to function
+// mappings to be passed together to the commit phase. A TemplateResponse will
+// be created when the commit phase is initiated from ResponseWriter.WriteTemplate.
 type TemplateResponse struct {
 	Template *Template
 	Data     *interface{}

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -39,8 +39,7 @@ type Template interface {
 }
 
 // TemplateResponse bundles a Template with its data and names to function
-// mappings to be passed together to the commit phase. A TemplateResponse will
-// be created when the commit phase is initiated from ResponseWriter.WriteTemplate.
+// mappings to be passed together to the commit phase.
 type TemplateResponse struct {
 	Template *Template
 	Data     *interface{}

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -44,6 +44,7 @@ type Template interface {
 type TemplateResponse struct {
 	Template *Template
 	Data     *interface{}
+	FuncMap  map[string]interface{}
 }
 
 // NoContentResponse is sent to the commit phase when it's initiated from

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -132,7 +132,8 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	if w.written {
 		panic("ResponseWriter was already written to")
 	}
-	w.handler.commitPhase(w, TemplateResponse{Template: &t, Data: &data})
+	tr := TemplateResponse{Template: &t, Data: &data, FuncMap: map[string]interface{}{}}
+	w.handler.commitPhase(w, tr)
 	if w.written {
 		return Result{}
 	}
@@ -143,7 +144,7 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	}
 	w.rw.Header().Set("Content-Type", ct)
 	w.rw.WriteHeader(int(StatusOK))
-	if err := w.d.ExecuteTemplate(w.rw, t, data); err != nil {
+	if err := w.d.ExecuteTemplate(w.rw, t, data, tr.FuncMap); err != nil {
 		panic(err)
 	}
 	return Result{}
@@ -233,7 +234,7 @@ type Dispatcher interface {
 	//
 	// This should return an error if the provided Template response is not a
 	// valid template or if an error occurs executing or writing the template.
-	ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}) error
+	ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}, funcMap map[string]interface{}) error
 
 	// Content-Type returns the Content-Type of the provided response if it is
 	// of a type supported by the Dispatcher and should return an error

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -230,7 +230,9 @@ type Dispatcher interface {
 	WriteJSON(rw http.ResponseWriter, resp JSONResponse) error
 
 	// ExecuteTemplate applies a parsed template to the provided data object
-	// and writes the output to the http.ResponseWriter.
+	// and writes the output to the http.ResponseWriter. If the funcMap is
+	// non-nil, the Dispatcher will try to update the names to function mappings
+	// of the template.
 	//
 	// This should return an error if the provided Template response is not a
 	// valid template or if an error occurs executing or writing the template.

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -132,8 +132,8 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	if w.written {
 		panic("ResponseWriter was already written to")
 	}
-	tr := TemplateResponse{Template: &t, Data: &data, FuncMap: map[string]interface{}{}}
-	w.handler.commitPhase(w, tr)
+	resp := TemplateResponse{Template: &t, Data: &data, FuncMap: map[string]interface{}{}}
+	w.handler.commitPhase(w, resp)
 	if w.written {
 		return Result{}
 	}
@@ -144,7 +144,7 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	}
 	w.rw.Header().Set("Content-Type", ct)
 	w.rw.WriteHeader(int(StatusOK))
-	if err := w.d.ExecuteTemplate(w.rw, tr); err != nil {
+	if err := w.d.ExecuteTemplate(w.rw, resp); err != nil {
 		panic(err)
 	}
 	return Result{}

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -144,7 +144,7 @@ func (w *ResponseWriter) WriteTemplate(t Template, data interface{}) Result {
 	}
 	w.rw.Header().Set("Content-Type", ct)
 	w.rw.WriteHeader(int(StatusOK))
-	if err := w.d.ExecuteTemplate(w.rw, t, data, tr.FuncMap); err != nil {
+	if err := w.d.ExecuteTemplate(w.rw, tr); err != nil {
 		panic(err)
 	}
 	return Result{}
@@ -225,18 +225,19 @@ type Dispatcher interface {
 
 	// WriteJSON serialises and writes a JSON object to the http.ResponseWriter.
 	//
-	// This should return an error if the provided response is not a valid
+	// This should return an error if the provided response is not a safe
 	// JSONResponse  or if writing the object to the http.ResponseWriter fails.
 	WriteJSON(rw http.ResponseWriter, resp JSONResponse) error
 
-	// ExecuteTemplate applies a parsed template to the provided data object
-	// and writes the output to the http.ResponseWriter. If the funcMap is
-	// non-nil, the Dispatcher will try to update the names to function mappings
-	// of the template.
+	// ExecuteTemplate applies the response parsed template to its data object
+	// and writes the output to the http.ResponseWriter. If the response funcMap
+	// is non-nil, the Dispatcher will try to update the names to functions
+	// mappings of the template.
 	//
-	// This should return an error if the provided Template response is not a
-	// valid template or if an error occurs executing or writing the template.
-	ExecuteTemplate(rw http.ResponseWriter, t Template, data interface{}, funcMap map[string]interface{}) error
+	// This should return an error if the template contained by the
+	// TemplateResponse is not a safe template or if an error occurs executing
+	// or writing the template.
+	ExecuteTemplate(rw http.ResponseWriter, resp TemplateResponse) error
 
 	// Content-Type returns the Content-Type of the provided response if it is
 	// of a type supported by the Dispatcher and should return an error

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csp_test
+
+import (
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/plugins/csp"
+	"github.com/google/go-safeweb/safehttp/safehttptest"
+	safetemplate "github.com/google/safehtml/template"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestServeMuxInstallCsp(t *testing.T) {
+	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+	mux.Install(&csp.Interceptor{})
+
+	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		fns := map[string]interface{}{
+			"CSPNonce": func() string { return "WrongNonce" },
+		}
+		t := safetemplate.Must(safetemplate.New("name").Funcs(fns).Parse(`<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`))
+
+		return w.WriteTemplate(t, "Content")
+	})
+	mux.Handle("/bar", safehttp.MethodGet, handler)
+
+	b := strings.Builder{}
+	rr := safehttptest.NewTestResponseWriter(&b)
+
+	req := httptest.NewRequest(safehttp.MethodGet, "https://foo.com/bar", nil)
+
+	mux.ServeHTTP(rr, req)
+
+	if want := safehttp.StatusOK; rr.Status() != want {
+		t.Errorf("rr.Status() got: %v want: %v", rr.Status(), want)
+	}
+
+	if strings.Contains(b.String(), "WrongNonce") {
+		t.Errorf("response body: invalid csp nonce injected")
+	}
+
+}

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -36,6 +36,10 @@ func TestServeMuxInstallCSP(t *testing.T) {
 		fns := map[string]interface{}{
 			"CSPNonce": func() string { return "WrongNonce" },
 		}
+		// These are not used in the handler, just recorded to test whether the
+		// handler can retrieve the CSP nonce (e.g. for when the CSP plugin is
+		// installed, but auto-injection isn't yet supported and has to be done
+		// manually by the handler).
 		nonce, err = csp.Nonce(r.Context())
 		t := safetemplate.Must(safetemplate.New("name").Funcs(fns).Parse(`<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`))
 
@@ -52,6 +56,10 @@ func TestServeMuxInstallCSP(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("csp.Nonce: got error %v", err)
+	}
+
+	if nonce == "" {
+		t.Fatalf("csp.Nonce: got %q, want non-empty", nonce)
 	}
 
 	if want, got := rr.Status(), safehttp.StatusOK; got != want {

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 )
 
-func TestServeMuxInstallCsp(t *testing.T) {
+func TestServeMuxInstallCSP(t *testing.T) {
 	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
 	mux.Install(&csp.Interceptor{})
 

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -58,7 +58,9 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
 
 				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-					return w.WriteTemplate(safetemplate.Must(safetemplate.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+					return w.WriteTemplate(safetemplate.
+						Must(safetemplate.New("name").
+							Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 				})
 				mux.Handle("/pizza", safehttp.MethodGet, h)
 				return mux
@@ -134,7 +136,9 @@ func TestMuxDefaultDispatcherUnsafeResponses(t *testing.T) {
 				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
 
 				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-					return w.WriteTemplate(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+					return w.WriteTemplate(template.
+						Must(template.New("name").
+							Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 				})
 				mux.Handle("/pizza", safehttp.MethodGet, h)
 				return mux
@@ -194,7 +198,16 @@ func TestMuxWithCSPAndXSRFPlugin(t *testing.T) {
 			"XSRFToken": func() string { return "WrongToken" },
 			"CSPNonce":  func() string { return "WrongNonce" },
 		}
-		t := safetemplate.Must(safetemplate.New("name").Funcs(fns).Parse(`<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script><form><input type="hidden" name="token" value="{{XSRFToken}}">{{.}}</form>`))
+		t := safetemplate.Must(safetemplate.
+			New("name").Funcs(fns).
+			Parse(`
+			<script nonce="{{CSPNonce}}" type="application/javascript">
+			alert("script")
+			</script>
+			<form>
+			<input type="hidden" name="token" value="{{XSRFToken}}">{{.}}
+			</form>
+			`))
 
 		return w.WriteTemplate(t, "Content")
 	})

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -202,10 +202,10 @@ func TestMuxWithCSPAndXSRFPlugin(t *testing.T) {
 			New("name").Funcs(fns).
 			Parse(`
 			<script nonce="{{CSPNonce}}" type="application/javascript">
-			alert("script")
+				alert("script")
 			</script>
 			<form>
-			<input type="hidden" name="token" value="{{XSRFToken}}">{{.}}
+				<input type="hidden" name="token" value="{{XSRFToken}}">{{.}}
 			</form>
 			`))
 

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -17,6 +17,8 @@ package mux_test
 import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/plugins/csp"
+	"github.com/google/go-safeweb/safehttp/plugins/xsrf"
 	"github.com/google/go-safeweb/safehttp/safehttptest"
 	"github.com/google/safehtml"
 	safetemplate "github.com/google/safehtml/template"
@@ -179,5 +181,37 @@ func TestMuxDefaultDispatcherUnsafeResponses(t *testing.T) {
 				t.Errorf("response body: got %v, want %v", gotBody, wantBody)
 			}
 		})
+	}
+}
+
+func TestMuxWithCSPAndXSRFPlugin(t *testing.T) {
+	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+	mux.Install(&xsrf.Interceptor{SecretAppKey: "testSecretAppKey"})
+	mux.Install(&csp.Interceptor{})
+
+	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		fns := map[string]interface{}{
+			"XSRFToken": func() string { return "WrongToken" },
+			"CSPNonce":  func() string { return "WrongNonce" },
+		}
+		t := safetemplate.Must(safetemplate.New("name").Funcs(fns).Parse(`<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script><form><input type="hidden" name="token" value="{{XSRFToken}}">{{.}}</form>`))
+
+		return w.WriteTemplate(t, "Content")
+	})
+	mux.Handle("/bar", safehttp.MethodGet, handler)
+
+	b := strings.Builder{}
+	rr := safehttptest.NewTestResponseWriter(&b)
+
+	req := httptest.NewRequest(safehttp.MethodGet, "https://foo.com/bar", nil)
+
+	mux.ServeHTTP(rr, req)
+
+	if want := safehttp.StatusOK; rr.Status() != want {
+		t.Errorf("rr.Status() got: %v want: %v", rr.Status(), want)
+	}
+
+	if body := b.String(); strings.Contains(body, "WrongToken") || strings.Contains(body, "WrongNonce") {
+		t.Errorf("response body: incorrect html injection")
 	}
 }

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -35,6 +35,10 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 		fns := map[string]interface{}{
 			"XSRFToken": func() string { return "WrongToken" },
 		}
+		// These are not used in the handler, just recorded to test whether the
+		// handler can retrieve the XSRF token (e.g. for when the XSRF plugin is
+		// installed, but auto-injection isn't yet supported and has to be done
+		// manually by the handler).
 		token, err = xsrf.Token(r)
 		t := safetemplate.Must(safetemplate.New("name").Funcs(fns).Parse(`<form><input type="hidden" name="token" value="{{XSRFToken}}">{{.}}</form>`))
 
@@ -51,6 +55,10 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("xsrf.Token: got error %v", err)
+	}
+
+	if token == "" {
+		t.Fatalf("csp.Nonce: got %q, want non-empty", token)
 	}
 
 	if got, want := rr.Status(), safehttp.StatusOK; got != want {

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 )
 
-func TestServeMuxInstallXsrf(t *testing.T) {
+func TestServeMuxInstallXSRF(t *testing.T) {
 	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
 	mux.Install(&xsrf.Interceptor{SecretAppKey: "testSecretAppKey"})
 

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xsrf_test
+
+import (
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/plugins/xsrf"
+	"github.com/google/go-safeweb/safehttp/safehttptest"
+	safetemplate "github.com/google/safehtml/template"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestServeMuxInstallXsrf(t *testing.T) {
+	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{}, "foo.com")
+	mux.Install(&xsrf.Interceptor{SecretAppKey: "testSecretAppKey"})
+
+	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		fns := map[string]interface{}{
+			"XSRFToken": func() string { return "WrongToken" },
+		}
+		t := safetemplate.Must(safetemplate.New("name").Funcs(fns).Parse(`<form><input type="hidden" name="token" value="{{XSRFToken}}">{{.}}</form>`))
+
+		return w.WriteTemplate(t, "Content")
+	})
+	mux.Handle("/bar", safehttp.MethodGet, handler)
+
+	b := strings.Builder{}
+	rr := safehttptest.NewTestResponseWriter(&b)
+
+	req := httptest.NewRequest(safehttp.MethodGet, "https://foo.com/bar", nil)
+
+	mux.ServeHTTP(rr, req)
+
+	if want := safehttp.StatusOK; rr.Status() != want {
+		t.Errorf("rr.Status() got: %v want: %v", rr.Status(), want)
+	}
+
+	if strings.Contains(b.String(), "WrongToken") {
+		t.Errorf("response body: invalid xsrf token injected")
+	}
+
+}


### PR DESCRIPTION
Fixes #76 

Extended the `safehttp.TemplateResponse` to support adding elements to a function map. This will be executed before the template is parsed. The CSP nonce and XSRF Token values will be added to this map in the `xsrf.Commit` and `csp.Commit` phases.