### PR TITLE
XSRF plugin for Angular

### DIFF
--- a/safehttp/plugins/angular_xsrf/angular_xsrf.go
+++ b/safehttp/plugins/angular_xsrf/angular_xsrf.go
@@ -112,3 +112,8 @@ func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 	}
 	return safehttp.NotWritten()
 }
+
+// OnError is a no-op, required to satisfy the safehttp.Interceptor interface.
+func (it *Interceptor) OnError(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+	return safehttp.NotWritten()
+}

--- a/safehttp/plugins/angular_xsrf/angular_xsrf.go
+++ b/safehttp/plugins/angular_xsrf/angular_xsrf.go
@@ -1,0 +1,114 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xsrf provides a safehttp.Interceptor that ensures Cross-Site Request
+// Forgery protection by verifying the incoming requests, rejecting those
+// requests that are suspected to be part of an attack.
+package angularxsrf
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"github.com/google/go-safeweb/safehttp"
+)
+
+var statePreservingMethods = map[string]bool{
+	safehttp.MethodGet:     true,
+	safehttp.MethodHead:    true,
+	safehttp.MethodOptions: true,
+}
+
+// Interceptor provides protection against Cross-Site Request Forgery attacks
+// for Angular's XHR requests.
+//
+// See https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection for more details.
+type Interceptor struct {
+	// TokenCookieName is the name of the seesion cookie that holds the XSRF
+	// token. In order to prevent collisions when multiple applications share
+	// the same domain or subdomain, each application should set a unique name
+	// for the cookie.
+	TokenCookieName string
+	// TokenHeaderName is the name of the HTTP header that also holds the XSRF
+	// token.
+	TokenHeaderName string
+}
+
+// Before should be executed before directing the safehttp.IncomingRequest to
+// the handler to ensure it is not part of a Cross-Site Request Forgery attacks.
+//
+// It will check for the presence of a matching XSRF token, generated on the
+// first page access, in both a cookie and a header. Their names should be set
+// when the Interceptor is created.
+func (it *Interceptor) Before(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, _ safehttp.InterceptorConfig) safehttp.Result {
+	c, err := r.Cookie(it.TokenCookieName)
+	if err != nil {
+		if !statePreservingMethods[r.Method()] {
+			return w.WriteError(safehttp.StatusForbidden)
+		}
+		return safehttp.NotWritten()
+	}
+
+	tok := r.Header.Get(it.TokenHeaderName)
+	if tok == "" || tok != c.Value() {
+		return w.WriteError(safehttp.StatusUnauthorized)
+	}
+
+	return safehttp.NotWritten()
+}
+
+func (it *Interceptor) addAngularTokenCookie(w *safehttp.ResponseWriter) error {
+	tok := make([]byte, 20)
+	if _, err := rand.Read(tok); err != nil {
+		return fmt.Errorf("crypto/rand.Read: %v", err)
+	}
+	c := safehttp.NewCookie(it.TokenCookieName, base64.StdEncoding.EncodeToString(tok))
+
+	c.SetSameSite(safehttp.SameSiteStrictMode)
+	c.SetPath("/")
+	// Set the duration of the token cookie to 24 hours.
+	c.SetMaxAge(86400)
+	// Needed in order to make the cookie accessible by JavaScript
+	// running on the user's domain.
+	c.DisableHTTPOnly()
+
+	if err := w.SetCookie(c); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Commit generates a cryptographically random cookie on the first state
+// preserving request (GET, HEAD or OPTION) and sets it in the response. On
+// every subsequent request the cookie is expected alongside a header that
+// matches its value.
+func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) safehttp.Result {
+
+	_, err := r.Cookie(it.TokenCookieName)
+	if err == nil {
+		return safehttp.NotWritten()
+	}
+
+	if !statePreservingMethods[r.Method()] {
+		return w.WriteError(safehttp.StatusForbidden)
+	}
+
+	err = it.addAngularTokenCookie(w)
+	if err != nil {
+		// A 500 error is returned when the plugin fails to set the Set-Cookie
+		// header in the response writer as this is a server misconfiguration.
+		return w.WriteError(safehttp.StatusInternalServerError)
+	}
+	return safehttp.NotWritten()
+}

--- a/safehttp/plugins/angular_xsrf/angular_xsrf_test.go
+++ b/safehttp/plugins/angular_xsrf/angular_xsrf_test.go
@@ -1,0 +1,147 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xsrf provides a safehttp.Interceptor that ensures Cross-Site Request
+// Forgery protection by verifying the incoming requests, rejecting those
+// requests that are suspected to be part of an attack.
+package angularxsrf
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/safehttptest"
+	"strings"
+	"testing"
+)
+
+const (
+	cookieName = "XSRF-TOKEN"
+	headerName = "X-XSRF-TOKEN"
+)
+
+func TestAngularAddCookie(t *testing.T) {
+	req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+	rec := safehttptest.NewResponseRecorder()
+	i := &Interceptor{
+		TokenCookieName: cookieName,
+		TokenHeaderName: headerName,
+	}
+	i.Commit(rec.ResponseWriter, req, nil, nil)
+
+	if got, want := rec.Status(), safehttp.StatusOK; got != want {
+		t.Errorf("rec.Status(): got %v, want %v", got, want)
+	}
+
+	tokCookieDefaults := "Path=/; Max-Age=86400; Secure; SameSite=Strict"
+	got := map[string][]string(rec.Header())["Set-Cookie"][0]
+	if !strings.Contains(got, i.TokenCookieName) {
+		t.Errorf("Set-Cookie header: %s not present", i.TokenCookieName)
+	}
+	if !strings.Contains(got, tokCookieDefaults) {
+		t.Errorf("Set-Cookie header: got %s, want defaults %s", got, tokCookieDefaults)
+	}
+
+	if got, want := rec.Body(), ""; got != want {
+		t.Errorf("rec.Body(): got %q want %q", got, want)
+	}
+}
+
+func TestAngularPostProtection(t *testing.T) {
+	tests := []struct {
+		name       string
+		req        *safehttp.IncomingRequest
+		wantStatus safehttp.StatusCode
+		wantHeader map[string][]string
+		wantBody   string
+	}{
+		{
+			name: "Same cookie and header",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest(safehttp.MethodPost, "/", nil)
+				req.Header.Set("Cookie", cookieName+"="+"1234")
+				req.Header.Set(headerName, "1234")
+				return req
+			}(),
+			wantStatus: safehttp.StatusOK,
+			wantHeader: map[string][]string{},
+			wantBody:   "",
+		},
+		{
+			name: "Different cookie and header",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest(safehttp.MethodPost, "/", nil)
+				req.Header.Set("Cookie", cookieName+"="+"5768")
+				req.Header.Set(headerName, "1234")
+				return req
+			}(),
+			wantStatus: safehttp.StatusUnauthorized,
+			wantHeader: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Unauthorized\n",
+		},
+		{
+			name: "Missing header",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest(safehttp.MethodPost, "/", nil)
+				req.Header.Set("Cookie", cookieName+"="+"1234")
+				return req
+			}(),
+			wantStatus: safehttp.StatusUnauthorized,
+			wantHeader: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Unauthorized\n",
+		},
+		{
+			name: "Missing cookie",
+			req: func() *safehttp.IncomingRequest {
+				req := safehttptest.NewRequest(safehttp.MethodPost, "/", nil)
+				req.Header.Set(headerName, "1234")
+				return req
+			}(),
+			wantStatus: safehttp.StatusForbidden,
+			wantHeader: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+			wantBody: "Forbidden\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := safehttptest.NewResponseRecorder()
+			i := &Interceptor{
+				TokenCookieName: cookieName,
+				TokenHeaderName: headerName,
+			}
+			i.Before(rec.ResponseWriter, test.req, nil)
+
+			if got := rec.Status(); got != test.wantStatus {
+				t.Errorf("rec.Status(): got %v, want %v", got, test.wantStatus)
+			}
+
+			if diff := cmp.Diff(test.wantHeader, map[string][]string(rec.Header())); diff != "" {
+				t.Errorf("rec.Header() mismatch (-want +got):\n%s", diff)
+			}
+
+			if got := rec.Body(); got != test.wantBody {
+				t.Errorf("rec.Body(): got %q want %q", got, test.wantBody)
+			}
+		})
+	}
+}

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -26,6 +26,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/google/go-safeweb/safehttp/plugins/htmlinject"
 	"strings"
 
 	"github.com/google/go-safeweb/safehttp"
