### PR TITLE
Example of mixing net/http and safehttp handlers using http.Handler.

### DIFF
--- a/examples/httpcompose/httpcompose.go
+++ b/examples/httpcompose/httpcompose.go
@@ -1,0 +1,81 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// httpcompose implements a simple server which composes net/http and safehttp muxes.
+//
+// Endpoints:
+//  - /foo?msg=<script>alert(1)</script>
+//  - /bar?msg=<script>alert(1)</script>
+//  - /secure?msg=<script>alert(1)</script>
+//  - /insecure?msg=<script>alert(1)</script>
+package main
+
+import (
+	"fmt"
+	"html"
+	"log"
+	"net/http"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+)
+
+func main() {
+
+	fooHandleFunc := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/html")
+		q := r.URL.Query().Get("msg")
+		fmt.Fprintf(w, "Foo, %q", html.EscapeString(q))
+	}
+
+	barHandleFunc := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/html")
+		q := r.URL.Query().Get("msg")
+		// Insecure: Forgot html.EscapeString. XSS is possible.
+		fmt.Fprintf(w, "Bar, %q", q)
+	}
+
+	secureHandler := func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		form, err := r.URL.Query()
+		if err != nil {
+			panic(err)
+		}
+		q := form.String("msg", "defaultstr")
+		return w.Write(safehtml.HTMLEscaped(q))
+	}
+
+	insecureMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			barHandleFunc(w, r)
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	mc := &safehttp.ServeMuxConfig{}
+	mc.Handle("/secure", safehttp.MethodGet, safehttp.HandlerFunc(secureHandler))
+	// Extract the relevant handlers to be used in existing net/http codebase.
+	safehttpHandler := mc.Mux().Handler(safehttp.MethodGet, "/secure")
+
+	http.HandleFunc("/foo", fooHandleFunc)
+	http.HandleFunc("/bar", barHandleFunc)
+	// Register safehttp handler in net/http.
+	http.Handle("/secure", safehttpHandler)
+	// Insecure: safehttp handler wrapped by net/http handler cannot provide any guarantees.
+	http.Handle("/insecure", insecureMiddleware(safehttpHandler))
+
+	log.Println("Visit http://localhost:8080")
+	log.Println("Listening on localhost:8080...")
+	http.ListenAndServe("localhost:8080", nil)
+
+}

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 )
 
 // The HTTP request methods defined by RFC.
@@ -217,4 +218,18 @@ func (s *ServeMuxConfig) Clone() *ServeMuxConfig {
 	copy(c.handlers, s.handlers)
 	copy(c.interceptors, s.interceptors)
 	return c
+}
+
+// Handler returns the handler to use for the given method and path.
+// TODO: add a host parameter?
+func (m *ServeMux) Handler(method, path string) http.Handler {
+	r := &http.Request{
+		Method: method,
+		Host:   "",
+		URL: &url.URL{
+			Path: path,
+		},
+	}
+	handler, _ := m.mux.Handler(r)
+	return handler
 }


### PR DESCRIPTION
Add ServeMux.Handler to extract http.Handlers from a ServeMux.

Fixes #245.