### PR TITLE
htmlinject: provide helpers to load safehtml.Templates

### DIFF
--- a/safehttp/plugins/htmlinject/htmlinject_test.go
+++ b/safehttp/plugins/htmlinject/htmlinject_test.go
@@ -75,7 +75,7 @@ Last name:<br>
 func BenchmarkTransform(b *testing.B) {
 	b.ReportAllocs()
 	var (
-		config = []Config{CSPNoncesDefault, XSRFTokensDefault}
+		config = []TransformConfig{CSPNoncesDefault, XSRFTokensDefault}
 		in     = `
 <html>
 <head>
@@ -243,7 +243,7 @@ h1 {
 func TestTransform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := []Config{}
+			cfg := []TransformConfig{}
 			if tt.csp {
 				cfg = append(cfg, CSPNoncesDefault)
 			}
@@ -265,7 +265,8 @@ func TestTransform(t *testing.T) {
 func TestLoadTrustedTemplateWithDefaultConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTpl, err := LoadTrustedTemplate(nil, tt.csp, tt.xsrf, uncheckedconversions.TrustedTemplateFromStringKnownToSatisfyTypeContract(tt.in))
+			cfg := LoadConfig{DisableCsp: !tt.csp, DisableXsrf: !tt.xsrf}
+			gotTpl, err := LoadTrustedTemplate(nil, cfg, uncheckedconversions.TrustedTemplateFromStringKnownToSatisfyTypeContract(tt.in))
 			if err != nil {
 				t.Fatalf("LoadTrustedTemplate: got err %q", err)
 			}
@@ -292,7 +293,7 @@ func TestLoadTrustedTemplateWithDefaultConfig(t *testing.T) {
 }
 
 func TestLoadGlob(t *testing.T) {
-	tpl, err := LoadGlob(nil, true, true, safetemplate.TrustedSourceFromConstant("testdata/*.tpl"))
+	tpl, err := LoadGlob(nil, LoadConfig{}, safetemplate.TrustedSourceFromConstant("testdata/*.tpl"))
 
 	// Test that whatever we provide is clonable or injection won't be possible.
 	tpl, err = tpl.Clone()

--- a/safehttp/plugins/htmlinject/testdata/first.tpl
+++ b/safehttp/plugins/htmlinject/testdata/first.tpl
@@ -1,0 +1,20 @@
+<html>
+<head>
+<link rel="stylesheet" href="styles.css">
+<link rel=preload as="script" src="gopher.js">
+<style>
+h1 {
+  border: 5px solid yellow;
+}
+</style>
+</head>
+<body>
+<script type="application/javascript">alert("script")</script>
+<form>
+  First name:<br>
+  <input type="text" name="firstname"><br>
+  Last name:<br>
+  <input type="text" name="lastname">
+</form>
+</body>
+</html>

--- a/safehttp/plugins/htmlinject/testdata/first.want
+++ b/safehttp/plugins/htmlinject/testdata/first.want
@@ -1,0 +1,20 @@
+<html>
+<head>
+<link rel="stylesheet" href="styles.css">
+<link nonce="{{CSPNonce}}" rel=preload as="script" src="gopher.js">
+<style nonce="{{CSPNonce}}">
+h1 {
+  border: 5px solid yellow;
+}
+</style>
+</head>
+<body>
+<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script>
+<form><input type="hidden" name="xsrf-token" value="{{XSRFToken}}">
+  First name:<br>
+  <input type="text" name="firstname"><br>
+  Last name:<br>
+  <input type="text" name="lastname">
+</form>
+</body>
+</html>

--- a/safehttp/plugins/htmlinject/testdata/second.tpl
+++ b/safehttp/plugins/htmlinject/testdata/second.tpl
@@ -1,0 +1,15 @@
+<html>
+<head>
+<link rel="stylesheet" href="styles.css">
+<link rel=preload as="script" src="gopher.js">
+</head>
+<body>
+<script type="application/javascript">alert("script")</script>
+<form>
+  First name:<br>
+  <input type="text" name="firstname"><br>
+  Last name:<br>
+  <input type="text" name="lastname">
+</form>
+</body>
+</html>

--- a/safehttp/plugins/htmlinject/testdata/second.want
+++ b/safehttp/plugins/htmlinject/testdata/second.want
@@ -1,0 +1,15 @@
+<html>
+<head>
+<link rel="stylesheet" href="styles.css">
+<link nonce="{{CSPNonce}}" rel=preload as="script" src="gopher.js">
+</head>
+<body>
+<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script>
+<form><input type="hidden" name="xsrf-token" value="{{XSRFToken}}">
+  First name:<br>
+  <input type="text" name="firstname"><br>
+  Last name:<br>
+  <input type="text" name="lastname">
+</form>
+</body>
+</html>


### PR DESCRIPTION
It was previously impossible to use htmlinject together with safehtml without an uncheckedconversion.

Depends on PR #197 
Fixes #173