### PR TITLE
Added the OnError method to the safehttp.Interceptor interface

### DIFF
--- a/safehttp/interceptor.go
+++ b/safehttp/interceptor.go
@@ -30,6 +30,11 @@ type Interceptor interface {
 	// is written to the ResponseWriter, then the Commit phases from the
 	// remaining interceptors won't execute.
 	Commit(w *ResponseWriter, r *IncomingRequest, resp Response, cfg InterceptorConfig) Result
+
+	// OnError runs when ResponseWriter.WriteError is called, before the
+	// actual error response is written. An attempt to write to the
+	// ResponseWriter in this phase will result in an irrecoverable error.
+	OnError(w *ResponseWriter, r *IncomingRequest, resp Response, cfg InterceptorConfig) Result
 }
 
 // InterceptorConfig is a configuration of an interceptor.

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -295,7 +295,7 @@ func (h handler) commitPhase(w *ResponseWriter, resp Response) {
 // ResponseWriter.
 //
 // TODO: BIG WARNING, if an interceptor attempts to write to the ResponseWriter
-// in the OnError phase then this method will recurse.
+// in the OnError phase will result in an irrecoverable error.
 func (h handler) errorPhase(w *ResponseWriter, resp Response) {
 	for i := len(h.interceps) - 1; i >= 0; i-- {
 		it := h.interceps[i]

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -289,3 +289,16 @@ func (h handler) commitPhase(w *ResponseWriter, resp Response) {
 		}
 	}
 }
+
+// errrorPhase calls the OnError phases of all the interceptors associated with
+// a handler. This stage runs before an error response is written to the
+// ResponseWriter.
+//
+// TODO: BIG WARNING, if an interceptor attempts to write to the ResponseWriter
+// in the OnError phase then this method will recurse.
+func (h handler) errorPhase(w *ResponseWriter, resp Response) {
+	for i := len(h.interceps) - 1; i >= 0; i-- {
+		it := h.interceps[i]
+		it.Interceptor.OnError(w, w.req, resp, it.Config)
+	}
+}

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -290,7 +290,7 @@ func (h handler) commitPhase(w *ResponseWriter, resp Response) {
 	}
 }
 
-// errrorPhase calls the OnError phases of all the interceptors associated with
+// errorPhase calls the OnError phases of all the interceptors associated with
 // a handler. This stage runs before an error response is written to the
 // ResponseWriter.
 //

--- a/safehttp/plugins/coop/coop.go
+++ b/safehttp/plugins/coop/coop.go
@@ -91,6 +91,9 @@ func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 }
 
 // OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+//
+// TODO: should OnError take as argument something that notifies it the commit
+// phase was already called?
 func (it Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
 	return safehttp.NotWritten()
 }

--- a/safehttp/plugins/coop/coop.go
+++ b/safehttp/plugins/coop/coop.go
@@ -85,8 +85,13 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	return safehttp.NotWritten()
 }
 
-// Commit does nothing.
-func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg safehttp.InterceptorConfig) safehttp.Result {
+// Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}
+
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (it Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
 	return safehttp.NotWritten()
 }
 

--- a/safehttp/plugins/cors/cors.go
+++ b/safehttp/plugins/cors/cors.go
@@ -168,6 +168,11 @@ func appendToVary(w *safehttp.ResponseWriter, val string) {
 	}
 }
 
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (it Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}
+
 // preflight handles requests that have the method OPTIONS.
 func (it *Interceptor) preflight(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.StatusCode {
 	rh := r.Header

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -238,3 +238,8 @@ func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	tmplResp.FuncMap["CSPNonce"] = func() string { return nonce }
 	return safehttp.NotWritten()
 }
+
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (it Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}

--- a/safehttp/plugins/fetch_metadata/fetch_metadata.go
+++ b/safehttp/plugins/fetch_metadata/fetch_metadata.go
@@ -173,3 +173,8 @@ func (p *Plugin) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest,
 func (p *Plugin) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
 	return safehttp.NotWritten()
 }
+
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (p *Plugin) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}

--- a/safehttp/plugins/hostcheck/hostcheck.go
+++ b/safehttp/plugins/hostcheck/hostcheck.go
@@ -54,3 +54,8 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 func (Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
 	return safehttp.NotWritten()
 }
+
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -116,3 +116,8 @@ func (it Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
 	return safehttp.NotWritten()
 }
+
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (it Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -54,3 +54,8 @@ func (Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingReques
 func (Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
 	return safehttp.NotWritten()
 }
+
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}

--- a/safehttp/plugins/xsrf/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrf.go
@@ -161,3 +161,8 @@ func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 	tmplResp.FuncMap["XSRFToken"] = func() string { return tok }
 	return safehttp.NotWritten()
 }
+
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (it *Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -15,7 +15,6 @@
 package safehttp
 
 import (
-	"github.com/google/go-safeweb/safehttp"
 	"io"
 )
 
@@ -53,7 +52,9 @@ type TemplateResponse struct {
 // ResponseWriter.NoContent.
 type NoContentResponse struct{}
 
-// ErrorResponse is sent to the on error phase when initiated from ResponseWriter.WriteError.
+// ErrorResponse is sent to the on error phase when initiated from
+// ResponseWriter.WriteError, encapsulating the status code with which the
+// method was called.
 type ErrorResponse struct {
-	code safehttp.StatusCode
+	Code StatusCode
 }

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -14,7 +14,10 @@
 
 package safehttp
 
-import "io"
+import (
+	"github.com/google/go-safeweb/safehttp"
+	"io"
+)
 
 // Response should encapsulate the data passed to the ResponseWriter to be
 // written by the Dispatcher. Any implementation of the interface should be
@@ -49,3 +52,8 @@ type TemplateResponse struct {
 // NoContentResponse is sent to the commit phase when it's initiated from
 // ResponseWriter.NoContent.
 type NoContentResponse struct{}
+
+// ErrorResponse is sent to the on error phase when initiated from ResponseWriter.WriteError.
+type ErrorResponse struct {
+	code safehttp.StatusCode
+}

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -172,7 +172,9 @@ func (w *ResponseWriter) NoContent() Result {
 // If the ResponseWriter has already been written to, then this method will panic.
 func (w *ResponseWriter) WriteError(code StatusCode) Result {
 	w.markWritten()
-	http.Error(w.rw, http.StatusText(int(code)), int(code))
+	resp := &ErrorResponse{code: code}
+	w.handler.errorPhase(w, resp)
+	http.Error(w.rw, http.StatusText(int(resp.code)), int(resp.code))
 	return Result{}
 }
 

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -166,15 +166,15 @@ func (w *ResponseWriter) NoContent() Result {
 	return Result{}
 }
 
-// WriteError writes an error response (400-599) according to the provided status
-// code.
+// WriteError writes an error response (400-599) according to the provided
+// status code.
 //
 // If the ResponseWriter has already been written to, then this method will panic.
 func (w *ResponseWriter) WriteError(code StatusCode) Result {
 	w.markWritten()
-	resp := &ErrorResponse{code: code}
+	resp := &ErrorResponse{Code: code}
 	w.handler.errorPhase(w, resp)
-	http.Error(w.rw, http.StatusText(int(resp.code)), int(resp.code))
+	http.Error(w.rw, http.StatusText(int(resp.Code)), int(resp.Code))
 	return Result{}
 }
 


### PR DESCRIPTION
Fixes #201 

The `OnError` method of all interceptors associated with a handler will be called in `safehttp.ResponseWriter.WriteError` before the error response is actually written.