### PR TITLE
Provide a StripPrefix utility

### DIFF
--- a/examples/echo/echo.go
+++ b/examples/echo/echo.go
@@ -49,7 +49,7 @@ func main() {
 }
 
 func echo(w safehttp.ResponseWriter, req *safehttp.IncomingRequest) safehttp.Result {
-	q, err := req.URL.Query()
+	q, err := req.URL().Query()
 	if err != nil {
 		return w.WriteError(safehttp.StatusBadRequest)
 	}
@@ -72,7 +72,7 @@ func uptime(w safehttp.ResponseWriter, req *safehttp.IncomingRequest) safehttp.R
 	x.Uptime = time.Now().Sub(start)
 
 	// Easter egg handling.
-	q, err := req.URL.Query()
+	q, err := req.URL().Query()
 	if err != nil {
 		return w.WriteError(safehttp.StatusBadRequest)
 	}

--- a/safehttp/defaults/defaults_test.go
+++ b/safehttp/defaults/defaults_test.go
@@ -30,7 +30,7 @@ func TestServeMuxConfig(t *testing.T) {
 		cfg, _ := ServeMuxConfig([]string{"test.host.example"}, "test-xsrf-key")
 		mux := cfg.Mux()
 		mux.Handle("/test", "GET", safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-			form, err := r.URL.Query()
+			form, err := r.URL().Query()
 			if err != nil {
 				t.Errorf("Cannot parse GET form: %v", err)
 			}

--- a/safehttp/fileserver.go
+++ b/safehttp/fileserver.go
@@ -107,7 +107,7 @@ func (fsrw *fileServerResponseWriter) WriteHeader(statusCode int) {
 	}
 
 	fsrw.result = fsrw.flight.Write(FileServerResponse{
-		Path:        fsrw.flight.req.URL.Path(),
+		Path:        fsrw.flight.req.URL().Path(),
 		contentType: ct,
 	})
 }

--- a/safehttp/flightvalues_test.go
+++ b/safehttp/flightvalues_test.go
@@ -63,7 +63,7 @@ func SetHeaderSafely(ctx context.Context, level int) {
 }
 
 func handlerInteractingWithTheInterceptor(w safehttp.ResponseWriter, req *safehttp.IncomingRequest) safehttp.Result {
-	f, err := req.URL.Query()
+	f, err := req.URL().Query()
 	if err != nil {
 		panic(err)
 	}

--- a/safehttp/handler_test.go
+++ b/safehttp/handler_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package safehttp_test
 
 import (

--- a/safehttp/handler_test.go
+++ b/safehttp/handler_test.go
@@ -1,0 +1,63 @@
+package safehttp_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+)
+
+var BarHandler = safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+	if !strings.HasPrefix(r.URL().Path(), "/bar") {
+		return w.WriteError(safehttp.StatusBadRequest)
+	}
+	return w.Write(safehtml.HTMLEscaped("Hello!"))
+})
+
+func TestStripPrefix(t *testing.T) {
+	mux := safehttp.NewServeMuxConfig(nil).Mux()
+
+	mux.Handle("/bar", safehttp.MethodGet, BarHandler)
+	mux.Handle("/more/bar", safehttp.MethodGet, safehttp.StripPrefix("/more", BarHandler))
+
+	r := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/bar", nil)
+	rw := httptest.NewRecorder()
+	mux.ServeHTTP(rw, r)
+
+	rStrip := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/more/bar", nil)
+	rwStrip := httptest.NewRecorder()
+	mux.ServeHTTP(rwStrip, rStrip)
+
+	if rwStrip.Code != rw.Code {
+		t.Errorf("Code got %v, want %v", rwStrip.Code, rw.Code)
+	}
+
+	if diff := cmp.Diff(rw.Header(), rwStrip.Header()); diff != "" {
+		t.Errorf("Header() mismatch (-want +got):\n%s", diff)
+	}
+
+	if got := rwStrip.Body.String(); got != rw.Body.String() {
+		t.Errorf("response body: got %q want %q", got, rw.Body.String())
+	}
+}
+
+func TestStripPrefixPanic(t *testing.T) {
+	mux := safehttp.NewServeMuxConfig(nil).Mux()
+
+	mux.Handle("/bar", safehttp.MethodGet, BarHandler)
+	mux.Handle("/more/bar", safehttp.MethodGet, safehttp.StripPrefix("/badprefix", BarHandler))
+
+	r := httptest.NewRequest(safehttp.MethodGet, "http://foo.com/more/bar", nil)
+	rw := httptest.NewRecorder()
+
+	defer func() {
+		if r := recover(); r != nil {
+			return
+		}
+		t.Errorf("expected panic")
+	}()
+	mux.ServeHTTP(rw, r)
+}

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -179,3 +179,7 @@ func (r *IncomingRequest) WithContext(ctx context.Context) *IncomingRequest {
 func (r *IncomingRequest) URL() *URL {
 	return &URL{url: r.req.URL}
 }
+
+func rawRequest(r *IncomingRequest) *http.Request {
+	return r.req
+}

--- a/safehttp/incoming_request.go
+++ b/safehttp/incoming_request.go
@@ -33,9 +33,6 @@ type IncomingRequest struct {
 	// TLS is set just like this TLS field of the net/http.Request. For more information
 	// see https://pkg.go.dev/net/http?tab=doc#Request.
 	TLS *tls.ConnectionState
-	// URL specifies the URL that is parsed from the Request-Line. For most requests,
-	// only URL.Path() will return a non-empty result. (See RFC 7230, Section 5.3)
-	URL *URL
 	req *http.Request
 
 	// The fields below are kept as pointers to allow cloning through
@@ -56,7 +53,6 @@ func NewIncomingRequest(req *http.Request) *IncomingRequest {
 		req:                req,
 		Header:             NewHeader(req.Header),
 		TLS:                req.TLS,
-		URL:                &URL{url: req.URL},
 		postParseOnce:      &sync.Once{},
 		multipartParseOnce: &sync.Once{},
 	}
@@ -176,4 +172,10 @@ func (r *IncomingRequest) WithContext(ctx context.Context) *IncomingRequest {
 	*r2 = *r
 	r2.req = r2.req.WithContext(ctx)
 	return r2
+}
+
+// URL specifies the URL that is parsed from the Request-Line. For most requests,
+// only URL.Path() will return a non-empty result. (See RFC 7230, Section 5.3)
+func (r *IncomingRequest) URL() *URL {
+	return &URL{url: r.req.URL}
 }

--- a/safehttp/internal/internal.go
+++ b/safehttp/internal/internal.go
@@ -1,0 +1,3 @@
+package internal
+
+var RawRequest interface{}

--- a/safehttp/internal/internal.go
+++ b/safehttp/internal/internal.go
@@ -1,3 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package internal contains internal APIs.
 package internal
 
+// RawRequest is a restricted API. See
+// github.com/google/go-safeweb/safehttp/restricted.RawRequest.
+//
+// After safehttp.init(), this becomes a func(*safehttp.IncomingRequest) *http.Request.
 var RawRequest interface{}

--- a/safehttp/internal/internal_test.go
+++ b/safehttp/internal/internal_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal_test
 
 import (

--- a/safehttp/internal/internal_test.go
+++ b/safehttp/internal/internal_test.go
@@ -1,0 +1,15 @@
+package internal_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/internal"
+)
+
+func TestRawRequest(t *testing.T) {
+	if _, ok := internal.RawRequest.(func(*safehttp.IncomingRequest) *http.Request); !ok {
+		t.Errorf("RawRequest type got %T, want func(*safehttp.IncomingRequest) *http.Request", internal.RawRequest)
+	}
+}

--- a/safehttp/internals.go
+++ b/safehttp/internals.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package safehttp
 
 import (

--- a/safehttp/internals.go
+++ b/safehttp/internals.go
@@ -1,0 +1,9 @@
+package safehttp
+
+import (
+	"github.com/google/go-safeweb/safehttp/internal"
+)
+
+func init() {
+	internal.RawRequest = rawRequest
+}

--- a/safehttp/plugins/hsts/hsts.go
+++ b/safehttp/plugins/hsts/hsts.go
@@ -95,7 +95,7 @@ func (it Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingRequ
 	}
 
 	if !it.BehindProxy && r.TLS == nil {
-		u, err := url.Parse(r.URL.String())
+		u, err := url.Parse(r.URL().String())
 		if err != nil {
 			return w.WriteError(safehttp.StatusInternalServerError)
 		}

--- a/safehttp/plugins/xsrf/xsrfhtml/xsrf.go
+++ b/safehttp/plugins/xsrf/xsrfhtml/xsrf.go
@@ -84,7 +84,7 @@ func (it *Interceptor) Before(w safehttp.ResponseWriter, r *safehttp.IncomingReq
 		return w.WriteError(safehttp.StatusUnauthorized)
 	}
 
-	if ok := xsrftoken.Valid(tok, it.SecretAppKey, cookieID.Value(), r.URL.Host()); !ok {
+	if ok := xsrftoken.Valid(tok, it.SecretAppKey, cookieID.Value(), r.URL().Host()); !ok {
 		return w.WriteError(safehttp.StatusForbidden)
 	}
 
@@ -125,7 +125,7 @@ func (it *Interceptor) Commit(w safehttp.ResponseHeadersWriter, r *safehttp.Inco
 		return
 	}
 
-	tok := xsrftoken.Generate(it.SecretAppKey, cookieID.Value(), r.URL.Host())
+	tok := xsrftoken.Generate(it.SecretAppKey, cookieID.Value(), r.URL().Host())
 	if tmplResp.FuncMap == nil {
 		tmplResp.FuncMap = map[string]interface{}{}
 	}

--- a/safehttp/restricted/request.go
+++ b/safehttp/restricted/request.go
@@ -1,3 +1,21 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package restricted contains restricted APIs. Their usage should be security
+// reviewed. You can use
+// https://github.com/google/go-safeweb/tree/master/cmd/bancheck to enforce
+// this.
 package restricted
 
 import (
@@ -9,6 +27,7 @@ import (
 
 var rawRequest = internal.RawRequest.(func(*safehttp.IncomingRequest) *http.Request)
 
+// RawRequest returns the underlying *http.Request.
 func RawRequest(r *safehttp.IncomingRequest) *http.Request {
 	return rawRequest(r)
 }

--- a/safehttp/restricted/request.go
+++ b/safehttp/restricted/request.go
@@ -1,0 +1,14 @@
+package restricted
+
+import (
+	"net/http"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/internal"
+)
+
+var rawRequest = internal.RawRequest.(func(*safehttp.IncomingRequest) *http.Request)
+
+func RawRequest(r *safehttp.IncomingRequest) *http.Request {
+	return rawRequest(r)
+}

--- a/tests/integration/devmode/devmode_test.go
+++ b/tests/integration/devmode/devmode_test.go
@@ -35,7 +35,7 @@ func TestDevMode(t *testing.T) {
 		cfg, _ := defaults.ServeMuxConfig([]string{"test.host.example"}, "test-xsrf-key")
 		mux := cfg.Mux()
 		mux.Handle("/test", "GET", safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-			form, err := r.URL.Query()
+			form, err := r.URL().Query()
 			if err != nil {
 				t.Errorf("Cannot parse GET form: %v", err)
 			}

--- a/tests/integration/devmodefreeze/devmodefreeze_test.go
+++ b/tests/integration/devmodefreeze/devmodefreeze_test.go
@@ -32,7 +32,7 @@ func TestDevMode(t *testing.T) {
 		mux := cfg.Mux()
 
 		mux.Handle("/test", "GET", safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-			form, err := r.URL.Query()
+			form, err := r.URL().Query()
 			if err != nil {
 				t.Errorf("Cannot parse GET form: %v", err)
 			}

--- a/tests/integration/errors/errors_test.go
+++ b/tests/integration/errors/errors_test.go
@@ -58,7 +58,7 @@ func TestCustomErrors(t *testing.T) {
 	mux := mb.Mux()
 
 	mux.Handle("/compute", safehttp.MethodGet, safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
-		qs, err := r.URL.Query()
+		qs, err := r.URL().Query()
 		if err != nil {
 			return w.WriteError(safehttp.StatusBadRequest)
 		}


### PR DESCRIPTION
Notable difference from the `net/http.StripPrefix`: it panics when a prefix cannot be matched. This is clearly a server configuration error.

In order to reduce complexity, the `IncomingRequest.URL` field is no longer there and was replaced by a method. `IncomingRequest` used to contain `req` and `URL` fields, the latter referencing the former. Removing the `URL` field removed the cross-referencing.

Fixes #316.