### PR TITLE
Rename the package name of the initial form parameters and query parameters test

### DIFF
--- a/tests/formparams/form_params_test.go
+++ b/tests/formparams/form_params_test.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package formparams provides tests to inspect the behaviour of form
+// Package formparams_test provides tests to inspect the behaviour of form
 // parameters parsing in HTTP requests.
-package formparams
+package formparams_test
 
 import (
 	"bytes"

--- a/tests/queryparams/query_params_test.go
+++ b/tests/queryparams/query_params_test.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package queryparams provides tests to inspect the behaviour of query
+// Package queryparams_test provides tests to inspect the behaviour of query
 // parameters parsing in HTTP requests.
-package queryparams
+package queryparams_test
 
 import (
 	"bytes"


### PR DESCRIPTION
Renamed the initial form parameters and query parameters test packages so they build when using Google internal tooling conventions. Otherwise, the build rules generated by running `glaze` will result in errors. This changes do not affect building the packages in the open-source.