### PR TITLE
Add a plaintext type that is safe by default

### DIFF
--- a/safehttp/default_dispatcher.go
+++ b/safehttp/default_dispatcher.go
@@ -46,6 +46,10 @@ func (DefaultDispatcher) Write(rw http.ResponseWriter, resp Response) error {
 		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 		io.WriteString(rw, ")]}',\n") // Break parsing of JavaScript in order to prevent XSSI.
 		return json.NewEncoder(rw).Encode(x.Data)
+	case StringResponse:
+		rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, err := rw.Write([]byte(x.Data))
+		return err
 	case *TemplateResponse:
 		t, ok := (x.Template).(*template.Template)
 		if !ok {

--- a/safehttp/response.go
+++ b/safehttp/response.go
@@ -43,6 +43,14 @@ func WriteJSON(w ResponseWriter, data interface{}) Result {
 	return w.Write(JSONResponse{data})
 }
 
+type StringResponse struct {
+	Data string
+}
+
+func WriteString(w ResponseWriter, data string) Result {
+	return w.Write(StringResponse{data})
+}
+
 // Template implements a template.
 type Template interface {
 	// Execute applies data to the template and then writes the result to


### PR DESCRIPTION
Fixes #246. 

> It's a good idea to open an issue first for discussion.

This is the smallest test case.

```golang
func example(w safehttp.ResponseWriter, req *safehttp.IncomingRequest) safehttp.Result {
	return safehttp.WriteString(w, "hello world")
}
```

I prevented the code `w.Write("string")` from appearing by specifying a `StringResponse` instead of a `string` type, because I noticed that this is a very different style from the rest of the API.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR