### PR TITLE
Allow the user to set a custom 1xx or 2xx status code in the safehttp.ResponseWriter

### DIFF
--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -99,7 +99,8 @@ func (w *ResponseWriter) SetStatusCode(statusCode StatusCode) {
 }
 
 // Write dispatches the response to the Dispatcher, setting the Content-Type and
-// response status if the provided response is a safe response. The
+// response status if the provided response is a safe response. The status code
+// will be set to safehttp.StatusOK unless a valid status code was provided. The
 // Dispatcher will then write the response to the underlying Response Writer.
 //
 // TODO: replace panics with proper error handling when getting the response
@@ -131,7 +132,8 @@ func (w *ResponseWriter) Write(resp Response) Result {
 
 // WriteJSON encapsulates data into a JSON response and dispatches it to the
 // Dispatcher, to be serialised and written to the ResponseWriter. It will also
-// set the Content-Type and response status will be set.
+// set the Content-Type and response status will be set. The status code
+// will be set to safehttp.StatusOK unless a valid status code was provided.
 //
 // TODO: replace panics with proper error handling when getting the response
 // Content-Type or writing the response fails.
@@ -164,7 +166,8 @@ func (w *ResponseWriter) WriteJSON(data interface{}) Result {
 // WriteTemplate dispatches a parsed template and a data object to the
 // Dispatcher to be executed and written to the underlying Response Writer, in
 // case the template is a safe HTML template. If it is a safe HTML Template, the
-// Content-Type  and response status will also be set.
+// Content-Type  and response status will also be set. The status code
+// will be set to safehttp.StatusOK unless a valid status code was provided.
 //
 // TODO: replace panics with proper error handling when getting the response
 // Content-Type or writing the response fails.

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -143,19 +143,10 @@ func TestResponseWriterStatusCode(t *testing.T) {
 			name: "Custom status code before calling write",
 			want: safehttp.StatusCreated,
 			write: func(w *safehttp.ResponseWriter) {
-				w.Code = safehttp.StatusCreated
+				w.SetStatusCode(safehttp.StatusCreated)
 				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
 			},
 		},
-		{
-			name: "Custom status code after calling write",
-			want: safehttp.StatusOK,
-			write: func(w *safehttp.ResponseWriter) {
-				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
-				w.Code = safehttp.StatusCreated
-			},
-		},
-
 		{
 			name: "No content status code",
 			want: safehttp.StatusNoContent,
@@ -175,9 +166,7 @@ func TestResponseWriterStatusCode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testRw := safehttptest.NewTestResponseWriter(&strings.Builder{})
 			w := safehttp.NewResponseWriter(safehttp.DefaultDispatcher{}, testRw, nil)
-
 			tt.write(w)
-
 			if got := testRw.Status(); tt.want != got {
 				t.Errorf("testRw.Status(): got %v want %v", got, tt.want)
 			}
@@ -193,22 +182,43 @@ func TestResponseWriterStatusCodePanic(t *testing.T) {
 		{
 			name: "Manual redirect status code set",
 			write: func(w *safehttp.ResponseWriter) {
-				w.Code = safehttp.StatusPermanentRedirect
+				w.SetStatusCode(safehttp.StatusPermanentRedirect)
 				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
 			},
 		},
 		{
 			name: "Manual error status code set",
 			write: func(w *safehttp.ResponseWriter) {
-				w.Code = safehttp.StatusBadRequest
+				w.SetStatusCode(safehttp.StatusBadRequest)
 				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
 			},
 		},
 		{
 			name: "Invalid status code set",
 			write: func(w *safehttp.ResponseWriter) {
-				w.Code = safehttp.StatusCode(50)
+				w.SetStatusCode(safehttp.StatusCode(50))
 				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
+			},
+		},
+		{
+			name: "Status code set after calling write",
+			write: func(w *safehttp.ResponseWriter) {
+				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
+				w.SetStatusCode(safehttp.StatusCreated)
+			},
+		},
+		{
+			name: "Status code set twice",
+			write: func(w *safehttp.ResponseWriter) {
+				w.SetStatusCode(safehttp.StatusCreated)
+				w.SetStatusCode(safehttp.StatusCreated)
+			},
+		},
+		{
+			name: "Status code set before writing a No Content response",
+			write: func(w *safehttp.ResponseWriter) {
+				w.SetStatusCode(safehttp.StatusCreated)
+				w.NoContent()
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #151

Previously, there was no way of setting a status code other than `safehttp.NoContent` as the write methods in the `safehttp.ResponseWriter` would  always set the status code to `safehttp.StatusOK`. Implemented initial functionality and tests to make this possible.