### PR TITLE
Examples fix and tests introduction

### DIFF
--- a/examples/echo/echo.go
+++ b/examples/echo/echo.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ func uptime(w safehttp.ResponseWriter, req *safehttp.IncomingRequest) safehttp.R
 		Uptime    time.Duration
 		EasterEgg string
 	}
-	x.Uptime = time.Now().Sub(start)
+	x.Uptime = time.Since(start)
 
 	// Easter egg handling.
 	q, err := req.URL().Query()

--- a/examples/echo/echo_test.go
+++ b/examples/echo/echo_test.go
@@ -1,0 +1,113 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/google/go-safeweb/safehttp"
+)
+
+func TestEcho(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "no error",
+			req:     "?message=<h1>h4x0r</h1>",
+			want:    "&lt;h1&gt;h4x0r&lt;/h1&gt;",
+			wantErr: false,
+		},
+		{
+			name:    "empty message",
+			req:     "?message=",
+			want:    "",
+			wantErr: true,
+		}, {
+			name:    "invalid query parameters",
+			req:     "?message=;something;",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		mb := safehttp.NewServeMuxConfig(nil)
+		mux := mb.Mux()
+		mux.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(echo))
+
+		req := httptest.NewRequest(safehttp.MethodGet, fmt.Sprintf("http://foo.com/%s", tt.req), nil)
+		rw := httptest.NewRecorder()
+		mux.ServeHTTP(rw, req)
+
+		if rw.Code != int(safehttp.StatusOK) && !tt.wantErr {
+			t.Errorf("echo() status = %v, wantErr = %v", rw.Code, tt.wantErr)
+		}
+
+		if body := rw.Body.String(); !tt.wantErr && body != tt.want {
+			t.Errorf("body got: %q want: %q", body, tt.want)
+		}
+	}
+}
+
+func TestUptime(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     string
+		wantErr bool
+	}{
+		{
+			name:    "no error",
+			req:     "",
+			wantErr: false,
+		},
+		{
+			name:    "invalid query parameters",
+			req:     "?message=;something;",
+			wantErr: true,
+		},
+	}
+
+	rgx := regexp.MustCompile("^<h1>Uptime: (.*)</h1>$")
+
+	for _, tt := range tests {
+		mb := safehttp.NewServeMuxConfig(nil)
+		mux := mb.Mux()
+		start = time.Date(1991, time.September, 17, 00, 00, 00, 00, time.UTC)
+		mux.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(uptime))
+
+		req := httptest.NewRequest(safehttp.MethodGet, fmt.Sprintf("http://foo.com/%s", tt.req), nil)
+		rw := httptest.NewRecorder()
+		mux.ServeHTTP(rw, req)
+
+		if rw.Code != int(safehttp.StatusOK) && !tt.wantErr {
+			t.Errorf("uptime() status = %v, wantErr = %v", rw.Code, tt.wantErr)
+		}
+
+		if !tt.wantErr {
+			matched := rgx.Match(rw.Body.Bytes())
+			if !matched {
+				t.Errorf("body got: %q want: %q", rw.Body.String(), "<h1>Uptime: X</h1>")
+			}
+		}
+	}
+}

--- a/examples/echo/security/web/web.go
+++ b/examples/echo/security/web/web.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import (
 // Warning: XSRF protection is currently missing due to
 // https://github.com/google/go-safeweb/issues/171.
 func NewMuxConfig(addr string) *safehttp.ServeMuxConfig {
-	c := &safehttp.ServeMuxConfig{}
+	c := safehttp.NewServeMuxConfig(nil)
 
 	c.Intercept(coop.Default(""))
 	c.Intercept(staticheaders.Interceptor{})
@@ -81,7 +81,7 @@ func NewMuxConfig(addr string) *safehttp.ServeMuxConfig {
 // Important: the host checking plugin will accept only requests coming to
 // localhost:port, not e.g. 127.0.0.1:port.
 func NewMuxConfigDev(port int) *safehttp.ServeMuxConfig {
-	c := &safehttp.ServeMuxConfig{}
+	c := safehttp.NewServeMuxConfig(nil)
 
 	c.Intercept(coop.Default(""))
 	for _, i := range csp.Default("") {

--- a/examples/echo/security/web/web_test.go
+++ b/examples/echo/security/web/web_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+)
+
+func TestNewMuxConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *safehttp.ServeMuxConfig
+		addr    string
+		hasHSTS bool
+	}{
+		{
+			name:    "development mux config",
+			config:  NewMuxConfigDev(8080),
+			addr:    "https://localhost:8080",
+			hasHSTS: false,
+		},
+		{
+			name:    "production mux config",
+			config:  NewMuxConfig("localhost:8080"),
+			addr:    "https://localhost:8080",
+			hasHSTS: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := tt.config.Mux()
+			h := safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+				return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+			})
+			mux.Handle("/spaghetti", safehttp.MethodGet, h)
+
+			req := httptest.NewRequest(safehttp.MethodGet, fmt.Sprintf("%s/spaghetti", tt.addr), nil)
+			rw := httptest.NewRecorder()
+			mux.ServeHTTP(rw, req)
+
+			hasHSTSHeader := rw.Header().Get("Strict-Transport-Security") != ""
+			if tt.hasHSTS && !hasHSTSHeader {
+				t.Errorf("expected \"Strict-Transport-Security\" header since HTST is enabled")
+			}
+			if !tt.hasHSTS && hasHSTSHeader {
+				t.Errorf("unexpected \"Strict-Transport-Security\" header since HTST is disabled")
+			}
+		})
+	}
+}

