### PR TITLE
Fix brittle test

### DIFF
--- a/internal/requesttesting/headers/host_test.go
+++ b/internal/requesttesting/headers/host_test.go
@@ -17,6 +17,7 @@ package headers
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-safeweb/internal/requesttesting"
@@ -100,7 +101,7 @@ func TestHostHeaderMultiple(t *testing.T) {
 		t.Fatalf("MakeRequest() got err: %v", err)
 	}
 
-	if got, want := extractStatus(resp), statusTooManyHostHeaders; got != want {
+	if got, want := extractStatus(resp), statusBadRequest; !strings.HasPrefix(got, want) {
 		t.Errorf("status code got: %q want: %q", got, want)
 	}
 }

--- a/internal/requesttesting/headers/statusmessages.go
+++ b/internal/requesttesting/headers/statusmessages.go
@@ -18,7 +18,6 @@ import "bytes"
 
 const (
 	statusOK                 = "HTTP/1.1 200 OK"
-	statusTooManyHostHeaders = "HTTP/1.1 400 Bad Request: too many Host headers"
 	statusNotImplemented     = "HTTP/1.1 501 Not Implemented"
 	statusBadRequest         = "HTTP/1.1 400 Bad Request"
 	statusInvalidHeaderName  = "HTTP/1.1 400 Bad Request: invalid header name"


### PR DESCRIPTION
It is considered poor practice to compare exact error strings,
which causes this test to break on Go1.17.
Fix the test to be more tolerant and work on both Go1.16 and Go1.17.
This test would othewise be broken by https://golang.org/cl/308952.