### PR TITLE
Improved naming for ServeMuxBuilder to make it more clear.

### DIFF
--- a/safehttp/plugins/hostcheck/hostcheck_test.go
+++ b/safehttp/plugins/hostcheck/hostcheck_test.go
@@ -46,8 +46,8 @@ func TestInterceptor(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
-			mb := &safehttp.ServeMuxBuilder{}
-			mb.Install(hostcheck.New("foo.com"))
+			mb := &safehttp.ServeMuxConfig{}
+			mb.Intercept(hostcheck.New("foo.com"))
 
 			h := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 				return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
@@ -56,7 +56,7 @@ func TestInterceptor(t *testing.T) {
 
 			b := &strings.Builder{}
 			rw := safehttptest.NewTestResponseWriter(b)
-			mux := mb.Build()
+			mux := mb.Mux()
 			mux.ServeHTTP(rw, tt.req)
 
 			if rw.Status() != tt.wantStatus {

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 func TestServeMuxInstallCSP(t *testing.T) {
-	mb := &safehttp.ServeMuxBuilder{}
+	mb := &safehttp.ServeMuxConfig{}
 	it := csp.Default("")
-	mb.Install(&it)
+	mb.Intercept(&it)
 
 	var nonce string
 	var err error
@@ -53,7 +53,7 @@ func TestServeMuxInstallCSP(t *testing.T) {
 
 	req := httptest.NewRequest(safehttp.MethodGet, "https://foo.com/bar", nil)
 
-	mux := mb.Build()
+	mux := mb.Mux()
 	mux.ServeHTTP(rr, req)
 
 	if err != nil {

--- a/tests/integration/header/header_test.go
+++ b/tests/integration/header/header_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestAccessIncomingHeaders(t *testing.T) {
-	mb := &safehttp.ServeMuxBuilder{}
+	mb := &safehttp.ServeMuxConfig{}
 	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
 		if got, want := ir.Header.Get("A"), "B"; got != want {
 			t.Errorf(`ir.Header.Get("A") got: %v want: %v`, got, want)
@@ -48,12 +48,12 @@ func TestAccessIncomingHeaders(t *testing.T) {
 	b := &strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(b)
 
-	mux := mb.Build()
+	mux := mb.Mux()
 	mux.ServeHTTP(rw, req)
 }
 
 func TestChangingResponseHeaders(t *testing.T) {
-	mb := &safehttp.ServeMuxBuilder{}
+	mb := &safehttp.ServeMuxConfig{}
 	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
 		rw.Header().Set("pIZZA", "Pasta")
 		return rw.Write(safehtml.HTMLEscaped("hello"))
@@ -64,7 +64,7 @@ func TestChangingResponseHeaders(t *testing.T) {
 	b := &strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(b)
 
-	mux := mb.Build()
+	mux := mb.Mux()
 	mux.ServeHTTP(rw, req)
 
 	want := []string{"Pasta"}

--- a/tests/integration/hsts/hsts_test.go
+++ b/tests/integration/hsts/hsts_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 func TestHSTSServeMuxInstall(t *testing.T) {
-	mb := &safehttp.ServeMuxBuilder{}
+	mb := &safehttp.ServeMuxConfig{}
 
-	mb.Install(hsts.Default())
+	mb.Intercept(hsts.Default())
 	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 	})
@@ -42,7 +42,7 @@ func TestHSTSServeMuxInstall(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "https://foo.com/asdf", nil)
 
-	mb.Build().ServeHTTP(rw, req)
+	mb.Mux().ServeHTTP(rw, req)
 
 	if want := safehttp.StatusOK; rw.Status() != want {
 		t.Errorf("rw.Status() got: %v want: %v", rw.Status(), want)

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -73,13 +73,13 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mb := &safehttp.ServeMuxBuilder{}
+			mb := &safehttp.ServeMuxConfig{}
 			mb.Handle("/pizza", safehttp.MethodGet, tt.handler)
 			req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/pizza", nil)
 			b := &strings.Builder{}
 			rw := safehttptest.NewTestResponseWriter(b)
 
-			mb.Build().ServeHTTP(rw, req)
+			mb.Mux().ServeHTTP(rw, req)
 
 			if wantStatus := safehttp.StatusOK; rw.Status() != wantStatus {
 				t.Errorf("rw.Status(): got %v want %v", rw.Status(), wantStatus)
@@ -132,9 +132,9 @@ func TestMuxDefaultDispatcherUnsafeResponses(t *testing.T) {
 			b := &strings.Builder{}
 			rw := safehttptest.NewTestResponseWriter(b)
 
-			mb := &safehttp.ServeMuxBuilder{}
+			mb := &safehttp.ServeMuxConfig{}
 			mb.Handle("/pizza", safehttp.MethodGet, tt.handler)
-			mux := mb.Build()
+			mux := mb.Mux()
 			mux.ServeHTTP(rw, req)
 
 			if wantStatus := safehttp.StatusInternalServerError; rw.Status() != wantStatus {

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestHandleRequestWrite(t *testing.T) {
-	mb := &safehttp.ServeMuxBuilder{}
+	mb := &safehttp.ServeMuxConfig{}
 	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
 		return rw.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
 	}))
@@ -37,7 +37,7 @@ func TestHandleRequestWrite(t *testing.T) {
 	b := &strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(b)
 
-	mb.Build().ServeHTTP(rw, req)
+	mb.Mux().ServeHTTP(rw, req)
 
 	body := b.String()
 
@@ -47,7 +47,7 @@ func TestHandleRequestWrite(t *testing.T) {
 }
 
 func TestHandleRequestWriteTemplate(t *testing.T) {
-	mb := &safehttp.ServeMuxBuilder{}
+	mb := &safehttp.ServeMuxConfig{}
 	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
 		return rw.WriteTemplate(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 	}))
@@ -57,7 +57,7 @@ func TestHandleRequestWriteTemplate(t *testing.T) {
 	b := &strings.Builder{}
 	rw := safehttptest.NewTestResponseWriter(b)
 
-	mb.Build().ServeHTTP(rw, req)
+	mb.Mux().ServeHTTP(rw, req)
 
 	body := b.String()
 

--- a/tests/integration/staticheaders/staticheaders_test.go
+++ b/tests/integration/staticheaders/staticheaders_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 func TestServeMuxInstallStaticHeaders(t *testing.T) {
-	mb := &safehttp.ServeMuxBuilder{}
+	mb := &safehttp.ServeMuxConfig{}
 
-	mb.Install(staticheaders.Interceptor{})
+	mb.Intercept(staticheaders.Interceptor{})
 	handler := safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
 		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
 	})
@@ -42,7 +42,7 @@ func TestServeMuxInstallStaticHeaders(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "https://foo.com/asdf", nil)
 
-	mb.Build().ServeHTTP(rw, req)
+	mb.Mux().ServeHTTP(rw, req)
 
 	if want := safehttp.StatusOK; rw.Status() != want {
 		t.Errorf("rw.Status() got: %v want: %v", rw.Status(), want)

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func TestServeMuxInstallXSRF(t *testing.T) {
-	mb := &safehttp.ServeMuxBuilder{}
+	mb := &safehttp.ServeMuxConfig{}
 	it := xsrf.Interceptor{SecretAppKey: "testSecretAppKey"}
-	mb.Install(&it)
+	mb.Intercept(&it)
 
 	var token string
 	var err error
@@ -52,7 +52,7 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 
 	req := httptest.NewRequest(safehttp.MethodGet, "https://foo.com/bar", nil)
 
-	mb.Build().ServeHTTP(rr, req)
+	mb.Mux().ServeHTTP(rr, req)
 
 	if err != nil {
 		t.Fatalf("xsrf.Token: got error %v", err)


### PR DESCRIPTION
`ServeMuxBuilder` is now `ServeMuxConfig`, and the API has telling names (e.g. `Build` is now a getter for the current `Mux`).