### PR TITLE
Replace safehttp.Result{} with safehttp.NotWritten() in the repository

### DIFF
--- a/safehttp/mux_test.go
+++ b/safehttp/mux_test.go
@@ -406,7 +406,7 @@ func (p setHeaderConfigInterceptor) Before(w *safehttp.ResponseWriter, _ *safeht
 		value = c.value
 	}
 	w.Header().Set(name, value)
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }
 
 func (p setHeaderConfigInterceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {

--- a/safehttp/plugins/cors/cors.go
+++ b/safehttp/plugins/cors/cors.go
@@ -151,12 +151,12 @@ func (it *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 	if status == safehttp.StatusNoContent {
 		return w.NoContent()
 	}
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }
 
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
 func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }
 
 func appendToVary(w *safehttp.ResponseWriter, val string) {

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -212,10 +212,10 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	setCSP(CSPs)
 	setCSPReportOnly(reportCSPs)
 
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }
 
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
 func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -145,7 +145,7 @@ func (p *Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest,
 		// The request is targeted to an endpoint on which Fetch Metadata
 		// policies are disabled because it is CORS-protected so we don't apply
 		// the policies.
-		return safehttp.Result{}
+		return safehttp.NotWritten()
 	}
 
 	rejected := false
@@ -161,15 +161,15 @@ func (p *Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest,
 			p.Logger.Log(r)
 		}
 		if p.reportOnly {
-			return safehttp.Result{}
+			return safehttp.NotWritten()
 		}
 		return w.WriteError(safehttp.StatusForbidden)
 	}
 
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }
 
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
 func (p *Plugin) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -99,5 +99,5 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
 func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -40,5 +40,5 @@ func (Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, cf
 
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
 func (Plugin) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -140,5 +140,5 @@ func (i *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
 func (i *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg interface{}) safehttp.Result {
-	return safehttp.Result{}
+	return safehttp.NotWritten()
 }


### PR DESCRIPTION
Repository cleanup to only have `safehttp.NotWritten()` as return value not also `safehttp.Result{}`.