### PR TITLE
ResponseWriter and Dispatcher now have a single Write method

### DIFF
--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -45,8 +45,7 @@ func (DefaultDispatcher) ContentType(resp Response) (string, error) {
 	}
 }
 
-// Write writes the response to the http.ResponseWriter if it's deemed safe.
-// A safe response is either safe HTML, a JSON object or safe HTML template. It
+// Write writes the response to the http.ResponseWriter if it's deemed safe. It
 // returns a non-nil error if the response is deemed unsafe or if the writing
 // operation fails.
 //

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -33,7 +33,7 @@ func (DefaultDispatcher) ContentType(resp Response) (string, error) {
 	case safehtml.HTML:
 		return "text/html; charset=utf-8", nil
 	case TemplateResponse:
-		_, ok := (*x.Template).(*template.Template)
+		_, ok := (x.Template).(*template.Template)
 		if !ok {
 			return "", fmt.Errorf("%T is not a safe response type, a Content-Type cannot be provided", resp)
 		}
@@ -55,7 +55,7 @@ func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
 		io.WriteString(rw, ")]}',\n") // Break parsing of JavaScript in order to prevent XSSI.
 		return json.NewEncoder(rw).Encode(x.Data)
 	case TemplateResponse:
-		t, ok := (*x.Template).(*template.Template)
+		t, ok := (x.Template).(*template.Template)
 		if !ok {
 			return fmt.Errorf("%T is not a safe template and it cannot be parsed and written", t)
 		}

--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -47,8 +47,16 @@ func (DefaultDispatcher) ContentType(resp Response) (string, error) {
 
 // Write writes the response to the http.ResponseWriter if it's deemed safe.
 // A safe response is either safe HTML, a JSON object or safe HTML template. It
-// will  return a non-nil error if the response is deemed unsafe or if writing
+// returns a non-nil error if the response is deemed unsafe or if the writing
 // operation fails.
+//
+// For JSONResponses, the underlying object is serialised and written if it's a
+// valid JSON.
+//
+// For TemplateResponses, the parsed template is applied to the provided data
+// object. If the funcMap is non-nil, its elements override the  existing names
+// to functions mappings in the template. An attempt to define a new name to
+// function mapping that is not already in the template will result  in a panic.
 func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
 	switch x := resp.(type) {
 	case JSONResponse:

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -51,7 +51,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
-				return d.Write(w, safehttp.NewTemplateResponse(t, data, nil))
+				return d.Write(w, safehttp.TemplateResp(t, data, nil))
 			},
 			wantBody: "<h1>This is an actual heading, though.</h1>",
 		},
@@ -69,7 +69,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				fm := map[string]interface{}{
 					"Token": func() string { return "Token-secret" },
 				}
-				return d.Write(w, safehttp.NewTemplateResponse(t, data, fm))
+				return d.Write(w, safehttp.TemplateResp(t, data, fm))
 			},
 			wantBody: `<form><input type="hidden" name="token" value="Token-secret">Content</form>`,
 		},
@@ -87,7 +87,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				fm := map[string]interface{}{
 					"Nonce": func() string { return "Nonce-secret" },
 				}
-				return d.Write(w, safehttp.NewTemplateResponse(t, data, fm))
+				return d.Write(w, safehttp.TemplateResp(t, data, fm))
 			},
 			wantBody: `<script nonce="Nonce-secret" type="application/javascript">alert("script")</script><h1>Content</h1>`,
 		},
@@ -98,7 +98,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				data := struct {
 					Field string `json:"field"`
 				}{Field: "myField"}
-				return d.Write(w, safehttp.NewJSONResponse(data))
+				return d.Write(w, safehttp.JSONResp(data))
 			},
 			wantBody: ")]}',\n{\"field\":\"myField\"}\n",
 		},
@@ -144,7 +144,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
-				return d.Write(w, safehttp.NewTemplateResponse(t, data, nil))
+				return d.Write(w, safehttp.TemplateResp(t, data, nil))
 			},
 			want: "",
 		},
