### PR TITLE
safehttp: correct the error message of test header is claimed

### DIFF
--- a/safehttp/header_test.go
+++ b/safehttp/header_test.go
@@ -364,7 +364,7 @@ func TestHeaderIsClaimedCanonicalization(t *testing.T) {
 func TestHeaderIsClaimedNotClaimed(t *testing.T) {
 	h := newHeader(http.Header{})
 	if got := h.IsClaimed("Foo-Key"); got != false {
-		t.Errorf(`h.IsClaimed("Foo-Key") got: %v want: true`, got)
+		t.Errorf(`h.IsClaimed("Foo-Key") got: %v want: false`, got)
 	}
 }
 


### PR DESCRIPTION
This error might confuse developers on a solution due to that error message.

- [ ] Tests pass