### PR TITLE
Add support for named templates.

### DIFF
--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -70,13 +70,22 @@ func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
 			return fmt.Errorf("%T is not a safe template and it cannot be parsed and written", t)
 		}
 		if len(x.FuncMap) == 0 {
-			return t.Execute(rw, x.Data)
+			if x.Name == "" {
+				return t.Execute(rw, x.Data)
+			} else {
+				return t.ExecuteTemplate(rw, x.Name, x.Data)
+			}
 		}
 		cloned, err := t.Clone()
 		if err != nil {
 			return err
 		}
-		return cloned.Funcs(x.FuncMap).Execute(rw, x.Data)
+		cloned = cloned.Funcs(x.FuncMap)
+		if x.Name == "" {
+			return cloned.Execute(rw, x.Data)
+		} else {
+			return cloned.ExecuteTemplate(rw, x.Name, x.Data)
+		}
 	case safehtml.HTML:
 		_, err := io.WriteString(rw, x.String())
 		return err

--- a/safehttp/default_dispatcher_test.go
+++ b/safehttp/default_dispatcher_test.go
@@ -52,9 +52,23 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
-				return d.Write(w, &safehttp.TemplateResponse{t, data, nil})
+				return d.Write(w, &safehttp.TemplateResponse{Template: t, Data: data})
 			},
 			wantBody: "<h1>This is an actual heading, though.</h1>",
+		},
+		{
+			name: "Named Safe HTML Template Response",
+			write: func(w http.ResponseWriter) error {
+				d := &safehttp.DefaultDispatcher{}
+				t := safehttp.Template(
+					safetemplate.Must(
+						safetemplate.Must(safetemplate.New("name").Parse("<h1>{{ . }}</h1>")).
+							New("associated").Parse("<h2>{{.}}</h2>")))
+				var data interface{}
+				data = "This is an actual heading, though."
+				return d.Write(w, &safehttp.TemplateResponse{t, "associated", data, nil})
+			},
+			wantBody: "<h2>This is an actual heading, though.</h2>",
 		},
 		{
 			name: "Safe HTML Template Response with Token",
@@ -70,7 +84,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				fm := map[string]interface{}{
 					"Token": func() string { return "Token-secret" },
 				}
-				return d.Write(w, &safehttp.TemplateResponse{t, data, fm})
+				return d.Write(w, &safehttp.TemplateResponse{Template: t, Data: data, FuncMap: fm})
 			},
 			wantBody: `<form><input type="hidden" name="token" value="Token-secret">Content</form>`,
 		},
@@ -88,7 +102,7 @@ func TestDefaultDispatcherValidResponse(t *testing.T) {
 				fm := map[string]interface{}{
 					"Nonce": func() string { return "Nonce-secret" },
 				}
-				return d.Write(w, &safehttp.TemplateResponse{t, data, fm})
+				return d.Write(w, &safehttp.TemplateResponse{Template: t, Data: data, FuncMap: fm})
 			},
 			wantBody: `<script nonce="Nonce-secret" type="application/javascript">alert("script")</script><h1>Content</h1>`,
 		},
@@ -145,7 +159,7 @@ func TestDefaultDispatcherInvalidResponse(t *testing.T) {
 						Parse("<h1>{{ . }}</h1>")))
 				var data interface{}
 				data = "This is an actual heading, though."