@@ -152,7 +152,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 			name: "Invalid JSON Response",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				return d.Write(w, safehttp.NewJSONResponse(math.Inf(1)))
+				return d.Write(w, safehttp.JSONResp(math.Inf(1)))
 			},
 			want: ")]}',\n",
 		},

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -51,7 +51,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
-				return d.Write(w, safehttp.TemplateResp(t, data, nil))
+				return d.Write(w, safehttp.TemplateResponse{t, data, nil})
 			},
 			wantBody: "<h1>This is an actual heading, though.</h1>",
 		},
@@ -69,7 +69,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				fm := map[string]interface{}{
 					"Token": func() string { return "Token-secret" },
 				}
-				return d.Write(w, safehttp.TemplateResp(t, data, fm))
+				return d.Write(w, safehttp.TemplateResponse{t, data, fm})
 			},
 			wantBody: `<form><input type="hidden" name="token" value="Token-secret">Content</form>`,
 		},
@@ -87,7 +87,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				fm := map[string]interface{}{
 					"Nonce": func() string { return "Nonce-secret" },
 				}
-				return d.Write(w, safehttp.TemplateResp(t, data, fm))
+				return d.Write(w, safehttp.TemplateResponse{t, data, fm})
 			},
 			wantBody: `<script nonce="Nonce-secret" type="application/javascript">alert("script")</script><h1>Content</h1>`,
 		},
@@ -98,7 +98,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				data := struct {
 					Field string `json:"field"`
 				}{Field: "myField"}
-				return d.Write(w, safehttp.JSONResp(data))
+				return d.Write(w, safehttp.JSONResponse{data})
 			},
 			wantBody: ")]}',\n{\"field\":\"myField\"}\n",
 		},
@@ -144,7 +144,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
-				return d.Write(w, safehttp.TemplateResp(t, data, nil))
+				return d.Write(w, safehttp.TemplateResponse{t, data, nil})
 			},
 			want: "",
 		},
@@ -152,7 +152,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 			name: "Invalid JSON Response",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				return d.Write(w, safehttp.JSONResp(math.Inf(1)))
+				return d.Write(w, safehttp.JSONResponse{math.Inf(1)})
 			},
 			want: ")]}',\n",
 		},

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -51,11 +51,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
-				resp := safehttp.TemplateResponse{
-					Template: &t,
-					Data:     &data,
-				}
-				return d.ExecuteTemplate(w, resp)
+				return d.Write(w, safehttp.NewTemplateResponse(t, data, nil))
 			},
 			wantBody: "<h1>This is an actual heading, though.</h1>",
 		},
@@ -73,13 +69,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				fm := map[string]interface{}{
 					"Token": func() string { return "Token-secret" },
 				}
-				resp := safehttp.TemplateResponse{
-					Template: &t,
-					Data:     &data,
-					FuncMap:  fm,
-				}
-
-				return d.ExecuteTemplate(w, resp)
+				return d.Write(w, safehttp.NewTemplateResponse(t, data, fm))
 			},
 			wantBody: `<form><input type="hidden" name="token" value="Token-secret">Content</form>`,
 		},
@@ -97,13 +87,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				fm := map[string]interface{}{
 					"Nonce": func() string { return "Nonce-secret" },
 				}
-				resp := safehttp.TemplateResponse{
-					Template: &t,
-					Data:     &data,
-					FuncMap:  fm,
-				}
-
-				return d.ExecuteTemplate(w, resp)
+				return d.Write(w, safehttp.NewTemplateResponse(t, data, fm))
 			},
 			wantBody: `<script nonce="Nonce-secret" type="application/javascript">alert("script")</script><h1>Content</h1>`,
 		},
@@ -114,7 +98,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				data := struct {
 					Field string `json:"field"`
 				}{Field: "myField"}
-				return d.WriteJSON(w, safehttp.JSONResponse{Data: data})
+				return d.Write(w, safehttp.NewJSONResponse(data))
 			},
 			wantBody: ")]}',\n{\"field\":\"myField\"}\n",
 		},
@@ -160,11 +144,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
-				resp := safehttp.TemplateResponse{
-					Template: &t,
-					Data:     &data,
-				}
-				return d.ExecuteTemplate(w, resp)
+				return d.Write(w, safehttp.NewTemplateResponse(t, data, nil))
 			},
 			want: "",
 		},
@@ -172,7 +152,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 			name: "Invalid JSON Response",
 			write: func(w http.ResponseWriter) error {
 				d := &safehttp.DefaultDispatcher{}
-				return d.WriteJSON(w, safehttp.JSONResponse{Data: math.Inf(1)})
+				return d.Write(w, safehttp.NewJSONResponse(math.Inf(1)))
 			},
 			want: ")]}',\n",
 		},

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -59,20 +59,20 @@ type ErrorResponse struct {
 	Code StatusCode
 }
 
-// NewJSONResponse creates a JSON response from a data object. This should be a
+// JSONResp creates a JSONResponse from a data object. This should be a
 // valid JSON object that can be serialised and written to the
 // http.ResponseWriter using a JSON encoder.
-func NewJSONResponse(data interface{}) JSONResponse {
+func JSONResp(data interface{}) JSONResponse {
 	return JSONResponse{Data: data}
 }
 
-// NewTemplateResponse creates a TemplateResponse from a Template, its data and
+// TemplateResp creates a TemplateResponse from a Template, its data and
 // the name to function mappings. These will be pre-processed and then written
 // to the http.ResponseWriter, if deemed safe. If the funcMap is non-nil, its
 // elements will override the existing name to function mappings in the
 // template. An attempt to define a new name to function mapping that is not
 // already in the template will result in a panic.
-func NewTemplateResponse(t Template, data interface{}, funcMap map[string]interface{}) TemplateResponse {
+func TemplateResp(t Template, data interface{}, funcMap map[string]interface{}) TemplateResponse {
 	return TemplateResponse{
 		Template: &t,
 		Data:     &data,

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -29,6 +29,13 @@ type JSONResponse struct {
 	Data interface{}
 }
 
+// WriteJSON creates a JSONResponse from the data object and calls the Write
+// function of the ResponseWriter, passing the response. The data object should
+// be valid JSON, otherwise an error will occur.
+func WriteJSON(w *ResponseWriter, data interface{}) Result {
+	return w.Write(JSONResponse{data})
+}
+
 // Template implements a template.
 type Template interface {
 	// Execute applies data to the template and then writes the result to
@@ -48,6 +55,20 @@ type TemplateResponse struct {
 	FuncMap  map[string]interface{}
 }
 
+// ExecuteTemplate creates a TemplateResponse from the provided Template and its
+// data and calls the Write function of the ResponseWriter, passing the
+// response.
+func ExecuteTemplate(w *ResponseWriter, t Template, data interface{}) Result {
+	return w.Write(TemplateResponse{t, data, nil})
+}
+
+// ExecuteTemplateWithFuncs creates a TemplateResponse from the provided
+// Template, its data and the name to function mappings and calls the Write
+// function of the ResponseWriter, passing the response.
+func ExecuteTemplateWithFuncs(w *ResponseWriter, t Template, data interface{}, fm map[string]interface{}) Result {
+	return w.Write(TemplateResponse{t, data, fm})
+}
+
 // NoContentResponse is sent to the commit phase when it's initiated from
 // ResponseWriter.NoContent.
 type NoContentResponse struct{}
@@ -57,25 +78,4 @@ type NoContentResponse struct{}
 // method was called.
 type ErrorResponse struct {
 	Code StatusCode
-}
-
-// JSONResp creates a JSONResponse from a data object. This should be a
-// valid JSON object that can be serialised and written to the
-// http.ResponseWriter using a JSON encoder.
-func JSONResp(data interface{}) JSONResponse {
-	return JSONResponse{Data: data}
-}
-
-// TemplateResp creates a TemplateResponse from a Template, its data and
-// the name to function mappings. These will be pre-processed and then written
-// to the http.ResponseWriter, if deemed safe. If the funcMap is non-nil, its
-// elements will override the existing name to function mappings in the
-// template. An attempt to define a new name to function mapping that is not
-// already in the template will result in a panic.
-func TemplateResp(t Template, data interface{}, funcMap map[string]interface{}) TemplateResponse {
-	return TemplateResponse{
-		Template: t,
-		Data:     data,
-		FuncMap:  funcMap,
-	}
 }

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -58,3 +58,24 @@ type NoContentResponse struct{}
 type ErrorResponse struct {
 	Code StatusCode
 }
+
+// NewJSONResponse creates a JSON response from a data object. This should be a
+// valid JSON object that can be serialised and written to the
+// http.ResponseWriter using a JSON encoder.
+func NewJSONResponse(data interface{}) JSONResponse {
+	return JSONResponse{Data: data}
+}
+
+// NewTemplateResponse creates a TemplateResponse from a Template, its data and
+// the name to function mappings. These will be pre-processed and then written
+// to the http.ResponseWriter, if deemed safe. If the funcMap is non-nil, its
+// elements will override the existing name to function mappings in the
+// template. An attempt to define a new name to function mapping that is not
+// already in the template will result in a panic.
+func NewTemplateResponse(t Template, data interface{}, funcMap map[string]interface{}) TemplateResponse {
+	return TemplateResponse{
+		Template: &t,
+		Data:     &data,
+		FuncMap:  funcMap,
+	}
+}

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -43,8 +43,8 @@ type Template interface {
 // TemplateResponse bundles a Template with its data and names to function
 // mappings to be passed together to the commit phase.
 type TemplateResponse struct {
-	Template *Template
-	Data     *interface{}
+	Template Template
+	Data     interface{}
 	FuncMap  map[string]interface{}
 }
 
@@ -74,8 +74,8 @@ func JSONResp(data interface{}) JSONResponse {
 // already in the template will result in a panic.
 func TemplateResp(t Template, data interface{}, funcMap map[string]interface{}) TemplateResponse {
 	return TemplateResponse{
-		Template: &t,
-		Data:     &data,
+		Template: t,
+		Data:     data,
 		FuncMap:  funcMap,
 	}
 }

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -95,9 +95,10 @@ func TestResponseWriterWriteTwicePanic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := safehttp.NewResponseWriter(safehttp.DefaultDispatcher{}, safehttptest.NewTestResponseWriter(&strings.Builder{}), nil)
 			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("tt.write(w) expected panic")
+				if r := recover(); r != nil {
+					return
 				}
+				t.Errorf("tt.write(w) expected panic")
 			}()
 			tt.write(w)
 		})
@@ -118,15 +119,15 @@ func TestResponseWriterUnsafeResponse(t *testing.T) {
 		{
 			name: "Invalid JSON Response",
 			write: func(w *safehttp.ResponseWriter) {
-				w.Write(safehttp.JSONResp(math.Inf(1)))
+				safehttp.WriteJSON(w, math.Inf(1))
 			},
 		},
 		{
 			name: "Unsafe Template Response",
 			write: func(w *safehttp.ResponseWriter) {
-				w.Write(safehttp.TemplateResp(template.
+				safehttp.ExecuteTemplate(w, template.
 					Must(template.New("name").
-						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
+						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 			},
 		},
 	}

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -118,13 +118,13 @@ func TestResponseWriterUnsafeResponse(t *testing.T) {
 		{
 			name: "Invalid JSON Response",
 			write: func(w *safehttp.ResponseWriter) {
-				w.Write(safehttp.NewJSONResponse(math.Inf(1)))
+				w.Write(safehttp.JSONResp(math.Inf(1)))
 			},
 		},
 		{
 			name: "Unsafe Template Response",
 			write: func(w *safehttp.ResponseWriter) {
-				w.Write(safehttp.NewTemplateResponse(template.
+				w.Write(safehttp.TemplateResp(template.
 					Must(template.New("name").
 						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
 			},

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -44,7 +44,7 @@ func TestServeMuxInstallCSP(t *testing.T) {
 		nonce, err = csp.Nonce(r.Context())
 		t := template.Must(template.New("name").Funcs(fns).Parse(`<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`))
 
-		return w.WriteTemplate(t, "Content")
+		return w.Write(safehttp.NewTemplateResponse(t, "Content", fns))
 	})
 	mb.Handle("/bar", safehttp.MethodGet, handler)
 

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -44,7 +44,7 @@ func TestServeMuxInstallCSP(t *testing.T) {
 		nonce, err = csp.Nonce(r.Context())
 		t := template.Must(template.New("name").Funcs(fns).Parse(`<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`))
 
-		return w.Write(safehttp.NewTemplateResponse(t, "Content", fns))
+		return w.Write(safehttp.TemplateResp(t, "Content", fns))
 	})
 	mb.Handle("/bar", safehttp.MethodGet, handler)
 

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -44,7 +44,7 @@ func TestServeMuxInstallCSP(t *testing.T) {
 		nonce, err = csp.Nonce(r.Context())
 		t := template.Must(template.New("name").Funcs(fns).Parse(`<script nonce="{{CSPNonce}}" type="application/javascript">alert("script")</script><h1>{{.}}</h1>`))
 
-		return w.Write(safehttp.TemplateResp(t, "Content", fns))
+		return safehttp.ExecuteTemplateWithFuncs(w, t, "Content", fns)
 	})
 	mb.Handle("/bar", safehttp.MethodGet, handler)
 

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -48,9 +48,9 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 		{
 			name: "Safe HTML Template Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.Write(safehttp.TemplateResp(safetemplate.
+				return safehttp.ExecuteTemplate(w, safetemplate.
 					Must(safetemplate.New("name").
-						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
+						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 			}),
 			wantHeaders: map[string][]string{
 				"Content-Type": {"text/html; charset=utf-8"},
@@ -63,7 +63,7 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 				data := struct {
 					Field string `json:"field"`
 				}{Field: "myField"}
-				return w.Write(safehttp.JSONResp(data))
+				return safehttp.WriteJSON(w, data)
 			}),
 			wantHeaders: map[string][]string{
 				"Content-Type": {"application/json; charset=utf-8"},
@@ -110,15 +110,15 @@ func TestMuxDefaultDispatcherUnsafeResponses(t *testing.T) {
 		{
 			name: "Unsafe Template Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.Write(safehttp.TemplateResp(template.
+				return safehttp.ExecuteTemplate(w, template.
 					Must(template.New("name").
-						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
+						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 			}),
 		},
 		{
 			name: "Invalid JSON Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.Write(safehttp.JSONResp(math.Inf(1)))
+				return safehttp.WriteJSON(w, math.Inf(1))
 			}),
 		},
 	}

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -48,9 +48,9 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 		{
 			name: "Safe HTML Template Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.WriteTemplate(safetemplate.
+				return w.Write(safehttp.NewTemplateResponse(safetemplate.
 					Must(safetemplate.New("name").
-						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
 			}),
 			wantHeaders: map[string][]string{
 				"Content-Type": {"text/html; charset=utf-8"},
@@ -63,7 +63,7 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 				data := struct {
 					Field string `json:"field"`
 				}{Field: "myField"}
-				return w.WriteJSON(data)
+				return w.Write(safehttp.NewJSONResponse(data))
 			}),
 			wantHeaders: map[string][]string{
 				"Content-Type": {"application/json; charset=utf-8"},
@@ -110,15 +110,15 @@ func TestMuxDefaultDispatcherUnsafeResponses(t *testing.T) {
 		{
 			name: "Unsafe Template Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.WriteTemplate(template.
+				return w.Write(safehttp.NewTemplateResponse(template.
 					Must(template.New("name").
-						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
 			}),
 		},
 		{
 			name: "Invalid JSON Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.WriteJSON(math.Inf(1))
+				return w.Write(safehttp.NewJSONResponse(math.Inf(1)))
 			}),
 		},
 	}

--- a/tests/integration/mux/mux_test.go
+++ b/tests/integration/mux/mux_test.go
@@ -48,7 +48,7 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 		{
 			name: "Safe HTML Template Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.Write(safehttp.NewTemplateResponse(safetemplate.
+				return w.Write(safehttp.TemplateResp(safetemplate.
 					Must(safetemplate.New("name").
 						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
 			}),
@@ -63,7 +63,7 @@ func TestMuxDefaultDispatcher(t *testing.T) {
 				data := struct {
 					Field string `json:"field"`
 				}{Field: "myField"}
-				return w.Write(safehttp.NewJSONResponse(data))
+				return w.Write(safehttp.JSONResp(data))
 			}),
 			wantHeaders: map[string][]string{
 				"Content-Type": {"application/json; charset=utf-8"},
@@ -110,7 +110,7 @@ func TestMuxDefaultDispatcherUnsafeResponses(t *testing.T) {
 		{
 			name: "Unsafe Template Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.Write(safehttp.NewTemplateResponse(template.
+				return w.Write(safehttp.TemplateResp(template.
 					Must(template.New("name").
 						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
 			}),
@@ -118,7 +118,7 @@ func TestMuxDefaultDispatcherUnsafeResponses(t *testing.T) {
 		{
 			name: "Invalid JSON Response",
 			handler: safehttp.HandlerFunc(func(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-				return w.Write(safehttp.NewJSONResponse(math.Inf(1)))
+				return w.Write(safehttp.JSONResp(math.Inf(1)))
 			}),
 		},
 	}

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -49,7 +49,7 @@ func TestHandleRequestWrite(t *testing.T) {
 func TestHandleRequestWriteTemplate(t *testing.T) {
 	mb := &safehttp.ServeMuxConfig{}
 	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
-		return rw.Write(safehttp.TemplateResp(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
+		return safehttp.ExecuteTemplate(rw, template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 	}))
 
 	req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/", nil)

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -49,7 +49,7 @@ func TestHandleRequestWrite(t *testing.T) {
 func TestHandleRequestWriteTemplate(t *testing.T) {
 	mb := &safehttp.ServeMuxConfig{}
 	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
-		return rw.Write(safehttp.NewTemplateResponse(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
+		return rw.Write(safehttp.TemplateResp(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
 	}))
 
 	req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/", nil)

--- a/tests/integration/safehtml/safehtml_test.go
+++ b/tests/integration/safehtml/safehtml_test.go
@@ -49,7 +49,7 @@ func TestHandleRequestWrite(t *testing.T) {
 func TestHandleRequestWriteTemplate(t *testing.T) {
 	mb := &safehttp.ServeMuxConfig{}
 	mb.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(func(rw *safehttp.ResponseWriter, ir *safehttp.IncomingRequest) safehttp.Result {
-		return rw.WriteTemplate(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+		return rw.Write(safehttp.NewTemplateResponse(template.Must(template.New("name").Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.", nil))
 	}))
 
 	req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/", nil)

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -43,7 +43,7 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 		token, err = xsrf.Token(r)
 		t := template.Must(template.New("name").Funcs(fns).Parse(`<form><input type="hidden" name="token" value="{{XSRFToken}}">{{.}}</form>`))
 
-		return w.Write(safehttp.NewTemplateResponse(t, "Content", fns))
+		return w.Write(safehttp.TemplateResp(t, "Content", fns))
 	})
 	mb.Handle("/bar", safehttp.MethodGet, handler)
 

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -43,7 +43,7 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 		token, err = xsrf.Token(r)
 		t := template.Must(template.New("name").Funcs(fns).Parse(`<form><input type="hidden" name="token" value="{{XSRFToken}}">{{.}}</form>`))
 
-		return w.WriteTemplate(t, "Content")
+		return w.Write(safehttp.NewTemplateResponse(t, "Content", fns))
 	})
 	mb.Handle("/bar", safehttp.MethodGet, handler)
 

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -43,7 +43,7 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 		token, err = xsrf.Token(r)
 		t := template.Must(template.New("name").Funcs(fns).Parse(`<form><input type="hidden" name="token" value="{{XSRFToken}}">{{.}}</form>`))
 
-		return w.Write(safehttp.TemplateResp(t, "Content", fns))
+		return safehttp.ExecuteTemplateWithFuncs(w, t, "Content", fns)
 	})
 	mb.Handle("/bar", safehttp.MethodGet, handler)
 


### PR DESCRIPTION
Fixes #150 

Unified the functionality of `WriteJSON`, `ExecuteTemplate` and `Write` inside the new `safehttp.DefaultDispatcher.Write` method, also responsible for setting the `Content-Type` header and writing the status code.