### PR TITLE
Refactor handler generation in mux.go and expose handler factory.

### DIFF
--- a/examples/echo/security/web/web.go
+++ b/examples/echo/security/web/web.go
@@ -45,7 +45,7 @@ import (
 // Warning: XSRF protection is currently missing due to
 // https://github.com/google/go-safeweb/issues/171.
 func NewMuxConfig() *safehttp.ServeMuxConfig {
-	c := &safehttp.ServeMuxConfig{}
+	c := safehttp.NewServeMuxConfig(nil)
 
 	c.Intercept(coop.Default(""))
 	c.Intercept(csp.Default(""))

--- a/examples/httpcompose/httpcompose.go
+++ b/examples/httpcompose/httpcompose.go
@@ -1,0 +1,82 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// httpcompose implements a simple server which composes net/http and safehttp muxes.
+//
+// Endpoints:
+//  - /foo?msg=<script>alert(1)</script>
+//  - /bar?msg=<script>alert(1)</script>
+//  - /secure?msg=<script>alert(1)</script>
+//  - /insecure?msg=<script>alert(1)</script>
+package main
+
+import (
+	"fmt"
+	"html"
+	"log"
+	"net/http"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+)
+
+func main() {
+
+	fooHandleFunc := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/html")
+		q := r.URL.Query().Get("msg")
+		fmt.Fprintf(w, "Foo, %q", html.EscapeString(q))
+	}
+
+	barHandleFunc := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/html")
+		q := r.URL.Query().Get("msg")
+		// Insecure: Forgot html.EscapeString. XSS is possible.
+		fmt.Fprintf(w, "Bar, %q", q)
+	}
+
+	safehttpHandler := func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		form, err := r.URL.Query()
+		if err != nil {
+			panic(err)
+		}
+		q := form.String("msg", "defaultstr")
+		return w.Write(safehtml.HTMLEscaped(q))
+	}
+
+	insecureMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			barHandleFunc(w, r)
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	mc := safehttp.NewServeMuxConfig(nil)
+	// Generate http.Handler using a safehttp.ServeMuxConfig.
+	httpHandlerFromSafehttp := mc.HttpHandlerForTransition(safehttp.MethodGet, safehttp.HandlerFunc(safehttpHandler))
+	// Note: no mux generation through Mux() call.
+
+	http.HandleFunc("/foo", fooHandleFunc)
+	http.HandleFunc("/bar", barHandleFunc)
+	// Register safehttp handler that was converted to net/http handler.
+	// Safe as long as no insecure middleware wraps the handler further.
+	http.Handle("/secure", httpHandlerFromSafehttp)
+	// Insecure: safehttp handler wrapped by net/http handler cannot provide any guarantees.
+	http.Handle("/insecure", insecureMiddleware(httpHandlerFromSafehttp))
+
+	log.Println("Visit http://localhost:8080")
+	log.Println("Listening on localhost:8080...")
+	http.ListenAndServe("localhost:8080", nil)
+
+}

--- a/examples/httpcompose/httpcompose.go
+++ b/examples/httpcompose/httpcompose.go
@@ -64,7 +64,7 @@ func main() {
 
 	mc := safehttp.NewServeMuxConfig(nil)
 	// Generate http.Handler using a safehttp.ServeMuxConfig.
-	httpHandlerFromSafehttp := mc.HttpHandlerForTransition(safehttp.MethodGet, safehttp.HandlerFunc(safehttpHandler))
+	httpHandlerFromSafehttp := mc.StdHandler(safehttp.MethodGet, safehttp.HandlerFunc(safehttpHandler))
 	// Note: no mux generation through Mux() call.
 
 	http.HandleFunc("/foo", fooHandleFunc)

--- a/safehttp/flight.go
+++ b/safehttp/flight.go
@@ -24,7 +24,7 @@ type flight struct {
 	rw  http.ResponseWriter
 	req *IncomingRequest
 
-	cfg handlerConfig
+	cfg *handlerConfig
 
 	code   StatusCode
 	header Header
@@ -48,7 +48,7 @@ func DeprecatedNewResponseWriter(rw http.ResponseWriter, dispatcher Dispatcher) 
 		dispatcher = DefaultDispatcher{}
 	}
 	return &flight{
-		cfg:    handlerConfig{Dispatcher: dispatcher},
+		cfg:    &handlerConfig{Dispatcher: dispatcher},
 		rw:     rw,
 		header: newHeader(rw.Header()),
 	}
@@ -62,7 +62,7 @@ type handlerConfig struct {
 	Interceptors []configuredInterceptor
 }
 
-func processRequest(cfg handlerConfig, rw http.ResponseWriter, req *http.Request) {
+func processRequest(cfg *handlerConfig, rw http.ResponseWriter, req *http.Request) {
 	f := &flight{
 		cfg:    cfg,
 		rw:     rw,


### PR DESCRIPTION
Refactor handler generation in mux.go

Besides other things, this enables to expose a public http.Handler factory API, which allows to use net/http and (converted) safehttp handlers in a http mux more easily.

This is the 3rd iteration attempting to address #245 (last one was #248 which has some relevant review comments).

I still consider this a bit drafty, but it seems to work (example works like before, and tests pass :)).