### PR TITLE
Add an example of a server which presents DOM XSS protection with Trusted Types

### DIFF
--- a/examples/trustedtypes/safe.html
+++ b/examples/trustedtypes/safe.html
@@ -1,0 +1,53 @@
+<!--
+Copyright 2020 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Trusted Types - example</title>
+    <!-- Install polyfill for browsers that do not support Trusted Types yet. -->
+    <script src="https://w3c.github.io/webappsec-trusted-types/dist/es5/trustedtypes.build.js"
+        data-csp="require-trusted-types-for 'script'"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.2.6/purify.min.js"
+        integrity="sha512-rXAHWSMciPq2KsOxTvUeYNBb45apbcEXUVSIexVPOBnKfD/xo99uUe5M2OOsC49hGdUrkRLYsATkQQHMzUo/ew=="
+        crossorigin="anonymous"></script>
+</head>
+
+<body>
+    <p>This document installs the following script which appends sanitized user input into the DOM:</p>
+    <code>
+        document.getElementById("hash").innerHTML = DOMPurify.sanitize(location.hash, {RETURN_TRUSTED_TYPE: true});
+    </code>
+    <p>location hash: <span id="hash"></span></p>
+    <script>
+        window.addEventListener('load', function () {
+            // This piece of code is safe from DOM XSS.
+            document.getElementById("hash").innerHTML = DOMPurify.sanitize(location.hash, { RETURN_TRUSTED_TYPE: true });
+        })
+    </script>
+    <p>Unsafe usage of DOM APIs will be blocked. The code snippet below will not be executed and will
+        trigger a warning in the console:</p>
+    <code>
+        document.getElementById("unsafehash").innerHTML = location.hash;
+    </code>
+    <p>location hash (unsafe): <span id="unsafehash"></span></p>
+    <script>
+        window.addEventListener('load', function () {
+            // This piece of code is vulnerable to DOM XSS.
+            document.getElementById("unsafehash").innerHTML = location.hash;
+        })
+    </script>
+</body>
+
+</html>

--- a/examples/trustedtypes/server.go
+++ b/examples/trustedtypes/server.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements a simple server presenting DOM XSS protection with Trusted Types.
+//
+// Endpoints:
+//  - /safe#<script>alert(1)</script>
+//  - /unsafe#<script>alert(1)</script>
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/google/safehtml/template"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/plugins/csp"
+	"github.com/google/go-safeweb/safehttp/plugins/htmlinject"
+)
+
+func main() {
+	host := "localhost"
+	port := "8080"
+	addr := net.JoinHostPort(host, port)
+	var mc safehttp.ServeMuxConfig
+	mc.Intercept(csp.Default(""))
+
+	safeTmplSrc, _ := template.TrustedSourceFromConstantDir("", template.TrustedSource{}, "safe.html")
+	safeTmpl := template.Must(htmlinject.LoadFiles(nil, htmlinject.LoadConfig{}, safeTmplSrc))
+	mc.Handle("/safe", safehttp.MethodGet, safehttp.HandlerFunc(handleTemplate(safeTmpl)))
+
+	unsafeTmplSrc, _ := template.TrustedSourceFromConstantDir("", template.TrustedSource{}, "unsafe.html")
+	unsafeTmpl := template.Must(htmlinject.LoadFiles(nil, htmlinject.LoadConfig{}, unsafeTmplSrc))
+	mc.Handle("/unsafe", safehttp.MethodGet, safehttp.HandlerFunc(handleTemplate(unsafeTmpl)))
+
+	log.Printf("Visit http://%s\n", addr)
+	log.Printf("Listening on %s...\n", addr)
+	log.Fatal(http.ListenAndServe(addr, mc.Mux()))
+}
+
+func handleTemplate(tmpl safehttp.Template) func(w safehttp.ResponseWriter, req *safehttp.IncomingRequest) safehttp.Result {
+	return func(w safehttp.ResponseWriter, req *safehttp.IncomingRequest) safehttp.Result {
+		return safehttp.ExecuteTemplate(w, tmpl, nil)
+	}
+}

--- a/examples/trustedtypes/unsafe.html
+++ b/examples/trustedtypes/unsafe.html
@@ -1,0 +1,40 @@
+<!--
+Copyright 2020 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Trusted Types - example</title>
+    <!-- Install polyfill for browsers that do not support Trusted Types yet. -->
+    <script src="https://w3c.github.io/webappsec-trusted-types/dist/es5/trustedtypes.build.js"
+        data-csp="require-trusted-types-for 'script'"></script>
+</head>
+
+<body>
+    <p>This document installs the following script which introduces a DOM XSS vulnerability:</p>
+    <p>
+        <code>document.getElementById("hash").innerHTML = location.hash;</code>
+    </p>
+    With TrustedTypes protection enabled, the browser will reject execution of any JavaScript code on this page.
+    You can verify it by looking at the console output)
+    <p>location hash: <span id="hash"></span></p>
+    <script>
+        window.addEventListener('load', function () {
+            // This piece of code is vulnerable to DOM XSS.
+            document.getElementById("hash").innerHTML = location.hash;
+        })
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Add an example of a server which presents DOM XSS protection with Trusted Types.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR