### PR TITLE
Add Trusted Types policy to CSP plugin

### DIFF
--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -225,7 +225,7 @@ type Interceptor struct {
 var _ safehttp.Interceptor = Interceptor{}
 
 // Default creates a new CSP interceptor with a strict nonce-based policy, a framing policy
-// and a TrustedType policy. All in enforcement mode.
+// and a TrustedTypes policy. All in enforcement mode.
 func Default(reportURI string) Interceptor {
 	return Interceptor{
 		Enforce: []Policy{

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -167,7 +167,7 @@ func (f FramingPolicy) Serialize(nonce string) string {
 	return b.String()
 }
 
-// TrustedTypesPolicy policy can be used to create a new CSP policy which makes
+// TrustedTypesPolicy policy can be used to create a new CSP which makes
 // dangerous web API functions secure by default.
 //
 // See https://web.dev/trusted-types for more info.

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -175,10 +175,6 @@ type TrustedTypesPolicy struct {
 	// ReportURI controls the report-uri directive. If ReportUri is empty, no report-uri
 	// directive will be set.
 	ReportURI string
-	// PolicyNames controls allowed names of policies that can be created.
-	PolicyNames []string
-	// AllowDuplicates allows creating policies with a name that was already used.
-	AllowDuplicates bool
 }
 
 // Serialize serializes this policy for use in a Content-Security-Policy header
@@ -187,19 +183,6 @@ type TrustedTypesPolicy struct {
 func (t TrustedTypesPolicy) Serialize(nonce string) string {
 	var b strings.Builder
 	b.WriteString("require-trusted-types-for 'script'")
-
-	if len(t.PolicyNames) > 0 {
-		b.WriteString("; trusted-types")
-		for _, name := range t.PolicyNames {
-			b.WriteString(" ")
-			b.WriteString(name)
-		}
-
-		if t.AllowDuplicates {
-			b.WriteString(" ")
-			b.WriteString("'allow-duplicates'")
-		}
-	}
 
 	if t.ReportURI != "" {
 		b.WriteString("; report-uri ")

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -96,6 +96,26 @@ func TestSerialize(t *testing.T) {
 			policy:     FramingPolicy{ReportURI: "httsp://example.com/collector"},
 			wantString: "frame-ancestors 'self'; report-uri httsp://example.com/collector",
 		},
+		{
+			name:       "TrustedTypesCSP",
+			policy:     TrustedTypesPolicy{},
+			wantString: "require-trusted-types-for 'script'",
+		},
+		{
+			name:       "TrustedTypesCSP with report-uri",
+			policy:     TrustedTypesPolicy{ReportURI: "httsp://example.com/collector"},
+			wantString: "require-trusted-types-for 'script'; report-uri httsp://example.com/collector",
+		},
+		{
+			name:       "TrustedTypesCSP with policy names",
+			policy:     TrustedTypesPolicy{PolicyNames: []string{"one", "two"}},
+			wantString: "require-trusted-types-for 'script'; trusted-types one two",
+		},
+		{
+			name:       "TrustedTypesCSP with policy names and allowed duplicates",
+			policy:     TrustedTypesPolicy{PolicyNames: []string{"one", "two"}, AllowDuplicates: true},
+			wantString: "require-trusted-types-for 'script'; trusted-types one two 'allow-duplicates'",
+		},
 	}
 
 	for _, tt := range tests {
@@ -128,6 +148,7 @@ func TestBefore(t *testing.T) {
 			wantEnforcePolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'strict-dynamic' https: http:; base-uri 'none'",
 				"frame-ancestors 'self'",
+				"require-trusted-types-for 'script'",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},
@@ -137,6 +158,7 @@ func TestBefore(t *testing.T) {
 			wantEnforcePolicy: []string{
 				"object-src 'none'; script-src 'unsafe-inline' 'nonce-KSkpKSkpKSkpKSkpKSkpKSkpKSk=' 'strict-dynamic' https: http:; base-uri 'none'; report-uri https://example.com/collector",
 				"frame-ancestors 'self'; report-uri https://example.com/collector",
+				"require-trusted-types-for 'script'; report-uri https://example.com/collector",
 			},
 			wantNonce: "KSkpKSkpKSkpKSkpKSkpKSkpKSk=",
 		},

--- a/safehttp/plugins/csp/csp_test.go
+++ b/safehttp/plugins/csp/csp_test.go
@@ -106,16 +106,6 @@ func TestSerialize(t *testing.T) {
 			policy:     TrustedTypesPolicy{ReportURI: "httsp://example.com/collector"},
 			wantString: "require-trusted-types-for 'script'; report-uri httsp://example.com/collector",
 		},
-		{
-			name:       "TrustedTypesCSP with policy names",
-			policy:     TrustedTypesPolicy{PolicyNames: []string{"one", "two"}},
-			wantString: "require-trusted-types-for 'script'; trusted-types one two",
-		},
-		{
-			name:       "TrustedTypesCSP with policy names and allowed duplicates",
-			policy:     TrustedTypesPolicy{PolicyNames: []string{"one", "two"}, AllowDuplicates: true},
-			wantString: "require-trusted-types-for 'script'; trusted-types one two 'allow-duplicates'",
-		},
 	}
 
 	for _, tt := range tests {

--- a/tests/integration/csp/csp_test.go
+++ b/tests/integration/csp/csp_test.go
@@ -72,7 +72,8 @@ func TestServeMuxInstallCSP(t *testing.T) {
 		"Content-Type": {"text/html; charset=utf-8"},
 		"Content-Security-Policy": {
 			"object-src 'none'; script-src 'unsafe-inline' 'nonce-" + nonce + "' 'strict-dynamic' https: http:; base-uri 'none'",
-			"frame-ancestors 'self'"},
+			"frame-ancestors 'self'",
+			"require-trusted-types-for 'script'"},
 	}
 	if diff := cmp.Diff(wantHeaders, map[string][]string(rr.Header())); diff != "" {
 		t.Errorf("rr.Header(): mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
An example server presenting the protection will follow up.
Fixes #99