--- a/examples/sample-application/secure/auth/auth_test.go
+++ b/examples/sample-application/secure/auth/auth_test.go
@@ -1,0 +1,219 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/google/go-safeweb/examples/sample-application/storage"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/go-safeweb/safehttp/safehttptest"
+)
+
+const TEST_USER = "test"
+
+func TestInterceptorBefore(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     safehttp.InterceptorConfig
+		hasAuth bool
+		want    safehttp.StatusCode
+	}{
+		{
+			name:    "base case, no error",
+			hasAuth: true,
+			cfg:     nil,
+			want:    safehttp.StatusOK,
+		},
+		{
+			name:    "force skip using config",
+			hasAuth: true,
+			cfg:     Skip{},
+			want:    safehttp.StatusOK,
+		},
+		{
+			name:    "missing auth, error",
+			hasAuth: false,
+			cfg:     nil,
+			want:    safehttp.StatusUnauthorized,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withUserDB, token := addTestUser(storage.NewDB())
+			ip := newTestInterceptor(withUserDB)
+
+			req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+			rw, r := safehttptest.NewFakeResponseWriter()
+
+			if tt.hasAuth {
+				addTestUserCookie(req, token)
+			}
+
+			// Note: "Before" return value is not significant
+			ip.Before(rw, req, tt.cfg)
+
+			if got := r.Code; got != int(tt.want) {
+				t.Errorf("status code got: %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInterceptorCommit(t *testing.T) {
+	tests := []struct {
+		name      string
+		action    sessionAction
+		hasCookie bool
+	}{
+		{
+			name:      "clear session, no error",
+			action:    clearSess,
+			hasCookie: false,
+		}, {
+			name:      "set session, no error",
+			action:    setSess,
+			hasCookie: true,
+		},
+		{
+			name:      "unexpected action, skip",
+			action:    sessionAction("unexpected"),
+			hasCookie: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withUserDB, _ := addTestUser(storage.NewDB())
+			ip := newTestInterceptor(withUserDB)
+
+			req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+			rw, r := safehttptest.NewFakeResponseWriter()
+
+			safehttp.FlightValues(req.Context()).Put(userKey, "user")
+			safehttp.FlightValues(req.Context()).Put(changeSessKey, tt.action)
+
+			ip.Commit(rw, req, r.Result, nil)
+
+			var token string
+			for _, c := range rw.Cookies {
+				if c.Name() == sessionCookie {
+					token = c.Value()
+				}
+			}
+
+			if tt.hasCookie == (token == "") {
+				t.Errorf("token = %q, want %v", token, tt.hasCookie)
+			}
+		})
+	}
+}
+
+func TestInterceptorMatch(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  safehttp.InterceptorConfig
+		want bool
+	}{
+		{
+			name: "basic case, no error",
+			cfg:  Skip{},
+			want: true,
+		},
+		{
+			name: "no Skip{}, error",
+			cfg:  nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := newTestInterceptor(nil)
+			if got := ip.Match(tt.cfg); got != tt.want {
+				t.Errorf("Interceptor.Match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInterceptorUserFromCookie(t *testing.T) {
+	withUserDB, validToken := addTestUser(storage.NewDB())
+	ip := newTestInterceptor(withUserDB)
+
+	tests := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{
+			name:  "basic case, no error",
+			token: validToken,
+			want:  TEST_USER,
+		},
+		{
+			name:  "empty cookie, error",
+			token: "",
+			want:  "",
+		},
+		{
+			name:  "invalid token, error",
+			token: "not_a_valid_token",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+			addTestUserCookie(req, tt.token)
+
+			if got := ip.userFromCookie(req); got != tt.want {
+				t.Errorf("Interceptor.userFromCookie() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionManagement(t *testing.T) {
+	want := "wanted"
+	r := safehttptest.NewRequest(safehttp.MethodGet, "/", nil)
+
+	CreateSession(r, want)
+	if got := User(r); got != want {
+		t.Errorf("user id got: %q, want %q", got, want)
+	}
+
+	ClearSession(r)
+	// Note: `ctxSessionAction` already tested inside ctx_test.go
+	if got := ctxSessionAction(r.Context()); got != clearSess {
+		t.Errorf("no clearSess action found in context after ClearSession")
+	}
+}
+
+func addTestUserCookie(r *safehttp.IncomingRequest, v string) {
+	r.Header.Add("Cookie", safehttp.NewCookie(sessionCookie, v).String())
+}
+
+func newTestInterceptor(db *storage.DB) Interceptor {
+	if db == nil {
+		db = storage.NewDB()
+	}
+	return Interceptor{
+		DB: db,
+	}
+}
+
+func addTestUser(db *storage.DB) (*storage.DB, string) {
+	token := (*db).GetToken(TEST_USER)
+	return db, token
+}

--- a/examples/sample-application/secure/auth/ctx_test.go
+++ b/examples/sample-application/secure/auth/ctx_test.go
@@ -1,0 +1,107 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-safeweb/safehttp"
+)
+
+func TestPutSessionAction(t *testing.T) {
+	req := safehttp.NewIncomingRequest(httptest.NewRequest(safehttp.MethodGet, "/spaghetti", nil))
+	ctx := req.Context()
+
+	putSessionAction(ctx, setSess)
+
+	if v := safehttp.FlightValues(ctx).Get(changeSessKey); v != setSess {
+		t.Errorf("putSessionAction(), got: %q, want: %q ", v, setSess)
+	}
+}
+
+func TestCtxSessionAction(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  sessionAction
+	}{
+		{
+			name:  "basic session action set/get",
+			value: setSess,
+			want:  setSess,
+		},
+		{
+			name:  "no sessionAction value, return empty string",
+			value: "unexpected",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := safehttp.NewIncomingRequest(httptest.NewRequest(safehttp.MethodGet, "/", nil))
+			ctx := req.Context()
+
+			safehttp.FlightValues(ctx).Put(changeSessKey, tt.value)
+
+			if got := ctxSessionAction(ctx); got != tt.want {
+				t.Errorf("ctxSessionAction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPutUser(t *testing.T) {
+	req := safehttp.NewIncomingRequest(httptest.NewRequest(safehttp.MethodGet, "/spaghetti", nil))
+	ctx := req.Context()
+	want := "someoneName"
+
+	putUser(ctx, want)
+
+	if v := safehttp.FlightValues(ctx).Get(userKey); v != want {
+		t.Errorf("putUser(), got: %q, want: %q ", v, setSess)
+	}
+}
+
+func TestCtxUser(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{
+			name:  "basic session user set/get",
+			value: "safeUser",
+			want:  "safeUser",
+		},
+		{
+			name:  "no string value, return empty string",
+			value: 42,
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := safehttp.NewIncomingRequest(httptest.NewRequest(safehttp.MethodGet, "/", nil))
+			ctx := req.Context()
+
+			safehttp.FlightValues(ctx).Put(userKey, tt.value)
+
+			if got := ctxUser(ctx); got != tt.want {
+				t.Errorf("ctxUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/examples/sample-application/secure/dispatcher_test.go
+++ b/examples/sample-application/secure/dispatcher_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secure
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-safeweb/examples/sample-application/secure/responses"
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+)
+
+func TestDispatcherError(t *testing.T) {
+	tests := []struct {
+		name string
+		resp safehttp.ErrorResponse
+		want string
+	}{
+		{
+			name: "default dispatcher, plaintext",
+			resp: safehttp.StatusForbidden,
+			want: http.StatusText(int(safehttp.StatusForbidden)),
+		},
+		{
+			name: "custom dispatcher, safe HTML",
+			resp: responses.Error{
+				StatusCode: safehttp.StatusNotFound,
+				Message:    safehtml.HTMLEscaped("<h1>Escaped</h1"),
+			},
+			want: "<p>&lt;h1&gt;Escaped&lt;/h1</p>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := dispatcher{}
+			rw := httptest.NewRecorder()
+			d.Error(rw, tt.resp)
+			if op := rw.Body.String(); !strings.Contains(op, tt.want) {
+				t.Errorf("body got: %q, want: %q", op, tt.want)
+			}
+		})
+	}
+}

--- a/examples/sample-application/secure/mux.go
+++ b/examples/sample-application/secure/mux.go
@@ -34,8 +34,7 @@ import (
 
 // NewMuxConfig creates a safe ServeMuxConfig.
 func NewMuxConfig(db *storage.DB, addr string) *safehttp.ServeMuxConfig {
-	c := safehttp.NewServeMuxConfig(dispatcher{})
-
+	c := safehttp.NewServeMuxConfig(nil)
 	c.Intercept(coop.Default(""))
 	c.Intercept(staticheaders.Interceptor{})
 	for _, i := range csp.Default("") {

--- a/examples/sample-application/secure/mux_test.go
+++ b/examples/sample-application/secure/mux_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secure
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-safeweb/safehttp"
+)
+
+func TestNewMuxConfig(t *testing.T) {
+	mux := NewMuxConfig(nil, "foo:8080").Mux()
+	mux.Handle("/", safehttp.MethodGet, nil)
+	req := httptest.NewRequest(safehttp.MethodGet, "http://foo:8080/", nil)
+	rw := httptest.NewRecorder()
+	mux.ServeHTTP(rw, req)
+}

--- a/examples/trustedtypes/server_test.go
+++ b/examples/trustedtypes/server_test.go
@@ -1,0 +1,96 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/safehtml/template"
+
+	"github.com/google/go-safeweb/safehttp"
+	"github.com/google/safehtml"
+)
+
+func TestNewMuxConfig(t *testing.T) {
+	cf, addr := newServeMuxConfig()
+	mux := cf.Mux()
+	h := safehttp.HandlerFunc(func(w safehttp.ResponseWriter, r *safehttp.IncomingRequest) safehttp.Result {
+		return w.Write(safehtml.HTMLEscaped("<h1>Hello World!</h1>"))
+	})
+	mux.Handle("/", safehttp.MethodGet, h)
+
+	req := httptest.NewRequest(safehttp.MethodGet, fmt.Sprintf("http://%s/", addr), nil)
+	rw := httptest.NewRecorder()
+	mux.ServeHTTP(rw, req)
+
+	body := rw.Body.String()
+	if want := "&lt;h1&gt;Hello World!&lt;/h1&gt;"; body != want {
+		t.Errorf("body got: %q want: %q", body, want)
+	}
+}
+
+func Test_loadTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr bool
+	}{
+		{
+			name:    "existing template, no error",
+			src:     "safe.html",
+			wantErr: false,
+		},
+		{
+			name:    "missing template, error",
+			src:     "not_existing.html",
+			wantErr: true,
+		},
+		{
+			name:    "invalid source name, error",
+			src:     "../../hidden.html",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil && !tt.wantErr {
+					t.Errorf("unexpected panic: %v", r)
+				}
+			}()
+			_, err := loadTemplate(tt.src)
+			if err != nil && !tt.wantErr {
+				t.Errorf("loadTemplate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestHandleTemplate(t *testing.T) {
+	mux := safehttp.NewServeMuxConfig(nil).Mux()
+	safeTmpl := template.Must(template.New("standard").Parse(`<h1>Hi there!</h1>`))
+	mux.Handle("/", safehttp.MethodGet, safehttp.HandlerFunc(handleTemplate(safeTmpl)))
+
+	req := httptest.NewRequest(safehttp.MethodGet, "/spaghetti", nil)
+	rw := httptest.NewRecorder()
+	mux.ServeHTTP(rw, req)
+
+	if body, want := rw.Body.String(), "<h1>Hi there!</h1>"; body != want {
+		t.Errorf("handleTemplate() got %q, want %q", body, want)
+	}
+}


### PR DESCRIPTION
This PR fixes the examples attached to this project. In particular, inside of them, composite literals were used to create new `ServeMuxConfig` instances instead of passing `nil` to the `NewServeMuxConfig` function. This was causing the applications to panic during the `Mux()` method execution.

In addition, some tests have been introduced in order to be notified in case of future breaks.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR