### PR TITLE
`flight` now knows whether a response has been dispatched (possibly written to `net/http.ResponseWriter`)

### DIFF
--- a/safehttp/flight.go
+++ b/safehttp/flight.go
@@ -29,10 +29,7 @@ type flight struct {
 	code   StatusCode
 	header Header
 
-	// TODO(kele): we need to distinguish between calling Write and actually
-	// writing to the net/http.ResponseWriter.
-	written      bool
-	writtenError bool
+	written bool
 }
 
 // DeprecatedNewResponseWriter creates a ResponseWriter implementation that has
@@ -70,13 +67,19 @@ func processRequest(cfg HandlerConfig, rw http.ResponseWriter, req *http.Request
 		req:    NewIncomingRequest(req),
 	}
 
-	// The net/http package recovers handler panics, but we cannot rely on that
-	// behavior here. The reason is, we might need to run some interceptor
-	// stages interceptors before we respond with a 500 Internal Server Error.
-	// Therefore we're calling WriteError.
+	// The net/http package handles all panics. In the early days of the
+	// framework we were handling them ourselves and running interceptors after
+	// a panic happened, but this might lead to information disclosure (i.e.
+	// different responses based on where the panic has occurred) and adds lots
+	// of complexity to the codebase. Instead, we just make sure to clear all
+	// the headers and cookies.
 	defer func() {
 		if r := recover(); r != nil {
-			f.WriteError(StatusInternalServerError)
+			// Clear all headers.
+			for h := range f.rw.Header() {
+				delete(f.rw.Header(), h)
+			}
+			panic(r)
 		}
 	}()
 
@@ -86,7 +89,6 @@ func processRequest(cfg HandlerConfig, rw http.ResponseWriter, req *http.Request
 			return
 		}
 	}
-
 	f.cfg.Handler.ServeHTTP(f, f.req)
 	if !f.written {
 		f.NoContent()
@@ -95,8 +97,6 @@ func processRequest(cfg HandlerConfig, rw http.ResponseWriter, req *http.Request
 
 // Write dispatches the response to the Dispatcher. This will be written to the
 // underlying http.ResponseWriter if the Dispatcher decides it's safe to do so.
-//
-// TODO: replace panics with proper error handling when writing the response fails.
 func (f *flight) Write(resp Response) Result {
 	if f.written {
 		panic("ResponseWriter was already written to")
@@ -142,13 +142,10 @@ func (f *flight) NoContent() Result {
 // If the ResponseWriter has already been written to, then this method will panic.
 func (f *flight) WriteError(code StatusCode) Result {
 	// TODO: accept custom error responses that need to go through the dispatcher.
-	if f.writtenError {
-		panic("ResponseWriter.WriteError called twice")
+	if f.written {
+		panic("ResponseWriter was already written to")
 	}
 	f.written = true
-	f.writtenError = true
-	// TODO: we cannot really write if the Dispatcher already started writing
-	// but panicked, resulting in a WriteError call.
 	resp := &ErrorResponse{Code: code}
 	f.errorPhase(resp)
 	http.Error(f.rw, http.StatusText(int(resp.Code)), int(resp.Code))

--- a/safehttp/flight_test.go
+++ b/safehttp/flight_test.go
@@ -1,0 +1,134 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safehttp_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/safehttptest"
+	"github.com/google/safehtml"
+)
+
+type panickingInterceptor struct {
+	before, commit, onError bool
+}
+
+func (p panickingInterceptor) Before(w safehttp.ResponseWriter, _ *safehttp.IncomingRequest, cfg safehttp.InterceptorConfig) safehttp.Result {
+	if p.before {
+		panic("before")
+	}
+	return safehttp.NotWritten()
+}
+
+func (p panickingInterceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg safehttp.InterceptorConfig) {
+	if p.commit {
+		panic("commit")
+	}
+}
+
+func (p panickingInterceptor) OnError(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg safehttp.InterceptorConfig) {
+	if p.onError {
+		panic("onError")
+	}
+}
+
+func TestFlightInterceptorPanic(t *testing.T) {
+	tests := []struct {
+		desc        string
+		interceptor panickingInterceptor
+		wantPanic   bool
+	}{
+		{
+			desc:        "panic in Before",
+			interceptor: panickingInterceptor{before: true},
+			wantPanic:   true,
+		},
+		{
+			desc:        "panic in Commit",
+			interceptor: panickingInterceptor{commit: true},
+			wantPanic:   true,
+		},
+		{
+			desc:        "panic in OnError, but handler finishes successfully, so it doesn't happen",
+			interceptor: panickingInterceptor{onError: true},
+			wantPanic:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			mb := &safehttp.ServeMuxConfig{}
+			mb.Intercept(tc.interceptor)
+			mb.Handle("/search", safehttp.MethodGet, safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+				// IMPORTANT: We are setting the header here and expecting to be
+				// cleared if a panic occurs.
+				w.Header().Set("foo", "bar")
+				return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+			}))
+			mux := mb.Mux()
+
+			req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/search", nil)
+			b := &strings.Builder{}
+			rw := safehttptest.NewTestResponseWriter(b)
+
+			defer func() {
+				r := recover()
+				if !tc.wantPanic {
+					if r != nil {
+						t.Fatalf("unexpected panic %v", r)
+					}
+					return
+				}
+				if r == nil {
+					t.Fatal("expected panic")
+				}
+				// Good, the panic got propagated.
+				if len(rw.Header()) > 0 {
+					t.Errorf("ResponseWriter.Header() got %v, want empty", rw.Header())
+				}
+			}()
+			mux.ServeHTTP(rw, req)
+		})
+	}
+}
+
+func TestFlightHandlerPanic(t *testing.T) {
+	mb := &safehttp.ServeMuxConfig{}
+	mb.Handle("/search", safehttp.MethodGet, safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		// IMPORTANT: We are setting the header here and expecting to be
+		// cleared if a panic occurs.
+		w.Header().Set("foo", "bar")
+		panic("handler")
+	}))
+	mux := mb.Mux()
+
+	req := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/search", nil)
+	b := &strings.Builder{}
+	rw := safehttptest.NewTestResponseWriter(b)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic")
+		}
+		// Good, the panic got propagated.
+		if len(rw.Header()) > 0 {
+			t.Errorf("ResponseWriter.Header() got %v, want empty", rw.Header())
+		}
+	}()
+	mux.ServeHTTP(rw, req)
+}


### PR DESCRIPTION
`flight` doesn't distinguish anymore between `written` and `writtenError`.

Since `Write` -> `WriteError` calls cannot be introduced by users, we no
longer need to distinguish between them (currently only the framework
can call `WriteError` when we're still in a `Write`, but that's going to
change soon as it can only be triggered by a `panic`).

Added a `dispatched` field in order to distinguish between a
write-operation being triggered by the user, and an actual write to the
`net/http.ResponseWriter`. If the latter hasn't happened yet (i.e. we
haven't asked the Go standard library to start writing the response), we
can still handle errors gracefully. After we've written any bytes to the
`net/http.ResponseWriter` (e.g. `200 OK`), there is nothing we can do in
case of an error. This is because the reponse status might have been
already sent over the wire, and the error happened just now.

#164, #79