### PR TITLE
xsrfhtml: relax action check to host.

### DIFF
--- a/safehttp/plugins/xsrf/xsrfhtml/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrfhtml/xsrf.go
@@ -84,7 +84,7 @@ func (it *Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingReq
 		return w.WriteError(safehttp.StatusUnauthorized)
 	}
 
-	if ok := xsrftoken.Valid(tok, it.SecretAppKey, cookieID.Value(), r.URL.Path()); !ok {
+	if ok := xsrftoken.Valid(tok, it.SecretAppKey, cookieID.Value(), r.URL.Host()); !ok {
 		return w.WriteError(safehttp.StatusForbidden)
 	}
 
@@ -125,7 +125,7 @@ func (it *Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.Inco
 		return
 	}
 
-	tok := xsrftoken.Generate(it.SecretAppKey, cookieID.Value(), r.URL.Path())
+	tok := xsrftoken.Generate(it.SecretAppKey, cookieID.Value(), r.URL.Host())
 	if tmplResp.FuncMap == nil {
 		tmplResp.FuncMap = map[string]interface{}{}
 	}


### PR DESCRIPTION
Currently we validate CSRF tokens based on paths, but this makes
writing applications very hard.

For example a "logout" button cannot post to a "/logout" endpoint
from a "/profile" page or it will be blocked.

This protection mechanism is aimed at protecting from cross-site
forgery anyways, not cross-path forgery.