### PR TITLE
Introducing ServeMuxBuilder

### DIFF
--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -164,8 +164,8 @@ type handlerRegistration struct {
 	cfgs    []InterceptorConfig
 }
 
-// Handle registers a handler for the given pattern and method. If another
-// handler is already registered for the same pattern and method, Handle panics.
+// Handle registers a handler for the given pattern and method. If a handler is
+// registered twice for the same pattern and method, Build will panic.
 //
 // InterceptorConfigs can be passed in order to modify the behavior of the
 // interceptors on a registered handler. Passing an InterceptorConfig whose

--- a/safehttp/plugins/hostcheck/hostcheck_test.go
+++ b/safehttp/plugins/hostcheck/hostcheck_test.go
@@ -46,16 +46,17 @@ func TestInterceptor(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
-			mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
-			mux.Install(hostcheck.New("foo.com"))
+			mb := &safehttp.ServeMuxBuilder{}
+			mb.Install(hostcheck.New("foo.com"))
 
 			h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 				return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 			})
-			mux.Handle("/", safehttp.MethodGet, h)
+			mb.Handle("/", safehttp.MethodGet, h)
 
 			b := &strings.Builder{}
 			rw := safehttptest.NewTestResponseWriter(b)
+			mux := mb.Build()
 			mux.ServeHTTP(rw, tt.req)
 
 			if rw.Status() != tt.wantStatus {

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 func TestServeMuxInstallCSP(t *testing.T) {
-	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+	mb := &safehttp.ServeMuxBuilder{}
 	it := csp.Default("")
-	mux.Install(&it)
+	mb.Install(&it)
 
 	var nonce string
 	var err error
@@ -46,13 +46,14 @@ func TestServeMuxInstallCSP(t *testing.T) {
 
 		return w.WriteTemplate(t, "Content")
 	})
-	mux.Handle("/bar", safehttp.MethodGet, handler)
+	mb.Handle("/bar", safehttp.MethodGet, handler)
 
 	b := strings.Builder{}
 	rr := safehttptest.NewTestResponseWriter(&b)
 
 	req := httptest.NewRequest(safehttp.MethodGet, "https://foo.com/bar", nil)
 
+	mux := mb.Build()
 	mux.ServeHTTP(rr, req)
 
 	if err != nil {

--- a/tests/integration/header/header_test.go
+++ b/tests/integration/header/header_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 func TestAccessIncomingHeaders(t *testing.T) {
-	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
-	mux.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
+	mb := &safehttp.ServeMuxBuilder{}
+	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
 		if got, want := ir.Header.Get("A"), "B"; got != want {
 			t.Errorf(`ir.Header.Get("A") got: %v want: %v`, got, want)
 		}
@@ -48,12 +48,13 @@ func TestAccessIncomingHeaders(t *testing.T) {
 	b := &strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(b)
 
+	mux := mb.Build()
 	mux.ServeHTTP(rw, req)
 }
 
 func TestChangingResponseHeaders(t *testing.T) {
-	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
-	mux.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
+	mb := &safehttp.ServeMuxBuilder{}
+	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
 		rw.Header().Set("pIZZA", "Pasta")
 		return rw.Write(safehtml.HTMLEscaped("hello"))
 	}))
@@ -63,6 +64,7 @@ func TestChangingResponseHeaders(t *testing.T) {
 	b := &strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(b)
 
+	mux := mb.Build()
 	mux.ServeHTTP(rw, req)
 
 	want := []string{"Pasta"}

--- a/tests/integration/hsts/hsts_test.go
+++ b/tests/integration/hsts/hsts_test.go
@@ -29,20 +29,20 @@ import (
 )
 
 func TestHSTSServeMuxInstall(t *testing.T) {
-	mux := safehttp.NewServeMux(&safehttp.DefaultDispatcher{})
+	mb := &safehttp.ServeMuxBuilder{}
 
-	mux.Install(hsts.Default())
+	mb.Install(hsts.Default())
 	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 	})
-	mux.Handle("/asdf", safehttp.MethodGet, handler)
+	mb.Handle("/asdf", safehttp.MethodGet, handler)
 
 	b := strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(&b)
 
 	req := httptest.NewRequest(http.MethodGet, "https://foo.com/asdf", nil)
 
-	mux.ServeHTTP(rw, req)
+	mb.Build().ServeHTTP(rw, req)
 
 	if want := safehttp.StatusOK; rw.Status() != want {
 		t.Errorf("rw.Status() got: %v want: %v", rw.Status(), want)

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -38,13 +38,13 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 		{
 			name: "Safe HTML Response",
 			mux: func() *safehttp.ServeMux {
-				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+				mb := &safehttp.ServeMuxBuilder{}
 
 				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 					return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 				})
-				mux.Handle("/pizza", safehttp.MethodGet, h)
-				return mux
+				mb.Handle("/pizza", safehttp.MethodGet, h)
+				return mb.Build()
 			}(),
 			wantHeaders: map[string][]string{
 				"Content-Type": {"text/html; charset=utf-8"},
@@ -54,15 +54,15 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 		{
 			name: "Safe HTML Template Response",
 			mux: func() *safehttp.ServeMux {
-				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+				mb := &safehttp.ServeMuxBuilder{}
 
 				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 					return w.WriteTemplate(safetemplate.
 						Must(safetemplate.New("name").
 							Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 				})
-				mux.Handle("/pizza", safehttp.MethodGet, h)
-				return mux
+				mb.Handle("/pizza", safehttp.MethodGet, h)
+				return mb.Build()
 			}(),
 			wantHeaders: map[string][]string{
 				"Content-Type": {"text/html; charset=utf-8"},
@@ -72,7 +72,7 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 		{
 			name: "Valid JSON Response",
 			mux: func() *safehttp.ServeMux {
-				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+				mb := &safehttp.ServeMuxBuilder{}
 
 				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 					data := struct {
@@ -80,8 +80,8 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 					}{Field: "myField"}
 					return w.WriteJSON(data)
 				})
-				mux.Handle("/pizza", safehttp.MethodGet, h)
-				return mux
+				mb.Handle("/pizza", safehttp.MethodGet, h)
+				return mb.Build()
 			}(),
 			wantHeaders: map[string][]string{
 				"Content-Type": {"application/json; charset=utf-8"},
@@ -120,39 +120,39 @@ func TestMuxDefaultDispatcherUnsafeResponses(t *testing.T) {
 		{
 			name: "Unsafe HTML Response",
 			mux: func() *safehttp.ServeMux {
-				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+				mb := &safehttp.ServeMuxBuilder{}
 
 				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 					return w.Write("<h1>Hello World!</h1>")
 				})
-				mux.Handle("/pizza", safehttp.MethodGet, h)
-				return mux
+				mb.Handle("/pizza", safehttp.MethodGet, h)
+				return mb.Build()
 			}(),
 		},
 		{
 			name: "Unsafe Template Response",
 			mux: func() *safehttp.ServeMux {
-				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+				mb := &safehttp.ServeMuxBuilder{}
 
 				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 					return w.WriteTemplate(template.
 						Must(template.New("name").
 							Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 				})
-				mux.Handle("/pizza", safehttp.MethodGet, h)
-				return mux
+				mb.Handle("/pizza", safehttp.MethodGet, h)
+				return mb.Build()
 			}(),
 		},
 		{
 			name: "Invalid JSON Response",
 			mux: func() *safehttp.ServeMux {
-				mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+				mb := &safehttp.ServeMuxBuilder{}
 
 				h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 					return w.WriteJSON(math.Inf(1))
 				})
-				mux.Handle("/pizza", safehttp.MethodGet, h)
-				return mux
+				mb.Handle("/pizza", safehttp.MethodGet, h)
+				return mb.Build()
 			}(),
 		},
 	}

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -15,10 +15,11 @@
 package safehtml_test
 
 import (
-	"github.com/google/go-safeweb/safehttp/safehttptest"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/google/go-safeweb/safehttp/safehttptest"
 
 	"github.com/google/go-safeweb/safehttp"
 	"github.com/google/safehtml"
@@ -26,8 +27,8 @@ import (
 )
 
 func TestHandleRequestWrite(t *testing.T) {
-	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
-	mux.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
+	mb := &safehttp.ServeMuxBuilder{}
+	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
 		return rw.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
 	}))
 