-				return d.Write(w, safehttp.TemplateResponse{t, data, nil})
+				return d.Write(w, safehttp.TemplateResponse{Template: t, Data: data})
 			},
 			want: "",
 		},

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -73,8 +73,15 @@ type TemplateResponse struct {
 // ExecuteTemplate creates a TemplateResponse from the provided Template and its
 // data and calls the Write function of the ResponseWriter, passing the
 // response.
+func ExecuteTemplate(w ResponseWriter, t Template, data interface{}) Result {
+	return ExecuteNamedTemplate(w, t, "", data)
+}
+
+// ExecuteNamedTemplate creates a TemplateResponse from the provided Template and its
+// data and calls the Write function of the ResponseWriter, passing the
+// response.
 // Leaving name empty is valid if the template does not have associated templates.
-func ExecuteTemplate(w ResponseWriter, t Template, name string, data interface{}) Result {
+func ExecuteNamedTemplate(w ResponseWriter, t Template, name string, data interface{}) Result {
 	return w.Write(&TemplateResponse{Template: t, Name: name, Data: data, FuncMap: nil})
 }
 
@@ -82,7 +89,15 @@ func ExecuteTemplate(w ResponseWriter, t Template, name string, data interface{}
 // Template, its data and the name to function mappings and calls the Write
 // function of the ResponseWriter, passing the response.
 // Leaving name empty is valid if the template does not have associated templates.
-func ExecuteTemplateWithFuncs(w ResponseWriter, t Template, name string, data interface{}, fm map[string]interface{}) Result {
+func ExecuteTemplateWithFuncs(w ResponseWriter, t Template, data interface{}, fm map[string]interface{}) Result {
+	return ExecuteNamedTemplateWithFuncs(w, t, "", data, fm)
+}
+
+// ExecuteTemplateWithFuncs creates a TemplateResponse from the provided
+// Template, its data and the name to function mappings and calls the Write
+// function of the ResponseWriter, passing the response.
+// Leaving name empty is valid if the template does not have associated templates.
+func ExecuteNamedTemplateWithFuncs(w ResponseWriter, t Template, name string, data interface{}, fm map[string]interface{}) Result {
 	return w.Write(&TemplateResponse{Template: t, Name: name, Data: data, FuncMap: fm})
 }
 

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -51,12 +51,21 @@ type Template interface {
 	// Template fails or if an error occurs while writing the result to the
 	// io.Writer.
 	Execute(wr io.Writer, data interface{}) error
+
+	// ExecuteTemplate applies the named associated template to the specified data
+	// object and writes the output to the io.Writer.
+	//
+	// ExecuteTemplate returns an error if applying the data object to the
+	// Template fails or if an error occurs while writing the result to the
+	// io.Writer.
+	ExecuteTemplate(wr io.Writer, name string, data interface{}) error
 }
 
 // TemplateResponse bundles a Template with its data and names to function
 // mappings to be passed together to the commit phase.
 type TemplateResponse struct {
 	Template Template
+	Name     string
 	Data     interface{}
 	FuncMap  map[string]interface{}
 }
@@ -64,15 +73,17 @@ type TemplateResponse struct {
 // ExecuteTemplate creates a TemplateResponse from the provided Template and its
 // data and calls the Write function of the ResponseWriter, passing the
 // response.
-func ExecuteTemplate(w ResponseWriter, t Template, data interface{}) Result {
-	return w.Write(&TemplateResponse{t, data, nil})
+// Leaving name empty is valid if the template does not have associated templates.
+func ExecuteTemplate(w ResponseWriter, t Template, name string, data interface{}) Result {
+	return w.Write(&TemplateResponse{Template: t, Name: name, Data: data, FuncMap: nil})
 }
 
 // ExecuteTemplateWithFuncs creates a TemplateResponse from the provided
 // Template, its data and the name to function mappings and calls the Write
 // function of the ResponseWriter, passing the response.
-func ExecuteTemplateWithFuncs(w ResponseWriter, t Template, data interface{}, fm map[string]interface{}) Result {
-	return w.Write(&TemplateResponse{t, data, fm})
+// Leaving name empty is valid if the template does not have associated templates.
+func ExecuteTemplateWithFuncs(w ResponseWriter, t Template, name string, data interface{}, fm map[string]interface{}) Result {
+	return w.Write(&TemplateResponse{Template: t, Name: name, Data: data, FuncMap: fm})
 }
 
 // NoContentResponse is sent to the commit phase when it's initiated from

--- a/safehttp/task_test.go
+++ b/safehttp/task_test.go
@@ -135,7 +135,7 @@ func TestTaskUnsafeResponse(t *testing.T) {
 			write: func(w safehttp.ResponseWriter) {
 				safehttp.ExecuteTemplate(w, template.
 					Must(template.New("name").
-						Parse("<h1>{{ . }}</h1>")), "", "This is an actual heading, though.")
+						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
 			},
 		},
 	}

--- a/safehttp/task_test.go
+++ b/safehttp/task_test.go
@@ -135,7 +135,7 @@ func TestTaskUnsafeResponse(t *testing.T) {
 			write: func(w safehttp.ResponseWriter) {
 				safehttp.ExecuteTemplate(w, template.
 					Must(template.New("name").
-						Parse("<h1>{{ . }}</h1>")), "This is an actual heading, though.")
+						Parse("<h1>{{ . }}</h1>")), "", "This is an actual heading, though.")
 			},
 		},
 	}


### PR DESCRIPTION
There is currently no way to execute associated templates.

This means loading a directory of templates is impossible, they need to be parsed one by one.

This change makes them available.