### PR TITLE
Make interceptors match configs instead of configs match interceptors.

### DIFF
--- a/examples/sample-application/secure/auth/auth.go
+++ b/examples/sample-application/secure/auth/auth.go
@@ -85,6 +85,11 @@ func (ip Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.Incom
 	}
 }
 
+func (Interceptor) Match(cfg safehttp.InterceptorConfig) bool {
+	_, ok := cfg.(Skip)
+	return ok
+}
+
 // User retrieves the user.
 func User(r *safehttp.IncomingRequest) string {
 	return ctxUser(r.Context())
@@ -125,9 +130,3 @@ func CreateSession(r *safehttp.IncomingRequest, user string) {
 // https://github.com/google/go-safeweb/blob/master/cmd/bancheck tool to enforce
 // this.
 type Skip struct{}
-
-func (Skip) Match(i safehttp.Interceptor) bool {
-	// This configuration only applies to the auth plugin.
-	_, ok := i.(Interceptor)
-	return ok
-}

--- a/safehttp/flight_test.go
+++ b/safehttp/flight_test.go
@@ -40,6 +40,10 @@ func (p panickingInterceptor) Commit(w safehttp.ResponseHeadersWriter, r *safeht
 	}
 }
 
+func (panickingInterceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
+}
+
 func TestFlightInterceptorPanic(t *testing.T) {
 	tests := []struct {
 		desc        string

--- a/safehttp/interceptor.go
+++ b/safehttp/interceptor.go
@@ -30,25 +30,13 @@ type Interceptor interface {
 	// is written to the ResponseWriter, then the Commit phases from the
 	// remaining interceptors won't execute.
 	Commit(w ResponseHeadersWriter, r *IncomingRequest, resp Response, cfg InterceptorConfig)
+
+	// Match checks whether the given config is meant to be applied to the Interceptor.
+	Match(InterceptorConfig) bool
 }
 
-// WrappedInterceptor is a wrapped interceptor.
-// This can be used to decorate an already existing interceptor and still allow
-// its native configurations to match with it.
-type WrappedInterceptor interface {
-	Interceptor
-	// Unwrap returns the wrapped interceptor.
-	Unwrap() Interceptor
-}
-
-// InterceptorConfig is a configuration of an interceptor.
-type InterceptorConfig interface {
-	// Match checks whether this InterceptorConfig is meant to be applied to the
-	// given Interceptor.
-	// If the Interceptor implements WrappedInterceptor the framework will take care of calling
-	// Match for all the nested interceptors.
-	Match(Interceptor) bool
-}
+// InterceptorConfig is a configuration for an interceptor.
+type InterceptorConfig interface{}
 
 // configuredInterceptor holds an interceptor together with its configuration.
 type configuredInterceptor struct {

--- a/safehttp/mux.go
+++ b/safehttp/mux.go
@@ -223,16 +223,8 @@ func configureInterceptors(interceptors []Interceptor, cfgs []InterceptorConfig)
 	for _, it := range interceptors {
 		var matches []InterceptorConfig
 		for _, c := range cfgs {
-			if c.Match(it) {
+			if it.Match(c) {
 				matches = append(matches, c)
-			}
-			wrapped, ok := it.(WrappedInterceptor)
-			for ok {
-				inner := wrapped.Unwrap()
-				if c.Match(inner) {
-					matches = append(matches, c)
-				}
-				wrapped, ok = inner.(WrappedInterceptor)
 			}
 		}
 

--- a/safehttp/plugins/coop/coop.go
+++ b/safehttp/plugins/coop/coop.go
@@ -19,6 +19,8 @@ import (
 	"github.com/google/go-safeweb/safehttp"
 )
 
+var _ safehttp.Interceptor = Interceptor{}
+
 // Mode represents a COOP mode.
 type Mode string
 
@@ -94,16 +96,16 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 func (it Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
 }
 
+// Match recognizes Overriders as COOP configurations.
+func (it Interceptor) Match(cfg safehttp.InterceptorConfig) bool {
+	_, ok := cfg.(Overrider)
+	return ok
+}
+
 // Overrider is a safehttp.InterceptorConfig that allows to override COOP for a specific handler.
 type Overrider serializedPolicies
 
 // Override creates an Overrider with the given policies.
-func Override(policies ...Policy) Overrider {
+func Override(reason string, policies ...Policy) Overrider {
 	return Overrider(serializePolicies(policies...))
-}
-
-// Match recognizes just this package Interceptor.
-func (p Overrider) Match(i safehttp.Interceptor) bool {
-	_, ok := i.(Interceptor)
-	return ok
 }

--- a/safehttp/plugins/coop/coop_test.go
+++ b/safehttp/plugins/coop/coop_test.go
@@ -36,7 +36,7 @@ func TestBefore(t *testing.T) {
 		{
 			name:           "No policies, override on header",
 			interceptor:    NewInterceptor(),
-			overrider:      Override(Policy{Mode: SameOrigin}),
+			overrider:      Override("testing", Policy{Mode: SameOrigin}),
 			wantOverridden: want{enf: []string{"same-origin"}},
 		},
 		{
@@ -55,7 +55,7 @@ func TestBefore(t *testing.T) {
 				ReportOnly:     true,
 			},
 			),
-			overrider: Override(Policy{
+			overrider: Override("testing", Policy{
 				Mode:           SameOrigin,
 				ReportingGroup: "coop-so",
 				ReportOnly:     true,

--- a/safehttp/plugins/cors/cors.go
+++ b/safehttp/plugins/cors/cors.go
@@ -158,6 +158,11 @@ func (it *Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingReq
 func (it *Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, cfg safehttp.InterceptorConfig) {
 }
 
+// Match returns false since there are no supported configurations.
+func (*Interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
+}
+
 func appendToVary(w safehttp.ResponseWriter, val string) {
 	h := w.Header()
 	if curr := h.Get("Vary"); curr != "" {

--- a/safehttp/plugins/csp/csp.go
+++ b/safehttp/plugins/csp/csp.go
@@ -290,3 +290,8 @@ func (it Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.Incom
 	}
 	tmplResp.FuncMap[htmlinject.CSPNoncesDefaultFuncName] = func() string { return nonce }
 }
+
+// Match returns false since there are no supported configurations.
+func (Interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
+}

--- a/safehttp/plugins/fetchmetadata/fetchmetadata.go
+++ b/safehttp/plugins/fetchmetadata/fetchmetadata.go
@@ -145,8 +145,8 @@ func (p *Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 	}
 
 	// Overridden to be disabled.
-	if d, ok := cfg.(Disable); ok {
-		if !d.SkipReporting && p.Logger != nil {
+	if d, ok := cfg.(disable); ok {
+		if !d.skipReporting && p.Logger != nil {
 			p.Logger.Log(r, nav)
 		}
 		return safehttp.NotWritten()
@@ -168,14 +168,18 @@ func (p *Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 func (p *Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
 }
 
-// Disable disables Fetch Metadata protection and switches it to report-only.
-type Disable struct {
-	// SkipReporting also disables reporting.
-	SkipReporting bool
+// Match recongnizes configs to disable fetch metadata protection.
+func (*Interceptor) Match(cfg safehttp.InterceptorConfig) bool {
+	_, ok := cfg.(disable)
+	return ok
 }
 
-// Match matches this config to *Interceptor.
-func (Disable) Match(i safehttp.Interceptor) bool {
-	_, ok := i.(*Interceptor)
-	return ok
+type disable struct {
+	skipReporting bool
+}
+
+// Disable returns a configuration that disables Fetch Metadata protection and switches it to report-only.
+// If skipReporting is true, it will also disable reporting.
+func Disable(reason string, skipReporting bool) safehttp.InterceptorConfig {
+	return disable{skipReporting: skipReporting}
 }

--- a/safehttp/plugins/fetchmetadata/fetchmetadata_test.go
+++ b/safehttp/plugins/fetchmetadata/fetchmetadata_test.go
@@ -443,7 +443,7 @@ func TestDisable(t *testing.T) {
 				Logger:       logger,
 				NavIsolation: true,
 			}
-			p.Before(fakeRW, req, fetchmetadata.Disable{})
+			p.Before(fakeRW, req, fetchmetadata.Disable("testing", false))
 
 			if want, got := safehttp.StatusOK, safehttp.StatusCode(rr.Code); want != got {
 				t.Errorf("rr.Code got: %v want: %v", got, want)
@@ -502,7 +502,7 @@ func TestDisableSkipLogger(t *testing.T) {
 				Logger:       logger,
 				NavIsolation: true,
 			}
-			p.Before(fakeRW, req, fetchmetadata.Disable{SkipReporting: true})
+			p.Before(fakeRW, req, fetchmetadata.Disable("testing", true))
 
 			if want, got := safehttp.StatusOK, safehttp.StatusCode(rr.Code); want != got {
 				t.Errorf("rr.Code got: %v want: %v", got, want)

--- a/safehttp/plugins/hostcheck/hostcheck.go
+++ b/safehttp/plugins/hostcheck/hostcheck.go
@@ -53,3 +53,8 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
 func (Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
 }
+
+// Match returns false since there are no supported configurations.
+func (Interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
+}

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -118,5 +118,10 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 }
 
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
-func (it Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
+func (Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
+}
+
+// Match returns false since there are no supported configurations.
+func (Interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
 }

--- a/safehttp/plugins/reportingapi/reporting.go
+++ b/safehttp/plugins/reportingapi/reporting.go
@@ -25,6 +25,8 @@ import (
 	"github.com/google/go-safeweb/safehttp"
 )
 
+var _ safehttp.Interceptor = Interceptor{}
+
 // DefaultMaxAge is used as default cache duration for report groups and will make them last 7 days.
 const DefaultMaxAge = 7 * 24 * 60 * 60
 
@@ -101,5 +103,10 @@ func (i Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingReque
 }
 
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
-func (i Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
+func (Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
+}
+
+// Match returns false since there are no supported configurations.
+func (Interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
 }

--- a/safehttp/plugins/staticheaders/staticheaders.go
+++ b/safehttp/plugins/staticheaders/staticheaders.go
@@ -54,3 +54,8 @@ func (Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequest
 // Commit is a no-op, required to satisfy the safehttp.Interceptor interface.
 func (Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
 }
+
+// Match returns false since there are no supported configurations.
+func (Interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
+}

--- a/safehttp/plugins/xsrf/xsrfangular/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrfangular/xsrf.go
@@ -112,3 +112,8 @@ func (it *Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.Inco
 		panic("cannot add token cookie")
 	}
 }
+
+// Match returns false since there are no supported configurations.
+func (*Interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
+}

--- a/safehttp/plugins/xsrf/xsrfhtml/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrfhtml/xsrf.go
@@ -131,3 +131,8 @@ func (it *Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.Inco
 	}
 	tmplResp.FuncMap[htmlinject.XSRFTokensDefaultFuncName] = func() string { return tok }
 }
+
+// Match returns false since there are no supported configurations.
+func (*Interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
+}

--- a/tests/integration/errors/errors_test.go
+++ b/tests/integration/errors/errors_test.go
@@ -119,7 +119,11 @@ func (it interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 	return safehttp.NotWritten()
 }
 
-func (it interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
+func (interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.IncomingRequest, resp safehttp.Response, _ safehttp.InterceptorConfig) {
+}
+
+func (interceptor) Match(safehttp.InterceptorConfig) bool {
+	return false
 }
 
 func TestCustomErrorsInBefore(t *testing.T) {


### PR DESCRIPTION
This makes it possible to have configs live in separate packages from their interceptors, thus empowering us to use simple restrictions rules.

Moreover we had inconsistent disabling mechanisms that didn't force user to attach a reason to them, this PR addresses that too.