@@ -36,7 +37,7 @@ func TestHandleRequestWrite(t *testing.T) {
 	b := &strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(b)
 
-	mux.ServeHTTP(rw, req)
+	mb.Build().ServeHTTP(rw, req)
 
 	body := b.String()
 
@@ -46,8 +47,8 @@ func TestHandleRequestWrite(t *testing.T) {
 }
 
 func TestHandleRequestWriteTemplate(t *testing.T) {
-	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
-	mux.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
+	mb := &safehttp.ServeMuxBuilder{}
+	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
 		return rw.WriteTemplate(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 	}))
 
@@ -56,7 +57,7 @@ func TestHandleRequestWriteTemplate(t *testing.T) {
 	b := &strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(b)
 
-	mux.ServeHTTP(rw, req)
+	mb.Build().ServeHTTP(rw, req)
 
 	body := b.String()
 

--- a/tests/integration/staticheaders/staticheaders_test.go
+++ b/tests/integration/staticheaders/staticheaders_test.go
@@ -29,20 +29,20 @@ import (
 )
 
 func TestServeMuxInstallStaticHeaders(t *testing.T) {
-	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+	mb := &safehttp.ServeMuxBuilder{}
 
-	mux.Install(staticheaders.Interceptor{})
+	mb.Install(staticheaders.Interceptor{})
 	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 	})
-	mux.Handle("/asdf", safehttp.MethodGet, handler)
+	mb.Handle("/asdf", safehttp.MethodGet, handler)
 
 	b := strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(&b)
 
 	req := httptest.NewRequest(http.MethodGet, "https://foo.com/asdf", nil)
 
-	mux.ServeHTTP(rw, req)
+	mb.Build().ServeHTTP(rw, req)
 
 	if want := safehttp.StatusOK; rw.Status() != want {
 		t.Errorf("rw.Status() got: %v want: %v", rw.Status(), want)

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func TestServeMuxInstallXSRF(t *testing.T) {
-	mux := safehttp.NewServeMux(safehttp.DefaultDispatcher{})
+	mb := &safehttp.ServeMuxBuilder{}
 	it := xsrf.Interceptor{SecretAppKey: "testSecretAppKey"}
-	mux.Install(&it)
+	mb.Install(&it)
 
 	var token string
 	var err error
@@ -45,14 +45,14 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 
 		return w.WriteTemplate(t, "Content")
 	})
-	mux.Handle("/bar", safehttp.MethodGet, handler)
+	mb.Handle("/bar", safehttp.MethodGet, handler)
 
 	b := strings.Builder{}
 	rr := safehttptest.NewTestResponseWriter(&b)
 
 	req := httptest.NewRequest(safehttp.MethodGet, "https://foo.com/bar", nil)
 
-	mux.ServeHTTP(rr, req)
+	mb.Build().ServeHTTP(rr, req)
 
 	if err != nil {
 		t.Fatalf("xsrf.Token: got error %v", err)


### PR DESCRIPTION
Related issues: #117, #88.

This is the first draft of a `ServeMuxBuilder`. Right now it's just a thin wrapper that contains virtually no logic.

In the nearest future, `ServeMux` will be simplified and some of the logic will be moved into `ServeMuxBuilder` instead.