### PR TITLE
Allow the user to set a custom status code in the safehttp.ResponseWriter

### DIFF
--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -167,6 +167,9 @@ func (w *ResponseWriter) SetCookie(c *Cookie) error {
 // invalid status code is passed (i.e. not in the range 1XX-5XX) or if the
 // response has already been written.
 //
+// If SetCode was called before NoContent, Redirect or WriteError, the status
+// code set by the latter will be the actual response status.
+//
 // TODO(empijei@, kele@, maramihali@): decide what should be done if the
 // code passed is either 3XX (redirect) or 4XX-5XX (client/server error).
 func (w *ResponseWriter) SetCode(code StatusCode) {

--- a/safehttp/response_writer.go
+++ b/safehttp/response_writer.go
@@ -163,9 +163,9 @@ func (w *ResponseWriter) SetCookie(c *Cookie) error {
 	return w.header.addCookie(c)
 }
 
-// SetCode allows setting a response status. This method will panic if an
-// invalid status code is passed (i.e. not in the range 1XX-5XX) or if the
-// response has already been written.
+// SetCode allows setting a response status. If the response was already
+// written, trying to set the status code will have no effect. This method will
+// panic if an invalid status code is passed (i.e. not in the range 1XX-5XX).
 //
 // If SetCode was called before NoContent, Redirect or WriteError, the status
 // code set by the latter will be the actual response status.
@@ -174,7 +174,7 @@ func (w *ResponseWriter) SetCookie(c *Cookie) error {
 // code passed is either 3XX (redirect) or 4XX-5XX (client/server error).
 func (w *ResponseWriter) SetCode(code StatusCode) {
 	if w.written {
-		panic("ResponseWriter was already written to")
+		return
 	}
 	if code < 100 || code >= 600 {
 		panic("invalid status code")

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -167,6 +167,14 @@ func TestResponseWriterStatusCode(t *testing.T) {
 			wantStatus: safehttp.StatusPartialContent,
 		},
 		{
+			name: "Status code set after Write",
+			write: func(w *safehttp.ResponseWriter) {
+				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
+				w.SetCode(safehttp.StatusPartialContent)
+			},
+			wantStatus: safehttp.StatusOK,
+		},
+		{
 			name: "SetCode then NoContent",
 			write: func(w *safehttp.ResponseWriter) {
 				w.SetCode(safehttp.StatusPartialContent)
@@ -220,13 +228,6 @@ func TestResponseWriterInvalidStatusCode(t *testing.T) {
 			write: func(w *safehttp.ResponseWriter) {
 				w.SetCode(1000)
 				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
-			},
-		},
-		{
-			name: "Status code set after write",
-			write: func(w *safehttp.ResponseWriter) {
-				w.Write(safehtml.HTMLEscaped("<h1>Escaped, so not really a heading</h1>"))
-				w.SetCode(safehttp.StatusPartialContent)
 			},
 		},
 	}

--- a/safehttp/response_writer_test.go
+++ b/safehttp/response_writer_test.go
@@ -166,6 +166,30 @@ func TestResponseWriterStatusCode(t *testing.T) {
 			},
 			wantStatus: safehttp.StatusPartialContent,
 		},
+		{
+			name: "SetCode then NoContent",
+			write: func(w *safehttp.ResponseWriter) {
+				w.SetCode(safehttp.StatusPartialContent)
+				w.NoContent()
+			},
+			wantStatus: safehttp.StatusNoContent,
+		},
+		{
+			name: "SetCode then Redirect",
+			write: func(w *safehttp.ResponseWriter) {
+				w.SetCode(safehttp.StatusPartialContent)
+				w.Redirect(safehttptest.NewRequest(safehttp.MethodGet, "/", nil), "", safehttp.StatusTemporaryRedirect)
+			},
+			wantStatus: safehttp.StatusTemporaryRedirect,
+		},
+		{
+			name: "SetCode then WriteError",
+			write: func(w *safehttp.ResponseWriter) {
+				w.SetCode(safehttp.StatusPartialContent)
+				w.WriteError(safehttp.StatusInsufficientStorage)
+			},
+			wantStatus: safehttp.StatusInsufficientStorage,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #151

Previously, there was no way of setting a status code other than `safehttp.NoContent` as the write method in the `safehttp.ResponseWriter` would always set the status code to `safehttp.StatusOK`. Implemented initial functionality and tests to make this possible.