@@ -235,7 +236,7 @@ func (it Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingReq
 	// htmlinject
 	// TODO: What should happen if the CSPNonce is not present in the
 	// tr.FuncMap?
-	tmplResp.FuncMap["CSPNonce"] = func() string { return nonce }
+	tmplResp.FuncMap[htmlinject.CSPNoncesDefaultFuncName] = func() string { return nonce }
 	return safehttp.NotWritten()
 }
 

--- a/safehttp/plugins/xsrf/angular/doc.go
+++ b/safehttp/plugins/xsrf/angular/doc.go
@@ -12,21 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package xsrf contains helper functions for the safehttp.Interceptor that
-// provide protection against Cross-Site Request Forgery attacks.
-package xsrf
-
-import (
-	"github.com/google/go-safeweb/safehttp"
-)
-
-var statePreservingMethods = map[string]bool{
-	safehttp.MethodGet:     true,
-	safehttp.MethodHead:    true,
-	safehttp.MethodOptions: true,
-}
-
-// StatePreserving checks if the provided request is state preserving.
-func StatePreserving(r *safehttp.IncomingRequest) bool {
-	return statePreservingMethods[r.Method()]
-}
+// Package xsrfangular provides a safehttp.Interceptor that ensures Cross-Site
+// Request Forgery protection for Angular applications by verifying the incoming
+// requests, rejecting those requests that are suspected to be part of an
+// attack.
+package xsrfangular

--- a/safehttp/plugins/xsrf/angular/xsrf.go
+++ b/safehttp/plugins/xsrf/angular/xsrf.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"github.com/google/go-safeweb/safehttp"
 	"github.com/google/go-safeweb/safehttp/plugins/xsrf"
+	"strconv"
+	"time"
 )
 
 // Interceptor provides protection against Cross-Site Request Forgery attacks
@@ -40,6 +42,8 @@ var _ safehttp.Interceptor = &Interceptor{}
 // TokenHeaderName set to X-XSRF-TOKEN, their default values. However, in order
 // to prevent collisions when multiple applications share the same domain or
 // subdomain, each application should set a unique name for the cookie.
+//
+// See https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection for more details.
 func Default() *Interceptor {
 	return &Interceptor{
 		TokenCookieName: "XSRF-TOKEN",
@@ -81,8 +85,13 @@ func (it *Interceptor) addTokenCookie(w *safehttp.ResponseWriter) error {
 
 	c.SetSameSite(safehttp.SameSiteStrictMode)
 	c.SetPath("/")
+	d := 24 * time.Hour
+	timeout, err := strconv.Atoi(fmt.Sprintf("%.0f", d.Seconds()))
+	if err != nil {
+		return err
+	}
 	// Set the duration of the token cookie to 24 hours.
-	c.SetMaxAge(86400)
+	c.SetMaxAge(timeout)
 	// Needed in order to make the cookie accessible by JavaScript
 	// running on the user's domain.
 	c.DisableHTTPOnly()

--- a/safehttp/plugins/xsrf/angular/xsrf.go
+++ b/safehttp/plugins/xsrf/angular/xsrf.go
@@ -28,8 +28,7 @@ import (
 //
 // See https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection for more details.
 type Interceptor struct {
-	// TokenCookieName is the name of the session cookie that holds the XSRF
-	// token.
+	// TokenCookieName is the name of the session cookie that holds the XSRF token.
 	TokenCookieName string
 	// TokenHeaderName is the name of the HTTP header that holds the XSRF token.
 	TokenHeaderName string
@@ -108,8 +107,7 @@ func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 		return w.WriteError(safehttp.StatusInternalServerError)
 	}
 
-	err := it.addTokenCookie(w)
-	if err != nil {
+	if err := it.addTokenCookie(w); err != nil {
 		// This is a server misconfiguration.
 		return w.WriteError(safehttp.StatusInternalServerError)
 	}

--- a/safehttp/plugins/xsrf/angular/xsrf.go
+++ b/safehttp/plugins/xsrf/angular/xsrf.go
@@ -89,10 +89,7 @@ func (it *Interceptor) addTokenCookie(w *safehttp.ResponseWriter) error {
 	// running on the same domain.
 	c.DisableHTTPOnly()
 
-	if err := w.SetCookie(c); err != nil {
-		return err
-	}
-	return nil
+	return w.SetCookie(c)
 }
 
 // Commit generates a cryptographically secure random cookie on the first state

--- a/safehttp/plugins/xsrf/angular/xsrf_test.go
+++ b/safehttp/plugins/xsrf/angular/xsrf_test.go
@@ -30,10 +30,7 @@ const (
 func TestAngularAddCookie(t *testing.T) {
 	req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
 	rec := safehttptest.NewResponseRecorder()
-	i := &Interceptor{
-		TokenCookieName: cookieName,
-		TokenHeaderName: headerName,
-	}
+	i := Default()
 	i.Commit(rec.ResponseWriter, req, nil, nil)
 
 	if got, want := rec.Status(), safehttp.StatusOK; got != want {
@@ -122,10 +119,7 @@ func TestAngularPostProtection(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			rec := safehttptest.NewResponseRecorder()
-			i := &Interceptor{
-				TokenCookieName: cookieName,
-				TokenHeaderName: headerName,
-			}
+			i := Default()
 			i.Before(rec.ResponseWriter, test.req, nil)
 
 			if got := rec.Status(); got != test.wantStatus {

--- a/safehttp/plugins/xsrf/angular/xsrf_test.go
+++ b/safehttp/plugins/xsrf/angular/xsrf_test.go
@@ -33,20 +33,16 @@ func TestAddCookie(t *testing.T) {
 		it           *Interceptor
 	}{
 		{
-			name: "Default interceptor",
-			it: func() *Interceptor {
-				return Default()
-			}(),
+			name:   "Default interceptor",
+			it:     Default(),
 			cookie: cookieName,
 		},
 		{
 			name: "Custom interceptor",
-			it: func() *Interceptor {
-				return &Interceptor{
-					TokenCookieName: "FOO-TOKEN",
-					TokenHeaderName: "X-FOO-TOKEN",
-				}
-			}(),
+			it: &Interceptor{
+				TokenCookieName: "FOO-TOKEN",
+				TokenHeaderName: "X-FOO-TOKEN",
+			},
 			cookie: "FOO-TOKEN",
 		},
 	}

--- a/safehttp/plugins/xsrf/angular/xsrf_test.go
+++ b/safehttp/plugins/xsrf/angular/xsrf_test.go
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package xsrf provides a safehttp.Interceptor that ensures Cross-Site Request
-// Forgery protection by verifying the incoming requests, rejecting those
-// requests that are suspected to be part of an attack.
-package angularxsrf
+package xsrfangular
 
 import (
 	"github.com/google/go-cmp/cmp"

--- a/safehttp/plugins/xsrf/angular/xsrf_test.go
+++ b/safehttp/plugins/xsrf/angular/xsrf_test.go
@@ -27,7 +27,7 @@ const (
 	headerName = "X-XSRF-TOKEN"
 )
 
-func TestAngularAddCookie(t *testing.T) {
+func TestAddCookie(t *testing.T) {
 	req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
 	rec := safehttptest.NewResponseRecorder()
 	i := Default()
@@ -37,13 +37,13 @@ func TestAngularAddCookie(t *testing.T) {
 		t.Errorf("rec.Status(): got %v, want %v", got, want)
 	}
 
-	tokCookieDefaults := "Path=/; Max-Age=86400; Secure; SameSite=Strict"
+	wantCookie := "Path=/; Max-Age=86400; Secure; SameSite=Strict"
 	got := map[string][]string(rec.Header())["Set-Cookie"][0]
 	if !strings.Contains(got, i.TokenCookieName) {
 		t.Errorf("Set-Cookie header: %s not present", i.TokenCookieName)
 	}
-	if !strings.Contains(got, tokCookieDefaults) {
-		t.Errorf("Set-Cookie header: got %s, want defaults %s", got, tokCookieDefaults)
+	if !strings.Contains(got, wantCookie) {
+		t.Errorf("Set-Cookie header: got %q, want defaults %q", got, wantCookie)
 	}
 
 	if got, want := rec.Body(), ""; got != want {
@@ -51,7 +51,7 @@ func TestAngularAddCookie(t *testing.T) {
 	}
 }
 
-func TestAngularPostProtection(t *testing.T) {
+func TestPostProtection(t *testing.T) {
 	tests := []struct {
 		name       string
 		req        *safehttp.IncomingRequest

--- a/safehttp/plugins/xsrf/html/doc.go
+++ b/safehttp/plugins/xsrf/html/doc.go
@@ -12,21 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package xsrf contains helper functions for the safehttp.Interceptor that
-// provide protection against Cross-Site Request Forgery attacks.
-package xsrf
-
-import (
-	"github.com/google/go-safeweb/safehttp"
-)
-
-var statePreservingMethods = map[string]bool{
-	safehttp.MethodGet:     true,
-	safehttp.MethodHead:    true,
-	safehttp.MethodOptions: true,
-}
-
-// StatePreserving checks if the provided request is state preserving.
-func StatePreserving(r *safehttp.IncomingRequest) bool {
-	return statePreservingMethods[r.Method()]
-}
+// Package xsrfhtml provides a safehttp.Interceptor that ensures Cross-Site
+// Request Forgery protection for HTML pages by verifying the incoming requests,
+// rejecting those requests that are suspected to be part of an attack.
+package xsrfhtml

--- a/safehttp/plugins/xsrf/html/doc.go
+++ b/safehttp/plugins/xsrf/html/doc.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // Package xsrfhtml provides a safehttp.Interceptor that ensures Cross-Site
-// Request Forgery protection for HTML pages by verifying the incoming requests,
-// rejecting those requests that are suspected to be part of an attack.
+// Request Forgery by verifying the incoming requests for the presence of an
+// XSRF token, rejecting those requests that are suspected to be part of an
+// attack.
 package xsrfhtml

--- a/safehttp/plugins/xsrf/html/xsrf.go
+++ b/safehttp/plugins/xsrf/html/xsrf.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/google/go-safeweb/safehttp/plugins/htmlinject"
 	"github.com/google/go-safeweb/safehttp/plugins/xsrf"
 
 	"github.com/google/go-safeweb/safehttp"
@@ -150,7 +151,7 @@ func (it *Interceptor) Commit(w *safehttp.ResponseWriter, r *safehttp.IncomingRe
 	// htmlinject
 	// TODO: what should happen if the XSRFToken key is not present in the
 	// tr.FuncMap?
-	tmplResp.FuncMap["XSRFToken"] = func() string { return tok }
+	tmplResp.FuncMap[htmlinject.XSRFTokensDefaultFuncName] = func() string { return tok }
 	return safehttp.NotWritten()
 }
 

--- a/safehttp/plugins/xsrf/html/xsrf_test.go
+++ b/safehttp/plugins/xsrf/html/xsrf_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package xsrf
+package xsrfhtml
 
 import (
 	"context"

--- a/tests/integration/xsrf/xsrf_test.go
+++ b/tests/integration/xsrf/xsrf_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	"github.com/google/go-safeweb/safehttp"
-	"github.com/google/go-safeweb/safehttp/plugins/xsrf"
+	"github.com/google/go-safeweb/safehttp/plugins/xsrf/html"
 	"github.com/google/go-safeweb/safehttp/safehttptest"
 	"github.com/google/safehtml/template"
 )
 
 func TestServeMuxInstallXSRF(t *testing.T) {
 	mb := &safehttp.ServeMuxConfig{}
-	it := xsrf.Interceptor{SecretAppKey: "testSecretAppKey"}
+	it := xsrfhtml.Interceptor{SecretAppKey: "testSecretAppKey"}
 	mb.Intercept(&it)
 
 	var token string
@@ -40,7 +40,7 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 		// handler can retrieve the XSRF token (e.g. for when the XSRF plugin is
 		// installed, but auto-injection isn't yet supported and has to be done
 		// manually by the handler).
-		token, err = xsrf.Token(r)
+		token, err = xsrfhtml.Token(r)
 		t := template.Must(template.New("name").Funcs(fns).Parse(`<form><input type="hidden" name="token" value="{{XSRFToken}}">{{.}}</form>`))
 
 		return w.WriteTemplate(t, "Content")
@@ -55,7 +55,7 @@ func TestServeMuxInstallXSRF(t *testing.T) {
 	mb.Mux().ServeHTTP(rr, req)
 
 	if err != nil {
-		t.Fatalf("xsrf.Token: got error %v", err)
+		t.Fatalf("xsrfhtml.Token: got error %v", err)
 	}
 
 	if token == "" {


### PR DESCRIPTION
Fixes #194

Created a separate plugin that provides protection against XSRF in Angular. More details can be found here: https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection

Changed the directory tree to include the two XSRF plugins in the same directory with the functionality used by both placed in a separate file.