### PR TITLE
Add a way to set up the framework in local development mode.

### DIFF
--- a/safehttp/cookie.go
+++ b/safehttp/cookie.go
@@ -28,7 +28,7 @@ type Cookie struct {
 
 // NewCookie creates a new Cookie with safe default settings.
 // Those safe defaults are:
-//  - Secure: true
+//  - Secure: true (if the framework is not in dev mode)
 //  - HttpOnly: true
 //  - SameSite: Lax
 // For more info about all the options, see:

--- a/safehttp/cookie.go
+++ b/safehttp/cookie.go
@@ -38,7 +38,7 @@ func NewCookie(name, value string) *Cookie {
 		&http.Cookie{
 			Name:     name,
 			Value:    value,
-			Secure:   true,
+			Secure:   !isLocalDev,
 			HttpOnly: true,
 			SameSite: http.SameSiteLaxMode,
 		},

--- a/safehttp/dev.go
+++ b/safehttp/dev.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package safehttp
 
 var (

--- a/safehttp/dev.go
+++ b/safehttp/dev.go
@@ -1,0 +1,27 @@
+package safehttp
+
+var (
+	isLocalDev bool
+	// freezeLocalDev is set on Mux construction.
+	freezeLocalDev bool
+)
+
+// UseLocalDev instructs the framework to disable some security mechanisms that
+// would make local development hard or impossible. This cannot be undone without
+// restarting the program and should only be done before any other function or type
+// of the framework is used.
+// This function should ideally be called by the main package immediately after
+// flag parsing.
+// This configuration is not valid for production use.
+func UseLocalDev() {
+	if freezeLocalDev {
+		panic("UseLocalDev should be called before any other part of the framework")
+	}
+	isLocalDev = true
+}
+
+// IsLocalDev returns whether the framework is set up to use local development
+// rules. Please see the doc on UseLocalDev.
+func IsLocalDev() bool {
+	return isLocalDev
+}

--- a/safehttp/dev.go
+++ b/safehttp/dev.go
@@ -29,7 +29,7 @@ var (
 // This configuration is not valid for production use.
 func UseLocalDev() {
 	if freezeLocalDev {
-		panic("UseLocalDev should be called before any other part of the framework")
+		panic("UseLocalDev can only be called before any other part of the framework")
 	}
 	isLocalDev = true
 }

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -16,6 +16,7 @@ package safehttp
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 )
 
@@ -148,6 +149,11 @@ func (s *ServeMuxConfig) Intercept(i Interceptor) {
 
 // Mux returns the ServeMux with a copy of the current configuration.
 func (s *ServeMuxConfig) Mux() *ServeMux {
+	freezeLocalDev = true
+	if IsLocalDev() {
+		log.Println("Warning: creating safehttp.Mux in dev mode. This configuration is not valid for production use")
+	}
+
 	dispatcher := s.Dispatcher
 	if dispatcher == nil {
 		dispatcher = DefaultDispatcher{}

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -17,7 +17,8 @@
 // HTTP Strict Transport Security informs browsers that a website
 // should only be accessed using HTTPS and not HTTP. This plugin enforces HSTS by
 // redirecting all HTTP traffic to HTTPS and by setting the
-// Strict-Transport-Security header on all HTTPS responses.
+// Strict-Transport-Security header on all HTTPS responses. Please note that this
+// only applies if the framework is not run in dev mode.
 //
 // More info:
 //  - MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -85,6 +85,9 @@ func Default() Interceptor {
 // is received the Strict-Transport-Security header is applied to the
 // response.
 func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest, _ safehttp.InterceptorConfig) safehttp.Result {
+	if safehttp.IsLocalDev() {
+		return safehttp.NotWritten()
+	}
 	if it.MaxAge < 0 {
 		return w.WriteError(safehttp.StatusInternalServerError)
 	}

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -88,6 +88,7 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 	if safehttp.IsLocalDev() {
 		return safehttp.NotWritten()
 	}
+
 	if it.MaxAge < 0 {
 		return w.WriteError(safehttp.StatusInternalServerError)
 	}

--- a/tests/integration/devmode/devmode_test.go
+++ b/tests/integration/devmode/devmode_test.go
@@ -26,8 +26,11 @@ import (
 )
 
 func TestDevMode(t *testing.T) {
-	safehttp.UseLocalDev()
 	t.Run("can load in dev mode", func(t *testing.T) {
+		safehttp.UseLocalDev()
+		if !safehttp.IsLocalDev() {
+			t.Errorf("IsLocalDev(): got false, want true")
+		}
 		const resp = "response"
 		cfg, _ := defaults.ServeMuxConfig([]string{"test.host.example"}, "test-xsrf-key")
 		cfg.Handle("/test", "GET", safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {

--- a/tests/integration/devmodefreeze/devmodefreeze_test.go
+++ b/tests/integration/devmodefreeze/devmodefreeze_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestDevMode(t *testing.T) {
-	t.Run("can load in prod mode", func(t *testing.T) {
+	t.Run("can load in prod mode and can't change afterwards", func(t *testing.T) {
 		const resp = "response"
 		cfg, _ := defaults.ServeMuxConfig([]string{"test.host.example"}, "test-xsrf-key")
 		cfg.Handle("/test", "GET", safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
@@ -64,8 +64,6 @@ func TestDevMode(t *testing.T) {
 				t.Errorf("got non-secure cookie %q, should have been secure", c.Raw)
 			}
 		}
-	})
-	t.Run("setting local dev after run panics", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {
 				t.Errorf("got no panic, wanted panic due to setting dev mode after running the framework")


### PR DESCRIPTION
This PR also wires the HSTS plugin and Cookie behavior to disable HTTPS-only behaviors if running in local development mode.

Fixes #171